### PR TITLE
feat(adapter): add ResponsesAdapter for OpenAI Responses API

### DIFF
--- a/src/capabilities/format.rs
+++ b/src/capabilities/format.rs
@@ -26,6 +26,8 @@ pub enum ProviderFormat {
     Mistral,
     /// AWS Bedrock Converse API format
     Converse,
+    /// OpenAI Responses API format (for reasoning models like o1-pro, o3)
+    Responses,
     /// Unknown or undetectable format
     #[default]
     #[serde(other)]
@@ -47,6 +49,7 @@ impl std::fmt::Display for ProviderFormat {
             ProviderFormat::Google => "google",
             ProviderFormat::Mistral => "mistral",
             ProviderFormat::Converse => "converse",
+            ProviderFormat::Responses => "responses",
             ProviderFormat::Unknown => "unknown",
         };
         write!(f, "{}", s)
@@ -63,6 +66,7 @@ impl std::str::FromStr for ProviderFormat {
             "google" => Ok(ProviderFormat::Google),
             "mistral" => Ok(ProviderFormat::Mistral),
             "converse" | "bedrock" => Ok(ProviderFormat::Converse),
+            "responses" => Ok(ProviderFormat::Responses),
             _ => Err(()),
         }
     }

--- a/src/processing/adapters.rs
+++ b/src/processing/adapters.rs
@@ -154,13 +154,18 @@ pub fn insert_opt_string(obj: &mut Map<String, Value>, key: &str, value: Option<
 ///
 /// Priority order (most specific first):
 /// 1. Anthropic (requires max_tokens, has specific structure)
-/// 2. OpenAI (most permissive, fallback)
+/// 2. Responses (OpenAI Responses API - specific input/output structure)
+/// 3. OpenAI (most permissive, fallback)
 pub fn adapters() -> Vec<Box<dyn ProviderAdapter>> {
     let mut list: Vec<Box<dyn ProviderAdapter>> = Vec::new();
 
     // Note: Order matters for detection - more specific formats first
     #[cfg(feature = "anthropic")]
     list.push(Box::new(crate::providers::anthropic::AnthropicAdapter));
+
+    // Responses must come before OpenAI since it's more specific
+    #[cfg(feature = "openai")]
+    list.push(Box::new(crate::providers::openai::ResponsesAdapter));
 
     #[cfg(feature = "openai")]
     list.push(Box::new(crate::providers::openai::OpenAIAdapter));

--- a/src/providers/openai/adapter.rs
+++ b/src/providers/openai/adapter.rs
@@ -1,5 +1,9 @@
 /*!
-OpenAI provider adapter for Chat Completions API.
+OpenAI provider adapters for chat completions and responses API.
+
+This module provides two adapters:
+- `OpenAIAdapter` for the standard Chat Completions API
+- `ResponsesAdapter` for the Responses API (used by reasoning models like o1)
 */
 
 use crate::capabilities::ProviderFormat;
@@ -10,11 +14,12 @@ use crate::processing::adapters::{
 use crate::processing::transform::TransformError;
 use crate::providers::openai::generated::{
     ChatCompletionRequestMessage, ChatCompletionResponseMessage, CreateChatCompletionRequestClass,
+    CreateResponseClass, InputItem, InputItemContent, InputItemRole, InputItemType, Instructions,
 };
-use crate::providers::openai::try_parse_openai;
+use crate::providers::openai::{try_parse_openai, try_parse_responses, universal_to_responses_input};
 use crate::serde_json::{self, Map, Value};
 use crate::universal::convert::TryFromLLM;
-use crate::universal::message::Message;
+use crate::universal::message::{AssistantContent, Message, UserContent};
 use crate::universal::{
     FinishReason, UniversalParams, UniversalRequest, UniversalResponse, UniversalUsage,
 };
@@ -40,6 +45,24 @@ const OPENAI_KNOWN_KEYS: &[&str] = &[
     // OpenAI-specific fields (not in UniversalParams) go to extras:
     // stream_options, n, logprobs, top_logprobs, logit_bias,
     // user, store, metadata, parallel_tool_calls, service_tier
+];
+
+/// Known request fields for OpenAI Responses API.
+/// These are fields extracted into UniversalRequest/UniversalParams.
+/// Fields not in this list go into `extras` for passthrough.
+const RESPONSES_KNOWN_KEYS: &[&str] = &[
+    "model",
+    "input",
+    "temperature",
+    "top_p",
+    "max_output_tokens",
+    "tools",
+    "tool_choice",
+    "stream",
+    // Responses-specific fields (not in UniversalParams) go to extras:
+    // instructions, stop, response_format, seed, presence_penalty,
+    // frequency_penalty, reasoning, truncation, user, store,
+    // metadata, parallel_tool_calls
 ];
 
 /// Adapter for OpenAI Chat Completions API.
@@ -252,6 +275,318 @@ impl ProviderAdapter for OpenAIAdapter {
     }
 }
 
+/// Adapter for OpenAI Responses API (used by reasoning models like o1).
+pub struct ResponsesAdapter;
+
+impl ProviderAdapter for ResponsesAdapter {
+    fn format(&self) -> ProviderFormat {
+        ProviderFormat::Responses
+    }
+
+    fn directory_name(&self) -> &'static str {
+        "responses"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Responses"
+    }
+
+    fn detect_request(&self, payload: &Value) -> bool {
+        try_parse_responses(payload).is_ok()
+    }
+
+    fn request_to_universal(&self, payload: &Value) -> Result<UniversalRequest, TransformError> {
+        let request: CreateResponseClass = serde_json::from_value(payload.clone())
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        // Extract input items from the request
+        let input_items: Vec<InputItem> = match request.input {
+            Some(Instructions::InputItemArray(items)) => items,
+            Some(Instructions::String(s)) => {
+                // Single string input - create a user message InputItem
+                vec![InputItem {
+                    input_item_type: Some(InputItemType::Message),
+                    role: Some(InputItemRole::User),
+                    content: Some(InputItemContent::String(s)),
+                    ..Default::default()
+                }]
+            }
+            None => vec![],
+        };
+
+        let messages = <Vec<Message> as TryFromLLM<Vec<InputItem>>>::try_from(input_items)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let params = UniversalParams {
+            temperature: request.temperature,
+            top_p: request.top_p,
+            top_k: None,
+            max_tokens: request.max_output_tokens,
+            stop: None, // Responses API doesn't use stop
+            tools: request.tools.and_then(|t| serde_json::to_value(t).ok()),
+            tool_choice: request.tool_choice.and_then(|t| serde_json::to_value(t).ok()),
+            response_format: None, // Different structure in Responses API
+            seed: None, // Responses API uses different randomness control
+            presence_penalty: None, // Responses API doesn't support penalties
+            frequency_penalty: None,
+            stream: request.stream,
+        };
+
+        Ok(UniversalRequest {
+            model: request.model,  // Already Option<String> in CreateResponseClass
+            messages,
+            params,
+            extras: collect_extras(payload, RESPONSES_KNOWN_KEYS),
+        })
+    }
+
+    fn request_from_universal(&self, req: &UniversalRequest) -> Result<Value, TransformError> {
+        let model = req.model.as_ref().ok_or(TransformError::ValidationFailed {
+            target: ProviderFormat::Responses,
+            reason: "missing model".to_string(),
+        })?;
+
+        // Use existing conversion with 1:N Tool message expansion
+        let input_items = universal_to_responses_input(&req.messages)
+            .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+        let mut obj = Map::new();
+        obj.insert("model".into(), Value::String(model.clone()));
+        obj.insert(
+            "input".into(),
+            serde_json::to_value(input_items)
+                .map_err(|e| TransformError::SerializationFailed(e.to_string()))?,
+        );
+
+        // Insert params (note: some params like temperature are not supported by reasoning models)
+        // We still include them for passthrough, the API will validate
+        insert_opt_f64(&mut obj, "temperature", req.params.temperature);
+        insert_opt_f64(&mut obj, "top_p", req.params.top_p);
+        insert_opt_i64(&mut obj, "max_output_tokens", req.params.max_tokens);
+        insert_opt_value(&mut obj, "tools", req.params.tools.clone());
+        insert_opt_value(&mut obj, "tool_choice", req.params.tool_choice.clone());
+        insert_opt_f64(&mut obj, "presence_penalty", req.params.presence_penalty);
+        insert_opt_f64(&mut obj, "frequency_penalty", req.params.frequency_penalty);
+        insert_opt_bool(&mut obj, "stream", req.params.stream);
+
+        // Merge extras
+        for (k, v) in &req.extras {
+            obj.insert(k.clone(), v.clone());
+        }
+
+        Ok(Value::Object(obj))
+    }
+
+    fn apply_defaults(&self, _req: &mut UniversalRequest) {
+        // Responses API doesn't require any specific defaults
+    }
+
+    fn detect_response(&self, payload: &Value) -> bool {
+        // Responses API response has output[] array and object="response"
+        payload.get("output").and_then(Value::as_array).is_some()
+            && payload
+                .get("object")
+                .and_then(Value::as_str)
+                .is_some_and(|o| o == "response")
+    }
+
+    fn response_to_universal(&self, payload: &Value) -> Result<UniversalResponse, TransformError> {
+        let output = payload
+            .get("output")
+            .and_then(Value::as_array)
+            .ok_or_else(|| TransformError::ToUniversalFailed("missing output".to_string()))?;
+
+        // Convert output items to messages
+        // Responses API has multiple output types: message, function_call, reasoning, etc.
+        let mut messages: Vec<Message> = Vec::new();
+        let mut tool_calls: Vec<Value> = Vec::new();
+
+        for item in output {
+            let item_type = item.get("type").and_then(Value::as_str);
+
+            match item_type {
+                Some("message") => {
+                    // Message type - extract text content
+                    if let Some(content) = item.get("content") {
+                        if let Some(content_arr) = content.as_array() {
+                            let text: String = content_arr
+                                .iter()
+                                .filter_map(|c| {
+                                    if c.get("type").and_then(Value::as_str) == Some("output_text") {
+                                        c.get("text").and_then(Value::as_str).map(String::from)
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                                .join("");
+                            if !text.is_empty() {
+                                messages.push(Message::Assistant {
+                                    content: AssistantContent::String(text),
+                                    id: None,
+                                });
+                            }
+                        }
+                    }
+                }
+                Some("function_call") => {
+                    // Function call - collect for later conversion to tool calls
+                    tool_calls.push(item.clone());
+                }
+                _ => {
+                    // Skip reasoning and other types for now
+                }
+            }
+        }
+
+        // If we have tool calls but no messages, create an assistant message with tool calls
+        if !tool_calls.is_empty() && messages.is_empty() {
+            // Convert function_call items to tool call format
+            use crate::universal::message::{AssistantContentPart, ToolCallArguments};
+            let parts: Vec<AssistantContentPart> = tool_calls
+                .iter()
+                .filter_map(|tc| {
+                    let name = tc.get("name").and_then(Value::as_str)?;
+                    let call_id = tc.get("call_id").and_then(Value::as_str)?;
+                    let arguments = tc.get("arguments").and_then(Value::as_str)?;
+
+                    // Try to parse arguments as JSON, fall back to invalid string
+                    let args = serde_json::from_str::<Map<String, Value>>(arguments)
+                        .map(ToolCallArguments::Valid)
+                        .unwrap_or_else(|_| ToolCallArguments::Invalid(arguments.to_string()));
+
+                    Some(AssistantContentPart::ToolCall {
+                        tool_call_id: call_id.to_string(),
+                        tool_name: name.to_string(),
+                        arguments: args,
+                        provider_options: None,
+                        provider_executed: None,
+                    })
+                })
+                .collect();
+
+            if !parts.is_empty() {
+                messages.push(Message::Assistant {
+                    content: AssistantContent::Array(parts),
+                    id: None,
+                });
+            }
+        }
+
+        // If still no messages, try output_text field as fallback
+        if messages.is_empty() {
+            if let Some(text) = payload.get("output_text").and_then(Value::as_str) {
+                if !text.is_empty() {
+                    messages.push(Message::Assistant {
+                        content: AssistantContent::String(text.to_string()),
+                        id: None,
+                    });
+                }
+            }
+        }
+
+        // Map status to finish_reason
+        let finish_reason = payload
+            .get("status")
+            .and_then(Value::as_str)
+            .map(FinishReason::from_str);
+
+        let usage = payload.get("usage").map(|u| UniversalUsage {
+            input_tokens: u.get("input_tokens").and_then(Value::as_i64),
+            output_tokens: u.get("output_tokens").and_then(Value::as_i64),
+        });
+
+        Ok(UniversalResponse {
+            model: payload
+                .get("model")
+                .and_then(Value::as_str)
+                .map(String::from),
+            messages,
+            usage,
+            finish_reason,
+            extras: Map::new(),
+        })
+    }
+
+    fn response_from_universal(&self, resp: &UniversalResponse) -> Result<Value, TransformError> {
+        // Build Responses API response format
+        let output: Vec<Value> = resp
+            .messages
+            .iter()
+            .map(|msg| {
+                let text = match msg {
+                    Message::Assistant { content, .. } => match content {
+                        AssistantContent::String(s) => s.clone(),
+                        AssistantContent::Array(_) => String::new(), // TODO: extract text from parts
+                    },
+                    Message::User { content } => match content {
+                        UserContent::String(s) => s.clone(),
+                        UserContent::Array(_) => String::new(),
+                    },
+                    _ => String::new(),
+                };
+
+                serde_json::json!({
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{
+                        "type": "output_text",
+                        "text": text
+                    }]
+                })
+            })
+            .collect();
+
+        let status = self
+            .map_finish_reason(resp.finish_reason.as_ref())
+            .unwrap_or_else(|| "completed".to_string());
+
+        // Build response with all required fields for TheResponseObject
+        let mut obj = serde_json::json!({
+            "id": resp.extras.get("id").and_then(Value::as_str).unwrap_or("resp_transformed"),
+            "object": "response",
+            "model": resp.model.as_deref().unwrap_or("transformed"),
+            "output": output,
+            "status": status,
+            "created_at": 0.0,
+            "tool_choice": "none",
+            "tools": [],
+            "parallel_tool_calls": false
+        });
+
+        if let Some(usage) = &resp.usage {
+            let input = usage.input_tokens.unwrap_or(0);
+            let output = usage.output_tokens.unwrap_or(0);
+            obj.as_object_mut().unwrap().insert(
+                "usage".into(),
+                serde_json::json!({
+                    "input_tokens": input,
+                    "output_tokens": output,
+                    "total_tokens": input + output,
+                    "input_tokens_details": {
+                        "cached_tokens": 0
+                    },
+                    "output_tokens_details": {
+                        "reasoning_tokens": 0
+                    }
+                }),
+            );
+        }
+
+        Ok(obj)
+    }
+
+    fn map_finish_reason(&self, reason: Option<&FinishReason>) -> Option<String> {
+        reason.map(|r| match r {
+            FinishReason::Stop => "completed".to_string(),
+            FinishReason::Length => "incomplete".to_string(),
+            FinishReason::ToolCalls => "completed".to_string(), // Tool calls also complete
+            FinishReason::ContentFilter => "incomplete".to_string(),
+            FinishReason::Other(s) => s.clone(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -301,5 +636,15 @@ mod tests {
         let reconstructed = adapter.request_from_universal(&universal).unwrap();
         assert_eq!(reconstructed.get("user").unwrap(), "test-user-123");
         assert_eq!(reconstructed.get("custom_field").unwrap(), "should_be_preserved");
+    }
+
+    #[test]
+    fn test_responses_detect_request() {
+        let adapter = ResponsesAdapter;
+        let payload = json!({
+            "model": "o1",
+            "input": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(adapter.detect_request(&payload));
     }
 }

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -13,8 +13,8 @@ pub mod detect;
 pub mod generated;
 pub mod transformations;
 
-// Re-export adapter
-pub use adapter::OpenAIAdapter;
+// Re-export adapters
+pub use adapter::{OpenAIAdapter, ResponsesAdapter};
 
 #[cfg(test)]
 pub mod test_responses;
@@ -25,8 +25,11 @@ pub mod test_chat_completions;
 #[cfg(test)]
 pub mod test_transformations;
 
-// Re-export detection function
-pub use detect::{try_parse_openai, DetectionError};
+// Re-export detection functions
+pub use detect::{try_parse_openai, try_parse_responses, DetectionError};
+
+// Re-export conversion functions
+pub use convert::universal_to_responses_input;
 
 // Re-export generated types (official OpenAI API types from OpenAPI spec)
 pub use generated::{


### PR DESCRIPTION
Add support for OpenAI's Responses API format (used by reasoning models like o1-pro, o3):
- ResponsesAdapter implementing ProviderAdapter trait
- ProviderFormat::Responses variant
- Request/response detection and transformation
- Coverage report updated to validate Responses transformations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>