### PR TITLE
typescript: export .wasm in dist/

### DIFF
--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -22,7 +22,7 @@
       "import": "./dist/index.browser.mjs",
       "default": "./dist/index.browser.mjs"
     },
-    "./browser/lingua_bg.wasm": "./wasm-web/lingua_bg.wasm"
+    "./browser/lingua_bg.wasm": "./dist/wasm-web/lingua_bg.wasm"
   },
   "scripts": {
     "build": "pnpm run build:wasm && pnpm run build:types",

--- a/bindings/typescript/tsup.config.ts
+++ b/bindings/typescript/tsup.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsup";
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync, cpSync, mkdirSync } from "fs";
 import { join } from "path";
 
 export default defineConfig([
@@ -36,6 +36,14 @@ export default defineConfig([
       );
 
       writeFileSync(filePath, content, "utf-8");
+
+      // Copy .wasm binaries for export
+      const distWasmNode = join(__dirname, "dist", "wasm-node");
+      const distWasmWeb = join(__dirname, "dist", "wasm-web");
+      mkdirSync(distWasmNode, { recursive: true });
+      mkdirSync(distWasmWeb, { recursive: true });
+      cpSync(join(__dirname, "wasm", "lingua_bg.wasm"), join(distWasmNode, "lingua_bg.wasm"));
+      cpSync(join(__dirname, "wasm-web", "lingua_bg.wasm"), join(distWasmWeb, "lingua_bg.wasm"));
     },
   },
 ]);


### PR DESCRIPTION
export all artifacts in `dist/` for less error-prone bundling and caching for package consumers