### PR TITLE
Add ProviderAdapter, ProviderFormat, transform_request/response/stream_chunk patterns to lingua

### DIFF
--- a/.github/workflows/cross-transformation-coverage.yml
+++ b/.github/workflows/cross-transformation-coverage.yml
@@ -1,0 +1,62 @@
+name: Cross-Transformation Coverage
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'payloads/**'
+      - 'Cargo.toml'
+  pull_request:
+    paths:
+      - 'crates/**'
+      - 'payloads/**'
+      - 'Cargo.toml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-coverage-
+
+      - name: Install protobuf compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Generate coverage report
+        run: |
+          cargo run -p coverage-report > coverage_report.md
+        # This job is informational only - it always succeeds
+        # Click into the job summary to see the actual coverage report
+
+      - name: Post coverage to job summary
+        run: |
+          echo "# 🔄 Cross-Provider Transformation Coverage" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          cat coverage_report.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: transformation-coverage-report
+          path: coverage_report.md
+          retention-days: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.106",
  "which",
@@ -563,6 +563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +631,16 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "coverage-report"
+version = "0.1.0"
+dependencies = [
+ "big_serde_json",
+ "bytes",
+ "lingua",
+ "serde",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -708,6 +724,17 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -877,8 +904,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -888,9 +917,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.3+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1141,6 +1172,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1192,10 +1224,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1241,6 +1375,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1351,13 +1495,17 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "aws-sdk-bedrockruntime",
+ "base64 0.22.1",
  "big_serde_json",
+ "bytes",
  "env_logger",
+ "js-sys",
  "log",
  "paste",
  "prost",
  "prost-types",
  "pyo3",
+ "reqwest",
  "serde",
  "serde-wasm-bindgen",
  "serde_with",
@@ -1365,6 +1513,8 @@ dependencies = [
  "thiserror",
  "tokio-test",
  "ts-rs",
+ "url",
+ "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1383,6 +1533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1552,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -1584,10 +1746,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1724,6 +1904,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.31",
+ "socket2 0.6.0",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.31",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.0",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1972,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1813,6 +2077,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.31",
+ "rustls-pki-types",
+ "serde",
+ "serde_json 1.0.143",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +2139,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -1893,6 +2201,7 @@ checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.4",
  "subtle",
@@ -1938,6 +2247,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2236,6 +2546,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,6 +2652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2689,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2443,6 +2791,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2895,29 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -2685,6 +3081,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +3235,25 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3066,7 +3505,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,23 @@ schemafy = "0.6"
 # Optional providers
 aws-sdk-bedrockruntime = "1.105.0"
 
+# URL and media handling
+url = "2.5"
+urlencoding = "2.1"
+base64 = "0.22"
+
+# Bytes
+bytes = "1"
+
 # WASM
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = "0.3"
+web-sys = { version = "0.3", features = ["Window", "Request", "RequestInit", "RequestMode", "Response", "Headers"] }
+js-sys = "0.3"
 serde-wasm-bindgen = "0.6"
+
+# Native HTTP client (non-WASM only)
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 # Python
 pyo3 = { version = "0.20", features = ["extension-module"] }

--- a/crates/coverage-report/Cargo.toml
+++ b/crates/coverage-report/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "coverage-report"
+version.workspace = true
+edition.workspace = true
+publish = false
+description = "Cross-provider transformation coverage report generator for Lingua"
+
+[[bin]]
+name = "coverage-report"
+path = "src/main.rs"
+
+[dependencies]
+lingua = { path = "../lingua", features = ["openai", "anthropic", "google", "bedrock"] }
+serde.workspace = true
+big_serde_json.workspace = true
+bytes.workspace = true

--- a/crates/coverage-report/src/discovery.rs
+++ b/crates/coverage-report/src/discovery.rs
@@ -1,0 +1,61 @@
+/*!
+Test case discovery for coverage-report.
+*/
+
+use bytes::Bytes;
+use std::fs;
+use std::path::PathBuf;
+
+/// Discover all test case directories in payloads/snapshots
+pub fn discover_test_cases() -> Vec<String> {
+    // Navigate from crates/coverage-report to workspace root
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent() // crates/
+        .and_then(|p| p.parent()) // workspace root
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+
+    let snapshots_dir = workspace_root.join("payloads").join("snapshots");
+
+    let mut test_cases = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(&snapshots_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    // Skip hidden directories and transformations directory
+                    if !name.starts_with('.') && name != "transformations" {
+                        test_cases.push(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    test_cases.sort();
+    test_cases
+}
+
+/// Load a JSON payload from a test case directory as bytes
+pub fn load_payload(test_case: &str, dir_name: &str, filename: &str) -> Option<Bytes> {
+    // Navigate from crates/coverage-report to workspace root
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent() // crates/
+        .and_then(|p| p.parent()) // workspace root
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+
+    let path = workspace_root
+        .join("payloads")
+        .join("snapshots")
+        .join(test_case)
+        .join(dir_name)
+        .join(filename);
+
+    if path.exists() {
+        fs::read(&path).ok().map(Bytes::from)
+    } else {
+        None
+    }
+}

--- a/crates/coverage-report/src/main.rs
+++ b/crates/coverage-report/src/main.rs
@@ -1,0 +1,42 @@
+/*!
+Cross-provider transformation coverage report generator.
+
+This binary runs all cross-provider transformation tests and outputs a
+markdown report showing which transformations succeed/fail.
+
+Validates:
+1. Transform doesn't error
+2. Transformed output deserializes into target provider's Rust types (schema validation)
+3. Key semantic fields are preserved (messages, model, tools, usage)
+
+Usage:
+    cargo run --bin generate-coverage-report
+*/
+
+mod discovery;
+mod report;
+mod runner;
+mod types;
+
+use lingua::processing::adapters::adapters;
+use report::generate_report;
+use runner::{run_all_tests, run_roundtrip_tests};
+
+fn main() {
+    let adapters = adapters();
+
+    // Cross-provider transformation tests
+    let (request_results, response_results, streaming_results) = run_all_tests(adapters);
+
+    // Roundtrip transform tests (Provider → Universal → Provider)
+    let roundtrip_results = run_roundtrip_tests(adapters);
+
+    let report = generate_report(
+        &request_results,
+        &response_results,
+        &streaming_results,
+        &roundtrip_results,
+        adapters,
+    );
+    println!("{}", report);
+}

--- a/crates/coverage-report/src/report.rs
+++ b/crates/coverage-report/src/report.rs
@@ -1,0 +1,517 @@
+/*!
+Report generation for coverage-report.
+*/
+
+use std::collections::HashMap;
+
+use lingua::processing::adapters::ProviderAdapter;
+
+use crate::runner::RoundtripResults;
+use crate::types::{PairResult, RoundtripResult, TableStats};
+
+pub fn format_cell(pair_result: &PairResult) -> String {
+    let total = pair_result.passed + pair_result.failed;
+    if total == 0 {
+        return "-".to_string();
+    }
+
+    let emoji = if pair_result.failed == 0 {
+        "✅"
+    } else {
+        "❌"
+    };
+    format!("{} {}/{}", emoji, pair_result.passed, total)
+}
+
+pub fn generate_table(
+    results: &HashMap<(usize, usize), PairResult>,
+    adapters: &[Box<dyn ProviderAdapter>],
+    title: &str,
+) -> (String, TableStats, Vec<(String, String, String)>) {
+    let mut table = String::new();
+    let mut stats = TableStats {
+        passed: 0,
+        failed: 0,
+    };
+    let mut all_failures: Vec<(String, String, String)> = Vec::new();
+
+    table.push_str(&format!("### {}\n\n", title));
+    table.push_str("| Source ↓ / Target → |");
+    for adapter in adapters {
+        table.push_str(&format!(" {} |", adapter.display_name()));
+    }
+    table.push_str("\n|---------------------|");
+    for _ in adapters {
+        table.push_str("-------------|");
+    }
+    table.push('\n');
+
+    for (source_idx, source) in adapters.iter().enumerate() {
+        table.push_str(&format!("| {} |", source.display_name()));
+        for (target_idx, target) in adapters.iter().enumerate() {
+            if source_idx == target_idx {
+                table.push_str(" - |");
+            } else {
+                let pair_result = results.get(&(source_idx, target_idx)).unwrap();
+                table.push_str(&format!(" {} |", format_cell(pair_result)));
+
+                stats.passed += pair_result.passed;
+                stats.failed += pair_result.failed;
+
+                for (test_case, error) in &pair_result.failures {
+                    all_failures.push((
+                        format!("{} → {}", source.display_name(), target.display_name()),
+                        test_case.clone(),
+                        error.clone(),
+                    ));
+                }
+            }
+        }
+        table.push('\n');
+    }
+
+    (table, stats, all_failures)
+}
+
+// ============================================================================
+// Roundtrip report section
+// ============================================================================
+
+fn format_roundtrip_cell(passed: usize, failed: usize) -> String {
+    let total = passed + failed;
+    if total == 0 {
+        return "-".to_string();
+    }
+    let emoji = if failed == 0 { "✅" } else { "❌" };
+    format!("{} {}/{}", emoji, passed, total)
+}
+
+fn format_roundtrip_diff(result: &RoundtripResult) -> String {
+    let mut output = String::new();
+
+    if let Some(error) = &result.error {
+        output.push_str(&format!("{}\n", error));
+    }
+
+    if let Some(diff) = &result.diff {
+        if !diff.lost_fields.is_empty() {
+            output.push_str("        Lost: ");
+            output.push_str(&diff.lost_fields.join(", "));
+            output.push('\n');
+        }
+        if !diff.added_fields.is_empty() {
+            output.push_str("        Added: ");
+            output.push_str(&diff.added_fields.join(", "));
+            output.push('\n');
+        }
+        if !diff.changed_fields.is_empty() {
+            output.push_str("        Changed:\n");
+            for (path, original, roundtripped) in &diff.changed_fields {
+                // Truncate long values
+                let orig_display = if original.len() > 50 {
+                    format!("{}...", &original[..47])
+                } else {
+                    original.clone()
+                };
+                let round_display = if roundtripped.len() > 50 {
+                    format!("{}...", &roundtripped[..47])
+                } else {
+                    roundtripped.clone()
+                };
+                output.push_str(&format!(
+                    "          - `{}`: {} → {}\n",
+                    path, orig_display, round_display
+                ));
+            }
+        }
+    }
+
+    output
+}
+
+/// Generate the roundtrip transform coverage section of the report.
+pub fn generate_roundtrip_section(
+    roundtrip_results: &RoundtripResults,
+    adapters: &[Box<dyn ProviderAdapter>],
+) -> String {
+    let mut report = String::new();
+
+    report.push_str("## Roundtrip Transform Coverage\n\n");
+    report.push_str("Tests Provider → Universal → Provider fidelity.\n\n");
+
+    // Summary table
+    report.push_str("### Summary\n\n");
+    report.push_str("| Provider | Requests | Responses |\n");
+    report.push_str("|----------|----------|----------|\n");
+
+    let mut total_req_passed = 0;
+    let mut total_req_failed = 0;
+    let mut total_resp_passed = 0;
+    let mut total_resp_failed = 0;
+
+    for (adapter_idx, adapter) in adapters.iter().enumerate() {
+        if let Some(result) = roundtrip_results.get(&adapter_idx) {
+            let req_cell = format_roundtrip_cell(result.request_passed, result.request_failed);
+            let resp_cell = format_roundtrip_cell(result.response_passed, result.response_failed);
+            report.push_str(&format!(
+                "| {} | {} | {} |\n",
+                adapter.display_name(),
+                req_cell,
+                resp_cell
+            ));
+
+            total_req_passed += result.request_passed;
+            total_req_failed += result.request_failed;
+            total_resp_passed += result.response_passed;
+            total_resp_failed += result.response_failed;
+        }
+    }
+
+    let total_passed = total_req_passed + total_resp_passed;
+    let total_failed = total_req_failed + total_resp_failed;
+    let total = total_passed + total_failed;
+    let pass_percentage = if total > 0 {
+        (total_passed as f64 / total as f64) * 100.0
+    } else {
+        0.0
+    };
+
+    report.push_str(&format!(
+        "\n**{}/{} ({:.1}%)** - {} failed\n",
+        total_passed, total, pass_percentage, total_failed
+    ));
+
+    // Issues by provider
+    let has_failures = roundtrip_results.values().any(|r| r.total_failed() > 0);
+
+    if has_failures {
+        report.push_str("\n### Issues by Provider\n\n");
+
+        // Sort providers by failure count
+        let mut providers_with_failures: Vec<_> = adapters
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, adapter)| {
+                roundtrip_results
+                    .get(&idx)
+                    .filter(|r| r.total_failed() > 0)
+                    .map(|r| (adapter, r))
+            })
+            .collect();
+        providers_with_failures.sort_by(|a, b| b.1.total_failed().cmp(&a.1.total_failed()));
+
+        for (adapter, result) in providers_with_failures {
+            let total_issues = result.total_failed();
+            report.push_str("<details>\n");
+            report.push_str(&format!(
+                "<summary>❌ {} ({} issues)</summary>\n\n",
+                adapter.display_name(),
+                total_issues
+            ));
+
+            // Request roundtrip issues
+            if !result.request_failures.is_empty() {
+                report.push_str(&format!(
+                    "**Request roundtrip issues ({}):**\n\n",
+                    result.request_failures.len()
+                ));
+                for (test_case, roundtrip_result) in &result.request_failures {
+                    report.push_str(&format!("- `{}`\n", test_case));
+                    let diff_output = format_roundtrip_diff(roundtrip_result);
+                    if !diff_output.is_empty() {
+                        report.push_str(&diff_output);
+                    }
+                }
+                report.push('\n');
+            }
+
+            // Response roundtrip issues
+            if !result.response_failures.is_empty() {
+                report.push_str(&format!(
+                    "**Response roundtrip issues ({}):**\n\n",
+                    result.response_failures.len()
+                ));
+                for (test_case, roundtrip_result) in &result.response_failures {
+                    report.push_str(&format!("- `{}`\n", test_case));
+                    let diff_output = format_roundtrip_diff(roundtrip_result);
+                    if !diff_output.is_empty() {
+                        report.push_str(&diff_output);
+                    }
+                }
+                report.push('\n');
+            }
+
+            report.push_str("</details>\n\n");
+        }
+    }
+
+    report
+}
+
+pub fn generate_report(
+    request_results: &HashMap<(usize, usize), PairResult>,
+    response_results: &HashMap<(usize, usize), PairResult>,
+    streaming_results: &HashMap<(usize, usize), PairResult>,
+    roundtrip_results: &RoundtripResults,
+    adapters: &[Box<dyn ProviderAdapter>],
+) -> String {
+    let mut report = String::new();
+
+    report.push_str("## Cross-Provider Transformation Coverage\n\n");
+
+    let (req_table, req_stats, req_failures) =
+        generate_table(request_results, adapters, "Request Transformations");
+    report.push_str(&req_table);
+
+    report.push('\n');
+    let (resp_table, resp_stats, resp_failures) =
+        generate_table(response_results, adapters, "Response Transformations");
+    report.push_str(&resp_table);
+
+    report.push('\n');
+    let (stream_table, stream_stats, stream_failures) = generate_table(
+        streaming_results,
+        adapters,
+        "Streaming Response Transformations",
+    );
+    report.push_str(&stream_table);
+
+    let total_passed = req_stats.passed + resp_stats.passed + stream_stats.passed;
+    let total_failed = req_stats.failed + resp_stats.failed + stream_stats.failed;
+    let total = total_passed + total_failed;
+
+    let pass_percentage = if total > 0 {
+        (total_passed as f64 / total as f64) * 100.0
+    } else {
+        0.0
+    };
+
+    report.push_str("\n### Summary\n\n");
+    report.push_str(&format!(
+        "**{}/{} ({:.1}%)** - {} failed\n",
+        total_passed, total, pass_percentage, total_failed
+    ));
+
+    let req_total = req_stats.passed + req_stats.failed;
+    let resp_total = resp_stats.passed + resp_stats.failed;
+    let stream_total = stream_stats.passed + stream_stats.failed;
+
+    report.push_str(&format!(
+        "\n**Requests:** {}/{} passed, {} failed\n",
+        req_stats.passed, req_total, req_stats.failed
+    ));
+    report.push_str(&format!(
+        "**Responses:** {}/{} passed, {} failed\n",
+        resp_stats.passed, resp_total, resp_stats.failed
+    ));
+    report.push_str(&format!(
+        "**Streaming:** {}/{} passed, {} failed\n",
+        stream_stats.passed, stream_total, stream_stats.failed
+    ));
+
+    // Organize issues by source provider → request/response/streaming → target
+    if !req_failures.is_empty() || !resp_failures.is_empty() || !stream_failures.is_empty() {
+        report.push_str("\n### Issues by Source\n\n");
+
+        // Group failures by source provider, keeping request/response/streaming separate
+        let mut req_by_source: HashMap<String, Vec<(String, String, String)>> = HashMap::new();
+        let mut resp_by_source: HashMap<String, Vec<(String, String, String)>> = HashMap::new();
+        let mut stream_by_source: HashMap<String, Vec<(String, String, String)>> = HashMap::new();
+
+        for (direction, test_case, error) in req_failures {
+            let source = direction
+                .split(" → ")
+                .next()
+                .unwrap_or(&direction)
+                .to_string();
+            req_by_source
+                .entry(source)
+                .or_default()
+                .push((direction, test_case, error));
+        }
+
+        for (direction, test_case, error) in resp_failures {
+            let source = direction
+                .split(" → ")
+                .next()
+                .unwrap_or(&direction)
+                .to_string();
+            resp_by_source
+                .entry(source)
+                .or_default()
+                .push((direction, test_case, error));
+        }
+
+        for (direction, test_case, error) in stream_failures {
+            let source = direction
+                .split(" → ")
+                .next()
+                .unwrap_or(&direction)
+                .to_string();
+            stream_by_source
+                .entry(source)
+                .or_default()
+                .push((direction, test_case, error));
+        }
+
+        // Get all unique sources and sort by total failure count
+        let mut all_sources: HashMap<String, usize> = HashMap::new();
+        for (source, failures) in &req_by_source {
+            *all_sources.entry(source.clone()).or_default() += failures.len();
+        }
+        for (source, failures) in &resp_by_source {
+            *all_sources.entry(source.clone()).or_default() += failures.len();
+        }
+        for (source, failures) in &stream_by_source {
+            *all_sources.entry(source.clone()).or_default() += failures.len();
+        }
+
+        let mut sources: Vec<_> = all_sources.into_iter().collect();
+        sources.sort_by(|a, b| b.1.cmp(&a.1));
+
+        for (source, total_count) in sources {
+            report.push_str("<details>\n");
+            report.push_str(&format!(
+                "<summary>❌ {} ({} issues)</summary>\n\n",
+                source, total_count
+            ));
+
+            // Request transformation issues for this source
+            if let Some(req_failures) = req_by_source.get(&source) {
+                report.push_str("<details>\n");
+                report.push_str(&format!(
+                    "<summary>  📤 Request transformations ({})</summary>\n\n",
+                    req_failures.len()
+                ));
+
+                // Group by target
+                let mut by_target: HashMap<String, Vec<(String, String)>> = HashMap::new();
+                for (direction, test_case, error) in req_failures {
+                    let target = direction
+                        .split(" → ")
+                        .nth(1)
+                        .unwrap_or("Unknown")
+                        .to_string();
+                    by_target
+                        .entry(target)
+                        .or_default()
+                        .push((test_case.clone(), error.clone()));
+                }
+
+                let mut targets: Vec<_> = by_target.into_iter().collect();
+                targets.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+
+                for (target, target_failures) in targets {
+                    report.push_str("<details>\n");
+                    report.push_str(&format!(
+                        "<summary>    → {} ({})</summary>\n\n",
+                        target,
+                        target_failures.len()
+                    ));
+
+                    for (test_case, error) in target_failures {
+                        report.push_str(&format!("      - `{}` - {}\n", test_case, error));
+                    }
+
+                    report.push_str("\n</details>\n\n");
+                }
+
+                report.push_str("</details>\n\n");
+            }
+
+            // Response transformation issues for this source
+            if let Some(resp_failures) = resp_by_source.get(&source) {
+                report.push_str("<details>\n");
+                report.push_str(&format!(
+                    "<summary>  📥 Response transformations ({})</summary>\n\n",
+                    resp_failures.len()
+                ));
+
+                // Group by target
+                let mut by_target: HashMap<String, Vec<(String, String)>> = HashMap::new();
+                for (direction, test_case, error) in resp_failures {
+                    let target = direction
+                        .split(" → ")
+                        .nth(1)
+                        .unwrap_or("Unknown")
+                        .to_string();
+                    by_target
+                        .entry(target)
+                        .or_default()
+                        .push((test_case.clone(), error.clone()));
+                }
+
+                let mut targets: Vec<_> = by_target.into_iter().collect();
+                targets.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+
+                for (target, target_failures) in targets {
+                    report.push_str("<details>\n");
+                    report.push_str(&format!(
+                        "<summary>    → {} ({})</summary>\n\n",
+                        target,
+                        target_failures.len()
+                    ));
+
+                    for (test_case, error) in target_failures {
+                        report.push_str(&format!("      - `{}` - {}\n", test_case, error));
+                    }
+
+                    report.push_str("\n</details>\n\n");
+                }
+
+                report.push_str("</details>\n\n");
+            }
+
+            // Streaming transformation issues for this source
+            if let Some(stream_failures) = stream_by_source.get(&source) {
+                report.push_str("<details>\n");
+                report.push_str(&format!(
+                    "<summary>  🌊 Streaming transformations ({})</summary>\n\n",
+                    stream_failures.len()
+                ));
+
+                // Group by target
+                let mut by_target: HashMap<String, Vec<(String, String)>> = HashMap::new();
+                for (direction, test_case, error) in stream_failures {
+                    let target = direction
+                        .split(" → ")
+                        .nth(1)
+                        .unwrap_or("Unknown")
+                        .to_string();
+                    by_target
+                        .entry(target)
+                        .or_default()
+                        .push((test_case.clone(), error.clone()));
+                }
+
+                let mut targets: Vec<_> = by_target.into_iter().collect();
+                targets.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+
+                for (target, target_failures) in targets {
+                    report.push_str("<details>\n");
+                    report.push_str(&format!(
+                        "<summary>    → {} ({})</summary>\n\n",
+                        target,
+                        target_failures.len()
+                    ));
+
+                    for (test_case, error) in target_failures {
+                        report.push_str(&format!("      - `{}` - {}\n", test_case, error));
+                    }
+
+                    report.push_str("\n</details>\n\n");
+                }
+
+                report.push_str("</details>\n\n");
+            }
+
+            report.push_str("</details>\n\n");
+        }
+    }
+
+    // Add roundtrip section
+    report.push('\n');
+    report.push_str(&generate_roundtrip_section(roundtrip_results, adapters));
+
+    report
+}

--- a/crates/coverage-report/src/runner.rs
+++ b/crates/coverage-report/src/runner.rs
@@ -1,0 +1,655 @@
+/*!
+Test execution for coverage-report.
+*/
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use lingua::capabilities::ProviderFormat;
+use lingua::processing::adapters::ProviderAdapter;
+use lingua::processing::transform::{
+    transform_request, transform_response, transform_stream_chunk,
+};
+use lingua::serde_json::Value;
+
+use crate::discovery::{discover_test_cases, load_payload};
+use crate::types::{PairResult, TransformResult, ValidationLevel};
+
+type PairResults = HashMap<(usize, usize), PairResult>;
+type AllResults = (PairResults, PairResults, PairResults);
+
+// Validation uses request_to_universal/response_to_universal from the adapter trait.
+// These methods return Result with detailed error info when validation fails.
+
+pub fn test_request_transformation(
+    test_case: &str,
+    source_adapter: &dyn ProviderAdapter,
+    target_adapter: &dyn ProviderAdapter,
+    filename: &str,
+) -> TransformResult {
+    let payload = match load_payload(test_case, source_adapter.directory_name(), filename) {
+        Some(p) => p,
+        None => {
+            return TransformResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("Source payload not found: {}", filename)),
+            }
+        }
+    };
+
+    // Provide model for formats that have model in URL (Google, Bedrock)
+    let model: Option<&str> = match source_adapter.format() {
+        ProviderFormat::Google => Some("gemini-1.5-pro"),
+        ProviderFormat::Converse => Some("anthropic.claude-3-sonnet"),
+        _ => None,
+    };
+
+    match transform_request(payload, target_adapter.format(), model) {
+        Ok(result) => {
+            if result.is_passthrough() && source_adapter.format() == target_adapter.format() {
+                return TransformResult {
+                    level: ValidationLevel::Pass,
+                    error: None,
+                };
+            }
+
+            // Parse result bytes to Value for validation
+            let output_bytes = result.into_bytes();
+            let transformed: Value = match lingua::serde_json::from_slice(&output_bytes) {
+                Ok(v) => v,
+                Err(e) => {
+                    return TransformResult {
+                        level: ValidationLevel::Fail,
+                        error: Some(format!("Failed to parse transformed output: {}", e)),
+                    }
+                }
+            };
+
+            // Use request_to_universal to validate - gives detailed error info
+            match target_adapter.request_to_universal(transformed) {
+                Ok(_) => TransformResult {
+                    level: ValidationLevel::Pass,
+                    error: None,
+                },
+                Err(e) => TransformResult {
+                    level: ValidationLevel::Fail,
+                    error: Some(e.to_string()),
+                },
+            }
+        }
+        Err(e) => TransformResult {
+            level: ValidationLevel::Fail,
+            error: Some(format!("{}", e)),
+        },
+    }
+}
+
+pub fn test_response_transformation(
+    test_case: &str,
+    source_adapter: &dyn ProviderAdapter,
+    target_adapter: &dyn ProviderAdapter,
+    filename: &str,
+) -> TransformResult {
+    let payload = match load_payload(test_case, source_adapter.directory_name(), filename) {
+        Some(p) => p,
+        None => {
+            return TransformResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("Response payload not found: {}", filename)),
+            }
+        }
+    };
+
+    match transform_response(payload, target_adapter.format()) {
+        Ok(result) => {
+            // Parse result bytes to Value for validation
+            let output_bytes = result.into_bytes();
+            let transformed: Value = match lingua::serde_json::from_slice(&output_bytes) {
+                Ok(v) => v,
+                Err(e) => {
+                    return TransformResult {
+                        level: ValidationLevel::Fail,
+                        error: Some(format!("Failed to parse transformed output: {}", e)),
+                    }
+                }
+            };
+
+            // Use response_to_universal to validate - gives detailed error info
+            match target_adapter.response_to_universal(transformed) {
+                Ok(_) => TransformResult {
+                    level: ValidationLevel::Pass,
+                    error: None,
+                },
+                Err(e) => TransformResult {
+                    level: ValidationLevel::Fail,
+                    error: Some(e.to_string()),
+                },
+            }
+        }
+        Err(e) => TransformResult {
+            level: ValidationLevel::Fail,
+            error: Some(format!("{}", e)),
+        },
+    }
+}
+
+/// Test streaming response transformation for a single test case.
+/// Returns a TransformResult indicating pass/fail for the entire streaming file.
+pub fn test_streaming_transformation(
+    test_case: &str,
+    source_adapter: &dyn ProviderAdapter,
+    target_adapter: &dyn ProviderAdapter,
+    filename: &str,
+) -> TransformResult {
+    let payload_bytes = match load_payload(test_case, source_adapter.directory_name(), filename) {
+        Some(p) => p,
+        None => {
+            // No streaming file - report as not found
+            return TransformResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("Streaming payload not found: {}", filename)),
+            };
+        }
+    };
+
+    // Parse the bytes to get the array of events
+    let payload: Value = match lingua::serde_json::from_slice(&payload_bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            return TransformResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("Failed to parse streaming payload: {}", e)),
+            };
+        }
+    };
+
+    let events = match payload.as_array() {
+        Some(arr) => arr,
+        None => {
+            return TransformResult {
+                level: ValidationLevel::Fail,
+                error: Some("Streaming payload is not an array".to_string()),
+            };
+        }
+    };
+
+    // Test all events - fail if any event fails
+    for (idx, event) in events.iter().enumerate() {
+        // Serialize each event back to bytes for the transform function
+        let event_bytes = match lingua::serde_json::to_vec(event) {
+            Ok(b) => Bytes::from(b),
+            Err(e) => {
+                return TransformResult {
+                    level: ValidationLevel::Fail,
+                    error: Some(format!("Event {}: failed to serialize: {}", idx, e)),
+                };
+            }
+        };
+
+        if let Err(e) = test_single_stream_event(event_bytes, target_adapter) {
+            return TransformResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("Event {}: {}", idx, e)),
+            };
+        }
+    }
+
+    TransformResult {
+        level: ValidationLevel::Pass,
+        error: None,
+    }
+}
+
+/// Test a single streaming event transformation
+fn test_single_stream_event(
+    event: Bytes,
+    target_adapter: &dyn ProviderAdapter,
+) -> Result<(), String> {
+    // Transform the event to target format
+    let result =
+        transform_stream_chunk(event, target_adapter.format()).map_err(|e| e.to_string())?;
+
+    // Parse result bytes to Value for validation
+    let output_bytes = result.into_bytes();
+    let transformed: Value =
+        lingua::serde_json::from_slice(&output_bytes).map_err(|e| e.to_string())?;
+
+    // Validate transformed output can be parsed by target adapter
+    match target_adapter.stream_to_universal(transformed) {
+        Ok(Some(_chunk)) => Ok(()),
+        Ok(None) => Ok(()), // Keep-alive events are valid
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Run all cross-transformation tests and collect results
+pub fn run_all_tests(adapters: &[Box<dyn ProviderAdapter>]) -> AllResults {
+    let test_cases = discover_test_cases();
+    let mut request_results: PairResults = HashMap::new();
+    let mut response_results: PairResults = HashMap::new();
+    let mut streaming_results: PairResults = HashMap::new();
+
+    // Initialize results for all pairs
+    for (source_idx, _) in adapters.iter().enumerate() {
+        for (target_idx, _) in adapters.iter().enumerate() {
+            if source_idx != target_idx {
+                request_results.insert((source_idx, target_idx), PairResult::default());
+                response_results.insert((source_idx, target_idx), PairResult::default());
+                streaming_results.insert((source_idx, target_idx), PairResult::default());
+            }
+        }
+    }
+
+    // Test each source→target pair for each test case
+    for test_case in &test_cases {
+        for (source_idx, source) in adapters.iter().enumerate() {
+            for (target_idx, target) in adapters.iter().enumerate() {
+                if source_idx == target_idx {
+                    continue;
+                }
+
+                let source = source.as_ref();
+                let target = target.as_ref();
+
+                // Test first turn request
+                let result = test_request_transformation(test_case, source, target, "request.json");
+                let pair_result = request_results.get_mut(&(source_idx, target_idx)).unwrap();
+
+                match result.level {
+                    ValidationLevel::Pass => pair_result.passed += 1,
+                    ValidationLevel::Fail => {
+                        pair_result.failed += 1;
+                        if let Some(error) = result.error {
+                            pair_result
+                                .failures
+                                .push((format!("{} (request)", test_case), error));
+                        }
+                    }
+                }
+
+                // Test followup request if exists
+                let followup_result =
+                    test_request_transformation(test_case, source, target, "followup-request.json");
+                if followup_result
+                    .error
+                    .as_ref()
+                    .is_none_or(|e| !e.contains("not found"))
+                {
+                    match followup_result.level {
+                        ValidationLevel::Pass => pair_result.passed += 1,
+                        ValidationLevel::Fail => {
+                            pair_result.failed += 1;
+                            if let Some(error) = followup_result.error {
+                                pair_result
+                                    .failures
+                                    .push((format!("{} (followup)", test_case), error));
+                            }
+                        }
+                    }
+                }
+
+                // Test response transformation (source response transforms to target format)
+                let response_result =
+                    test_response_transformation(test_case, source, target, "response.json");
+                let resp_pair_result = response_results.get_mut(&(source_idx, target_idx)).unwrap();
+
+                if response_result
+                    .error
+                    .as_ref()
+                    .is_none_or(|e| !e.contains("not found"))
+                {
+                    match response_result.level {
+                        ValidationLevel::Pass => resp_pair_result.passed += 1,
+                        ValidationLevel::Fail => {
+                            resp_pair_result.failed += 1;
+                            if let Some(error) = response_result.error {
+                                resp_pair_result
+                                    .failures
+                                    .push((format!("{} (response)", test_case), error));
+                            }
+                        }
+                    }
+                }
+
+                // Test streaming response transformation
+                let stream_pair_result = streaming_results
+                    .get_mut(&(source_idx, target_idx))
+                    .unwrap();
+
+                let streaming_result = test_streaming_transformation(
+                    test_case,
+                    source,
+                    target,
+                    "response-streaming.json",
+                );
+                if streaming_result
+                    .error
+                    .as_ref()
+                    .is_none_or(|e| !e.contains("not found"))
+                {
+                    match streaming_result.level {
+                        ValidationLevel::Pass => stream_pair_result.passed += 1,
+                        ValidationLevel::Fail => {
+                            stream_pair_result.failed += 1;
+                            if let Some(error) = streaming_result.error {
+                                stream_pair_result
+                                    .failures
+                                    .push((format!("{} (streaming)", test_case), error));
+                            }
+                        }
+                    }
+                }
+
+                // Test followup streaming if exists
+                let followup_streaming_result = test_streaming_transformation(
+                    test_case,
+                    source,
+                    target,
+                    "followup-response-streaming.json",
+                );
+                if followup_streaming_result
+                    .error
+                    .as_ref()
+                    .is_none_or(|e| !e.contains("not found"))
+                {
+                    match followup_streaming_result.level {
+                        ValidationLevel::Pass => stream_pair_result.passed += 1,
+                        ValidationLevel::Fail => {
+                            stream_pair_result.failed += 1;
+                            if let Some(error) = followup_streaming_result.error {
+                                stream_pair_result
+                                    .failures
+                                    .push((format!("{} (followup-streaming)", test_case), error));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    (request_results, response_results, streaming_results)
+}
+
+// ============================================================================
+// Roundtrip testing (Provider → Universal → Provider)
+// ============================================================================
+
+use crate::types::{ProviderRoundtripResult, RoundtripDiff, RoundtripResult};
+use std::collections::HashSet;
+
+/// Type alias for roundtrip results indexed by adapter index
+pub type RoundtripResults = HashMap<usize, ProviderRoundtripResult>;
+
+/// Fields that are expected to change during roundtrip and should be ignored.
+/// These are typically metadata fields set by providers or computed values.
+const IGNORED_FIELDS: &[&str] = &[
+    "id",
+    "created",
+    "system_fingerprint",
+    "service_tier",
+    "object",
+];
+
+/// Compare two JSON values and produce a RoundtripDiff.
+fn compare_values(original: &Value, roundtripped: &Value) -> RoundtripResult {
+    let mut diff = RoundtripDiff::default();
+    compare_recursive(original, roundtripped, "", &mut diff);
+
+    if diff.is_empty() {
+        RoundtripResult {
+            level: ValidationLevel::Pass,
+            error: None,
+            diff: None,
+        }
+    } else {
+        RoundtripResult {
+            level: ValidationLevel::Fail,
+            error: Some(format!(
+                "{} lost, {} added, {} changed",
+                diff.lost_fields.len(),
+                diff.added_fields.len(),
+                diff.changed_fields.len()
+            )),
+            diff: Some(diff),
+        }
+    }
+}
+
+/// Recursively compare two JSON values and accumulate differences.
+fn compare_recursive(original: &Value, roundtripped: &Value, path: &str, diff: &mut RoundtripDiff) {
+    match (original, roundtripped) {
+        (Value::Object(orig), Value::Object(round)) => {
+            let orig_keys: HashSet<_> = orig.keys().collect();
+            let round_keys: HashSet<_> = round.keys().collect();
+
+            // Check for lost fields (in original but not in roundtripped)
+            for key in orig_keys.difference(&round_keys) {
+                let field_path = if path.is_empty() {
+                    (*key).clone()
+                } else {
+                    format!("{}.{}", path, key)
+                };
+                // Skip ignored fields
+                if !IGNORED_FIELDS.contains(&key.as_str()) {
+                    diff.lost_fields.push(field_path);
+                }
+            }
+
+            // Check for added fields (in roundtripped but not in original)
+            for key in round_keys.difference(&orig_keys) {
+                let field_path = if path.is_empty() {
+                    (*key).clone()
+                } else {
+                    format!("{}.{}", path, key)
+                };
+                // Skip ignored fields
+                if !IGNORED_FIELDS.contains(&key.as_str()) {
+                    diff.added_fields.push(field_path);
+                }
+            }
+
+            // Recursively compare common keys
+            for key in orig_keys.intersection(&round_keys) {
+                let new_path = if path.is_empty() {
+                    (*key).clone()
+                } else {
+                    format!("{}.{}", path, key)
+                };
+                compare_recursive(&orig[*key], &round[*key], &new_path, diff);
+            }
+        }
+        (Value::Array(orig), Value::Array(round)) => {
+            // Compare array lengths
+            if orig.len() != round.len() {
+                diff.changed_fields.push((
+                    format!("{}.length", path),
+                    orig.len().to_string(),
+                    round.len().to_string(),
+                ));
+                return;
+            }
+
+            // Compare element by element
+            for (idx, (o, r)) in orig.iter().zip(round.iter()).enumerate() {
+                let new_path = format!("{}[{}]", path, idx);
+                compare_recursive(o, r, &new_path, diff);
+            }
+        }
+        (Value::Null, Value::Null) => {}
+        (Value::Bool(o), Value::Bool(r)) if o == r => {}
+        (Value::Number(o), Value::Number(r)) if o == r => {}
+        (Value::String(o), Value::String(r)) if o == r => {}
+        _ => {
+            // Values differ - skip if this is an ignored field
+            let field_name = path.rsplit('.').next().unwrap_or(path);
+            if !IGNORED_FIELDS.contains(&field_name) {
+                diff.changed_fields.push((
+                    path.to_string(),
+                    lingua::serde_json::to_string(original).unwrap_or_else(|_| "?".to_string()),
+                    lingua::serde_json::to_string(roundtripped).unwrap_or_else(|_| "?".to_string()),
+                ));
+            }
+        }
+    }
+}
+
+/// Test request roundtrip: Provider → Universal → Provider
+pub fn test_request_roundtrip(
+    test_case: &str,
+    adapter: &dyn ProviderAdapter,
+    filename: &str,
+) -> Option<RoundtripResult> {
+    // 1. Load payload
+    let payload = load_payload(test_case, adapter.directory_name(), filename)?;
+
+    // 2. Parse to Value
+    let original: Value = match lingua::serde_json::from_slice(&payload) {
+        Ok(v) => v,
+        Err(e) => {
+            return Some(RoundtripResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("Failed to parse payload: {}", e)),
+                diff: None,
+            });
+        }
+    };
+
+    // 3. Convert to Universal
+    let universal = match adapter.request_to_universal(original.clone()) {
+        Ok(u) => u,
+        Err(e) => {
+            return Some(RoundtripResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("request_to_universal failed: {}", e)),
+                diff: None,
+            });
+        }
+    };
+
+    // 4. Convert back to provider format
+    let roundtripped = match adapter.request_from_universal(&universal) {
+        Ok(r) => r,
+        Err(e) => {
+            return Some(RoundtripResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("request_from_universal failed: {}", e)),
+                diff: None,
+            });
+        }
+    };
+
+    // 5. Compare original vs roundtripped
+    Some(compare_values(&original, &roundtripped))
+}
+
+/// Test response roundtrip: Provider → Universal → Provider
+pub fn test_response_roundtrip(
+    test_case: &str,
+    adapter: &dyn ProviderAdapter,
+    filename: &str,
+) -> Option<RoundtripResult> {
+    // 1. Load payload
+    let payload = load_payload(test_case, adapter.directory_name(), filename)?;
+
+    // 2. Parse to Value
+    let original: Value = match lingua::serde_json::from_slice(&payload) {
+        Ok(v) => v,
+        Err(e) => {
+            return Some(RoundtripResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("Failed to parse payload: {}", e)),
+                diff: None,
+            });
+        }
+    };
+
+    // 3. Convert to Universal
+    let universal = match adapter.response_to_universal(original.clone()) {
+        Ok(u) => u,
+        Err(e) => {
+            return Some(RoundtripResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("response_to_universal failed: {}", e)),
+                diff: None,
+            });
+        }
+    };
+
+    // 4. Convert back to provider format
+    let roundtripped = match adapter.response_from_universal(&universal) {
+        Ok(r) => r,
+        Err(e) => {
+            return Some(RoundtripResult {
+                level: ValidationLevel::Fail,
+                error: Some(format!("response_from_universal failed: {}", e)),
+                diff: None,
+            });
+        }
+    };
+
+    // 5. Compare original vs roundtripped
+    Some(compare_values(&original, &roundtripped))
+}
+
+/// Run all roundtrip tests for all providers.
+pub fn run_roundtrip_tests(adapters: &[Box<dyn ProviderAdapter>]) -> RoundtripResults {
+    let test_cases = discover_test_cases();
+    let mut results: RoundtripResults = HashMap::new();
+
+    // Initialize results for each adapter
+    for (adapter_idx, _) in adapters.iter().enumerate() {
+        results.insert(adapter_idx, ProviderRoundtripResult::default());
+    }
+
+    // Test each provider's roundtrip for each test case
+    for test_case in &test_cases {
+        for (adapter_idx, adapter) in adapters.iter().enumerate() {
+            let adapter = adapter.as_ref();
+            let provider_result = results.get_mut(&adapter_idx).unwrap();
+
+            // Test request roundtrip
+            if let Some(result) = test_request_roundtrip(test_case, adapter, "request.json") {
+                match result.level {
+                    ValidationLevel::Pass => provider_result.request_passed += 1,
+                    ValidationLevel::Fail => {
+                        provider_result.request_failed += 1;
+                        provider_result
+                            .request_failures
+                            .push((format!("{} (request)", test_case), result));
+                    }
+                }
+            }
+
+            // Test followup request roundtrip if exists
+            if let Some(result) =
+                test_request_roundtrip(test_case, adapter, "followup-request.json")
+            {
+                match result.level {
+                    ValidationLevel::Pass => provider_result.request_passed += 1,
+                    ValidationLevel::Fail => {
+                        provider_result.request_failed += 1;
+                        provider_result
+                            .request_failures
+                            .push((format!("{} (followup-request)", test_case), result));
+                    }
+                }
+            }
+
+            // Test response roundtrip
+            if let Some(result) = test_response_roundtrip(test_case, adapter, "response.json") {
+                match result.level {
+                    ValidationLevel::Pass => provider_result.response_passed += 1,
+                    ValidationLevel::Fail => {
+                        provider_result.response_failed += 1;
+                        provider_result
+                            .response_failures
+                            .push((format!("{} (response)", test_case), result));
+                    }
+                }
+            }
+        }
+    }
+
+    results
+}

--- a/crates/coverage-report/src/types.rs
+++ b/crates/coverage-report/src/types.rs
@@ -1,0 +1,87 @@
+/*!
+Type definitions for coverage-report.
+*/
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ValidationLevel {
+    Pass,
+    Fail,
+}
+
+#[derive(Debug)]
+pub struct TransformResult {
+    pub level: ValidationLevel,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct PairResult {
+    pub passed: usize,
+    pub failed: usize,
+    pub failures: Vec<(String, String)>,
+}
+
+pub struct TableStats {
+    pub passed: usize,
+    pub failed: usize,
+}
+
+// ============================================================================
+// Roundtrip testing types
+// ============================================================================
+
+/// Structured diff showing what changed during roundtrip transformation.
+///
+/// Tracks three categories of differences:
+/// - `lost_fields`: Fields present in original but missing after roundtrip
+/// - `added_fields`: Fields added during roundtrip (not in original)
+/// - `changed_fields`: Fields where values changed (path, original, roundtripped)
+#[derive(Debug, Default)]
+pub struct RoundtripDiff {
+    pub lost_fields: Vec<String>,
+    pub added_fields: Vec<String>,
+    pub changed_fields: Vec<(String, String, String)>,
+}
+
+impl RoundtripDiff {
+    pub fn is_empty(&self) -> bool {
+        self.lost_fields.is_empty()
+            && self.added_fields.is_empty()
+            && self.changed_fields.is_empty()
+    }
+
+    #[allow(dead_code)]
+    pub fn total_issues(&self) -> usize {
+        self.lost_fields.len() + self.added_fields.len() + self.changed_fields.len()
+    }
+}
+
+/// Result of a single roundtrip test (Provider → Universal → Provider).
+#[derive(Debug)]
+pub struct RoundtripResult {
+    pub level: ValidationLevel,
+    pub error: Option<String>,
+    pub diff: Option<RoundtripDiff>,
+}
+
+/// Per-provider aggregated roundtrip test results.
+#[derive(Debug, Default)]
+pub struct ProviderRoundtripResult {
+    pub request_passed: usize,
+    pub request_failed: usize,
+    pub request_failures: Vec<(String, RoundtripResult)>,
+    pub response_passed: usize,
+    pub response_failed: usize,
+    pub response_failures: Vec<(String, RoundtripResult)>,
+}
+
+impl ProviderRoundtripResult {
+    #[allow(dead_code)]
+    pub fn total_passed(&self) -> usize {
+        self.request_passed + self.response_passed
+    }
+
+    pub fn total_failed(&self) -> usize {
+        self.request_failed + self.response_failed
+    }
+}

--- a/crates/lingua/Cargo.toml
+++ b/crates/lingua/Cargo.toml
@@ -25,6 +25,7 @@ python = ["dep:pyo3"]
 [dependencies]
 serde.workspace = true
 big_serde_json.workspace = true
+bytes.workspace = true
 serde_yaml.workspace = true
 serde_with.workspace = true
 ts-rs.workspace = true
@@ -33,12 +34,21 @@ thiserror.workspace = true
 assert-json-diff.workspace = true
 prost.workspace = true
 prost-types.workspace = true
+url.workspace = true
+urlencoding.workspace = true
+base64.workspace = true
+aws-sdk-bedrockruntime = { workspace = true, optional = true }
+pyo3 = { workspace = true, optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
 web-sys.workspace = true
+js-sys.workspace = true
 serde-wasm-bindgen.workspace = true
-aws-sdk-bedrockruntime = { workspace = true, optional = true }
-pyo3 = { workspace = true, optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+reqwest.workspace = true
 
 [dev-dependencies]
 tokio-test.workspace = true

--- a/crates/lingua/docs/ADDING_PROVIDER_FORMAT.md
+++ b/crates/lingua/docs/ADDING_PROVIDER_FORMAT.md
@@ -1,0 +1,845 @@
+# Adding a provider format
+
+This guide walks through adding support for a new LLM provider to lingua using a test-first approach.
+
+## Overview
+
+Lingua uses the `ProviderAdapter` trait for unified provider handling. Each adapter handles:
+- **Format detection**: Identifying payloads belonging to this provider
+- **Request transformation**: Converting to/from universal format
+- **Response transformation**: Converting to/from universal format
+- **Streaming**: Handling streaming chunks (optional)
+
+The transformation follows a three-layer pattern:
+
+```
+Source Payload → Universal Format → Target Payload
+```
+
+When source and target formats match, lingua returns the original bytes unchanged (zero-copy passthrough).
+
+## Workflow summary
+
+1. **Add payload snapshots** - Create test fixtures from real API calls
+2. **Add to ProviderFormat enum** - Register the new format
+3. **Create provider module** - Types based on your snapshots
+4. **Implement ProviderAdapter** - Fill in methods one by one
+5. **Run coverage-report** - Validate transformations and roundtrips
+6. **Iterate** - Fix failures until all tests pass
+
+---
+
+## Step 1: Add payload snapshots
+
+**Location**: `payloads/`
+
+Start by capturing real API payloads. These become your test fixtures and source of truth for the provider's format.
+
+### Setup
+
+```bash
+cd payloads
+pnpm install
+```
+
+Set environment variables for API access:
+```bash
+export OPENAI_API_KEY="..."
+export ANTHROPIC_API_KEY="..."
+export GOOGLE_API_KEY="..."
+export MY_PROVIDER_API_KEY="..."  # Your provider's API key
+```
+
+### Output structure
+
+Captured payloads are saved to `payloads/snapshots/`:
+
+```
+payloads/snapshots/
+├── simpleRequest/
+│   ├── myprovider/           # Your provider's directory
+│   │   ├── request.json
+│   │   ├── response.json
+│   │   ├── response-streaming.json
+│   │   ├── followup-request.json
+│   │   ├── followup-response.json
+│   │   └── followup-response-streaming.json
+│   ├── anthropic/
+│   ├── chat-completions/
+│   └── ...
+├── toolCallRequest/
+└── ...
+```
+
+### File naming convention
+
+| File | Description |
+|------|-------------|
+| `request.json` | First turn request |
+| `response.json` | Non-streaming response |
+| `response-streaming.json` | Streaming events (JSON array) |
+| `followup-request.json` | Second turn request (includes assistant response) |
+| `followup-response.json` | Second turn response |
+| `followup-response-streaming.json` | Second turn streaming |
+
+### Option A: Add to the capture system (recommended)
+
+The capture system automatically handles streaming, follow-up conversations, and tool call responses.
+
+#### 1. Add provider to types
+
+Edit `payloads/cases/types.ts`:
+
+```typescript
+export interface TestCase {
+  "chat-completions": OpenAI.Chat.Completions.ChatCompletionCreateParams | null;
+  responses: OpenAI.Responses.ResponseCreateParams | null;
+  anthropic: Anthropic.Messages.MessageCreateParams | null;
+  google: GoogleGenerateContentRequest | null;
+  bedrock: BedrockConverseRequest | null;
+  myprovider: MyProviderRequest | null;  // Add this
+}
+
+export const PROVIDER_TYPES = [
+  "chat-completions",
+  "responses",
+  "anthropic",
+  "google",
+  "bedrock",
+  "myprovider",  // Add this
+] as const;
+```
+
+#### 2. Add model configuration
+
+Edit `payloads/cases/models.ts`:
+
+```typescript
+export const MYPROVIDER_MODEL = "my-model-name";
+```
+
+#### 3. Add test cases
+
+Edit `payloads/cases/simple.ts`:
+
+```typescript
+import { MYPROVIDER_MODEL } from "./models";
+
+export const simpleCases: TestCaseCollection = {
+  simpleRequest: {
+    // ... existing providers ...
+
+    myprovider: {
+      model: MYPROVIDER_MODEL,
+      messages: [
+        { role: "user", content: "Say a one-sentence greeting." }
+      ],
+    },
+  },
+
+  // Add other cases: toolCallRequest, multimodalRequest, etc.
+};
+```
+
+#### 4. Create provider executor
+
+Create `payloads/scripts/providers/myprovider.ts`:
+
+```typescript
+import { CaptureResult, ProviderExecutor } from "../types";
+import { allTestCases, getCaseNames, getCaseForProvider } from "../../cases";
+
+type MyProviderRequest = { /* match your API */ };
+type MyProviderResponse = { /* match your API */ };
+type MyProviderStreamChunk = { /* match your API */ };
+
+export const myproviderCases: Record<string, MyProviderRequest> = {};
+
+getCaseNames(allTestCases).forEach((caseName) => {
+  const caseData = getCaseForProvider(allTestCases, caseName, "myprovider");
+  if (caseData) {
+    myproviderCases[caseName] = caseData;
+  }
+});
+
+export async function executeMyProvider(
+  caseName: string,
+  payload: MyProviderRequest,
+  stream?: boolean
+): Promise<CaptureResult<MyProviderRequest, MyProviderResponse, MyProviderStreamChunk>> {
+  const client = new MyProviderClient({ apiKey: process.env.MY_PROVIDER_API_KEY });
+  const result: CaptureResult<...> = { request: payload };
+
+  // Non-streaming call
+  if (stream !== true) {
+    result.response = await client.create({ ...payload, stream: false });
+  }
+
+  // Streaming call
+  if (stream !== false) {
+    const chunks = [];
+    const streamResponse = await client.create({ ...payload, stream: true });
+    for await (const chunk of streamResponse) {
+      chunks.push(chunk);
+    }
+    result.streamingResponse = chunks;
+  }
+
+  // Build follow-up request (append assistant response + user message)
+  // Handle tool calls if present
+  // ...
+
+  return result;
+}
+
+export const myproviderExecutor: ProviderExecutor<...> = {
+  name: "myprovider",
+  cases: myproviderCases,
+  execute: executeMyProvider,
+};
+```
+
+#### 5. Register executor
+
+Edit `payloads/scripts/capture.ts`:
+
+```typescript
+import { myproviderExecutor } from "./providers/myprovider";
+
+const allProviders = [
+  // ... existing providers ...
+  myproviderExecutor,
+] as const;
+```
+
+#### 6. Run capture
+
+```bash
+# Capture all cases for your provider
+pnpm capture --providers myprovider
+
+# Capture specific cases
+pnpm capture --providers myprovider --cases simpleRequest
+
+# Force re-capture (skip cache)
+pnpm capture --providers myprovider --force
+
+# List available cases and status
+pnpm capture --list
+```
+
+### Option B: Manually capture payloads
+
+For quick prototyping, manually create the JSON files:
+
+1. Make a real API call to your provider
+2. Save the request body as `request.json`
+3. Save the response body as `response.json`
+4. For streaming, collect all SSE event payloads into a JSON array as `response-streaming.json`
+
+```bash
+mkdir -p payloads/snapshots/simpleRequest/myprovider
+```
+
+**`payloads/snapshots/simpleRequest/myprovider/request.json`**:
+```json
+{
+  "model": "my-model-name",
+  "messages": [
+    {"role": "user", "content": "Hello, how are you?"}
+  ]
+}
+```
+
+**`payloads/snapshots/simpleRequest/myprovider/response.json`**:
+```json
+{
+  "model": "my-model-name",
+  "output": {
+    "role": "assistant",
+    "content": "I'm doing well, thank you for asking!"
+  },
+  "stop_reason": "stop",
+  "usage": {
+    "input_tokens": 12,
+    "output_tokens": 15
+  }
+}
+```
+
+### Recommended test cases
+
+| Case | Tests | Priority |
+|------|-------|----------|
+| `simpleRequest` | Basic text chat | Required |
+| `toolCallRequest` | Function/tool calling | High |
+| `multimodalRequest` | Images, files | Medium |
+| `reasoningRequest` | Extended thinking | If supported |
+
+### Capture commands reference
+
+```bash
+# List all cases and capture status
+pnpm capture --list
+
+# Capture all providers, all cases
+pnpm capture
+
+# Filter by provider
+pnpm capture --providers myprovider
+pnpm capture --providers myprovider,anthropic
+
+# Filter by case
+pnpm capture --cases simpleRequest,toolCallRequest
+
+# Filter by name pattern
+pnpm capture --filter reasoning
+
+# Streaming only / non-streaming only
+pnpm capture --stream true
+pnpm capture --stream false
+
+# Force re-capture (ignore cache)
+pnpm capture --force
+
+# Combine filters
+pnpm capture --providers myprovider --cases simpleRequest --force
+```
+
+### Prune orphaned snapshots
+
+Remove snapshots that no longer have corresponding test cases:
+
+```bash
+pnpm prune
+```
+
+---
+
+## Step 2: Add to ProviderFormat enum
+
+**Location**: `crates/lingua/src/capabilities/format.rs`
+
+```rust
+pub enum ProviderFormat {
+    OpenAI,
+    Anthropic,
+    Google,
+    Mistral,
+    Converse,   // Bedrock
+    Responses,  // OpenAI Responses API
+    MyProvider, // Add here
+    Unknown,
+}
+```
+
+Update the implementations:
+
+```rust
+// Display
+impl std::fmt::Display for ProviderFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            // ... existing variants ...
+            ProviderFormat::MyProvider => "myprovider",
+            ProviderFormat::Unknown => "unknown",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+// FromStr
+impl std::str::FromStr for ProviderFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            // ... existing variants ...
+            "myprovider" => Ok(ProviderFormat::MyProvider),
+            _ => Err(()),
+        }
+    }
+}
+```
+
+---
+
+## Step 3: Create provider module
+
+Create the directory structure:
+
+```
+crates/lingua/src/providers/myprovider/
+├── mod.rs
+├── adapter.rs
+├── convert.rs
+└── detect.rs
+```
+
+### detect.rs
+
+Define types based on your payload snapshots:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+/// Request type - match structure from your request.json snapshots
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MyProviderRequest {
+    pub model: String,
+    pub messages: Vec<MyProviderMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    // Add fields as you see them in your snapshots
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MyProviderMessage {
+    pub role: String,
+    pub content: String,
+}
+
+/// Response type - match structure from your response.json snapshots
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MyProviderResponse {
+    pub model: Option<String>,
+    pub output: MyProviderOutputMessage,
+    pub stop_reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<MyProviderUsage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MyProviderOutputMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MyProviderUsage {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+}
+
+/// Detection function - tries to parse payload as this provider's format
+pub fn try_parse_myprovider(
+    payload: &serde_json::Value,
+) -> Result<MyProviderRequest, serde_json::Error> {
+    serde_json::from_value(payload.clone())
+}
+```
+
+### mod.rs
+
+```rust
+pub mod adapter;
+pub mod convert;
+pub mod detect;
+
+pub use adapter::MyProviderAdapter;
+pub use detect::{try_parse_myprovider, MyProviderRequest, MyProviderResponse};
+```
+
+### Add to providers/mod.rs
+
+```rust
+#[cfg(feature = "myprovider")]
+pub mod myprovider;
+```
+
+### Add feature flag to Cargo.toml
+
+```toml
+[features]
+default = ["openai", "anthropic", "google", "bedrock", "myprovider"]
+myprovider = []
+```
+
+---
+
+## Step 4: Implement ProviderAdapter
+
+**Location**: `crates/lingua/src/providers/myprovider/adapter.rs`
+
+The `ProviderAdapter` trait has 11 required methods:
+
+| Category | Method | Purpose |
+|----------|--------|---------|
+| **Metadata** | `format()` | Returns the `ProviderFormat` enum variant |
+| | `directory_name()` | Directory name in `payloads/snapshots/` |
+| | `display_name()` | Human-readable name for reports |
+| **Request** | `detect_request()` | Returns `true` if payload matches this format |
+| | `request_to_universal()` | Provider request → `UniversalRequest` |
+| | `request_from_universal()` | `UniversalRequest` → Provider request |
+| | `apply_defaults()` | Set required defaults (e.g., Anthropic's `max_tokens`) |
+| **Response** | `detect_response()` | Returns `true` if payload matches this format |
+| | `response_to_universal()` | Provider response → `UniversalResponse` |
+| | `response_from_universal()` | `UniversalResponse` → Provider response |
+| | `map_finish_reason()` | Map `FinishReason` to provider's string |
+
+### Start with a skeleton
+
+```rust
+use crate::capabilities::ProviderFormat;
+use crate::processing::adapters::{collect_extras, insert_opt_f64, ProviderAdapter};
+use crate::processing::transform::TransformError;
+use crate::serde_json::{self, Map, Value};
+use crate::universal::convert::TryFromLLM;
+use crate::universal::message::Message;
+use crate::universal::{FinishReason, UniversalRequest, UniversalResponse, UniversalUsage};
+
+use super::detect::{try_parse_myprovider, MyProviderMessage};
+
+/// Fields to extract to UniversalRequest.params - everything else goes to extras
+const MYPROVIDER_KNOWN_KEYS: &[&str] = &[
+    "model",
+    "messages",
+    "temperature",
+    "max_tokens",
+];
+
+pub struct MyProviderAdapter;
+
+impl ProviderAdapter for MyProviderAdapter {
+    fn format(&self) -> ProviderFormat {
+        ProviderFormat::MyProvider
+    }
+
+    fn directory_name(&self) -> &'static str {
+        "myprovider"  // Must match payloads/snapshots/*/myprovider/
+    }
+
+    fn display_name(&self) -> &'static str {
+        "MyProvider"
+    }
+
+    fn detect_request(&self, payload: &Value) -> bool {
+        // Start simple, refine based on coverage-report failures
+        try_parse_myprovider(payload).is_ok()
+    }
+
+    fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
+        todo!("Implement based on your request.json snapshots")
+    }
+
+    fn request_from_universal(&self, req: &UniversalRequest) -> Result<Value, TransformError> {
+        todo!("Implement to produce your provider's request format")
+    }
+
+    fn apply_defaults(&self, _req: &mut UniversalRequest) {
+        // Set required defaults if your provider needs them
+    }
+
+    fn detect_response(&self, payload: &Value) -> bool {
+        // Check for your provider's response structure
+        payload.get("output").is_some() && payload.get("stop_reason").is_some()
+    }
+
+    fn response_to_universal(&self, payload: Value) -> Result<UniversalResponse, TransformError> {
+        todo!("Implement based on your response.json snapshots")
+    }
+
+    fn response_from_universal(&self, resp: &UniversalResponse) -> Result<Value, TransformError> {
+        todo!("Implement to produce your provider's response format")
+    }
+
+    fn map_finish_reason(&self, reason: Option<&FinishReason>) -> Option<String> {
+        reason.map(|r| match r {
+            FinishReason::Stop => "stop".to_string(),
+            FinishReason::Length => "max_tokens".to_string(),
+            FinishReason::ToolCalls => "tool_use".to_string(),
+            FinishReason::ContentFilter => "content_filter".to_string(),
+            FinishReason::Other(s) => s.clone(),
+        })
+    }
+}
+```
+
+### Register the adapter
+
+**Location**: `crates/lingua/src/processing/adapters.rs`
+
+```rust
+static ADAPTERS: LazyLock<Vec<Box<dyn ProviderAdapter>>> = LazyLock::new(|| {
+    let mut list: Vec<Box<dyn ProviderAdapter>> = Vec::new();
+
+    // Order matters! More specific formats first
+    #[cfg(feature = "openai")]
+    list.push(Box::new(crate::providers::openai::ResponsesAdapter));
+
+    #[cfg(feature = "myprovider")]  // Add with feature gate
+    list.push(Box::new(crate::providers::myprovider::MyProviderAdapter));
+
+    #[cfg(feature = "bedrock")]
+    list.push(Box::new(crate::providers::bedrock::BedrockAdapter));
+
+    // ... other adapters ...
+
+    #[cfg(feature = "openai")]
+    list.push(Box::new(crate::providers::openai::OpenAIAdapter));  // Last - most permissive
+
+    list
+});
+```
+
+**Detection priority**: Place more distinctive formats earlier. OpenAI must be last because its detection is permissive.
+
+---
+
+## Step 5: Run coverage-report
+
+Now run the coverage report to see what's failing:
+
+```bash
+cargo run --bin coverage-report
+```
+
+This tests:
+1. **Cross-provider transformations**: Source → Target for all provider pairs
+2. **Roundtrip transformations**: Provider → Universal → Provider
+
+### Reading the output
+
+```
+## Cross-Provider Transformation Coverage
+
+| Source → Target | OpenAI | Anthropic | MyProvider |
+|-----------------|--------|-----------|------------|
+| OpenAI          | ✓      | ✓         | ✗          |  <- MyProvider failing
+| Anthropic       | ✓      | ✓         | ✗          |
+| MyProvider      | ✗      | ✗         | ✓          |  <- Your provider
+
+## Roundtrip Transform Coverage
+
+| Provider   | Request | Response | Streaming |
+|------------|---------|----------|-----------|
+| MyProvider | ✗       | ✗        | -         |  <- Implement these
+```
+
+The `✗` marks show what needs implementation.
+
+---
+
+## Step 6: Iterate until tests pass
+
+### Implementing request_to_universal
+
+Look at your `request.json` snapshot and extract fields:
+
+```rust
+fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
+    let request: MyProviderRequest = serde_json::from_value(payload.clone())
+        .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+    // Convert messages using TryFromLLM (implement in convert.rs)
+    let messages: Vec<Message> =
+        <Vec<Message> as TryFromLLM<Vec<MyProviderMessage>>>::try_from(request.messages)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+    Ok(UniversalRequest {
+        model: Some(request.model),
+        messages,
+        params: crate::universal::UniversalParams {
+            temperature: request.temperature,
+            ..Default::default()
+        },
+        extras: collect_extras(&payload, MYPROVIDER_KNOWN_KEYS),
+    })
+}
+```
+
+### Implementing request_from_universal
+
+Build the provider format from universal:
+
+```rust
+fn request_from_universal(&self, req: &UniversalRequest) -> Result<Value, TransformError> {
+    let model = req.model.clone().ok_or_else(|| TransformError::ValidationFailed {
+        target: ProviderFormat::MyProvider,
+        reason: "model is required".to_string(),
+    })?;
+
+    let provider_messages: Vec<MyProviderMessage> =
+        <Vec<MyProviderMessage> as TryFromLLM<Vec<Message>>>::try_from(req.messages.clone())
+            .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+    let mut obj = Map::new();
+    obj.insert("model".into(), Value::String(model));
+    obj.insert("messages".into(), serde_json::to_value(provider_messages)
+        .map_err(|e| TransformError::SerializationFailed(e.to_string()))?);
+
+    insert_opt_f64(&mut obj, "temperature", req.params.temperature);
+
+    // Merge extras (preserves unknown fields for roundtrip)
+    for (k, v) in &req.extras {
+        if !MYPROVIDER_KNOWN_KEYS.contains(&k.as_str()) {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+
+    Ok(Value::Object(obj))
+}
+```
+
+### Implementing TryFromLLM conversions
+
+**Location**: `crates/lingua/src/providers/myprovider/convert.rs`
+
+```rust
+use crate::error::ConvertError;
+use crate::universal::convert::TryFromLLM;
+use crate::universal::message::{AssistantContent, Message, UserContent};
+
+use super::detect::MyProviderMessage;
+
+// Provider -> Universal
+impl TryFromLLM<MyProviderMessage> for Message {
+    type Error = ConvertError;
+
+    fn try_from(msg: MyProviderMessage) -> Result<Self, Self::Error> {
+        match msg.role.as_str() {
+            "user" => Ok(Message::User {
+                content: UserContent::String(msg.content),
+            }),
+            "assistant" => Ok(Message::Assistant {
+                content: AssistantContent::String(msg.content),
+                id: None,
+            }),
+            "system" => Ok(Message::System {
+                content: UserContent::String(msg.content),
+            }),
+            other => Err(ConvertError::InvalidRole { role: other.to_string() }),
+        }
+    }
+}
+
+// Universal -> Provider
+impl TryFromLLM<Message> for MyProviderMessage {
+    type Error = ConvertError;
+
+    fn try_from(msg: Message) -> Result<Self, Self::Error> {
+        match msg {
+            Message::User { content } => Ok(MyProviderMessage {
+                role: "user".to_string(),
+                content: content.to_string(),
+            }),
+            Message::Assistant { content, .. } => Ok(MyProviderMessage {
+                role: "assistant".to_string(),
+                content: content.to_string(),
+            }),
+            Message::System { content } => Ok(MyProviderMessage {
+                role: "system".to_string(),
+                content: content.to_string(),
+            }),
+            Message::Tool { .. } => {
+                // Handle tool results based on your provider's format
+                todo!("Implement tool result handling")
+            }
+        }
+    }
+}
+```
+
+### Run coverage-report again
+
+```bash
+cargo run --bin coverage-report
+```
+
+Watch the `✗` marks turn to `✓` as you implement each method.
+
+### Roundtrip validation
+
+The coverage report compares original JSON with roundtripped JSON. If fields are lost or changed, you'll see:
+
+```
+Roundtrip diff for myprovider/simpleRequest:
+  - lost_fields: ["custom_field"]
+  - added_fields: []
+  - changed_fields: ["temperature"]
+```
+
+Fix by:
+- Adding missing fields to `KNOWN_KEYS` or handling in `extras`
+- Ensuring numeric precision is preserved
+- Checking field name casing matches
+
+---
+
+## Streaming support (optional)
+
+If your provider supports streaming, override the default methods:
+
+```rust
+fn detect_stream_response(&self, payload: &Value) -> bool {
+    payload.get("type").and_then(Value::as_str)
+        .map(|t| t.starts_with("stream."))
+        .unwrap_or(false)
+}
+
+fn stream_to_universal(
+    &self,
+    payload: Value,
+) -> Result<Option<UniversalStreamChunk>, TransformError> {
+    // Parse streaming events from your response-streaming.json snapshots
+    todo!()
+}
+
+fn stream_from_universal(
+    &self,
+    chunk: &UniversalStreamChunk,
+) -> Result<Value, TransformError> {
+    todo!()
+}
+```
+
+Add `response-streaming.json` snapshots and run coverage-report to validate.
+
+---
+
+## Helper functions
+
+The `adapters` module provides helpers:
+
+```rust
+use crate::processing::adapters::{
+    collect_extras,      // Extract unknown fields into extras map
+    insert_opt_value,    // Insert Option<Value> if Some
+    insert_opt_f64,      // Insert Option<f64> as Number
+    insert_opt_i64,      // Insert Option<i64> as Number
+    insert_opt_bool,     // Insert Option<bool> as Bool
+    insert_opt_string,   // Insert Option<&str> as String
+};
+```
+
+---
+
+## Provider comparison reference
+
+### Field mappings by provider
+
+| Field | OpenAI | Anthropic | Google | Bedrock |
+|-------|--------|-----------|--------|---------|
+| Model | `model` | `model` | `model` | `modelId` |
+| Messages | `messages` | `messages` | `contents` | `messages` |
+| Temperature | `temperature` | `temperature` | `generationConfig.temperature` | `inferenceConfig.temperature` |
+| Max tokens | `max_tokens` | `max_tokens` (required) | `generationConfig.maxOutputTokens` | `inferenceConfig.maxTokens` |
+| System | In messages | Separate `system` param | `systemInstruction` | Separate `system` array |
+
+### Finish reason mappings
+
+| Universal | OpenAI | Anthropic | Google | Bedrock |
+|-----------|--------|-----------|--------|---------|
+| `Stop` | `"stop"` | `"end_turn"` | `"STOP"` | `"end_turn"` |
+| `Length` | `"length"` | `"max_tokens"` | `"MAX_TOKENS"` | `"max_tokens"` |
+| `ToolCalls` | `"tool_calls"` | `"tool_use"` | `"TOOL_CALLS"` | `"tool_use"` |
+| `ContentFilter` | `"content_filter"` | `"content_filter"` | `"SAFETY"` | `"content_filtered"` |
+
+### Detection priority
+
+| Priority | Format | Distinctive feature |
+|----------|--------|---------------------|
+| 1 | Responses | Has `input` field, no `messages` |
+| 2 | Bedrock | Has `modelId` (not `model`) |
+| 3 | Google | Has `contents[].parts[]` |
+| 4 | Anthropic | Requires `max_tokens` |
+| 5 | OpenAI | Most permissive (fallback) |

--- a/crates/lingua/src/capabilities/format.rs
+++ b/crates/lingua/src/capabilities/format.rs
@@ -1,0 +1,100 @@
+/*!
+Provider format enum - the authoritative source of truth for provider formats.
+
+This enum represents the different LLM provider API formats that lingua can handle.
+*/
+
+use serde::{Deserialize, Serialize};
+
+/// Represents the API format/protocol used by an LLM provider.
+///
+/// This enum is the single source of truth for provider formats across the ecosystem.
+/// When adding a new provider format:
+/// 1. Add a variant here
+/// 2. Update detection heuristics in `processing/detect.rs`
+/// 3. Add conversion logic in `providers/<name>/convert.rs` if needed
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ProviderFormat {
+    /// OpenAI Chat Completions API format (also used by OpenAI-compatible providers)
+    OpenAI,
+    /// Anthropic Messages API format
+    Anthropic,
+    /// Google AI / Gemini GenerateContent API format
+    Google,
+    /// Mistral AI API format (similar to OpenAI with some differences)
+    Mistral,
+    /// AWS Bedrock Converse API format
+    Converse,
+    /// OpenAI Responses API format (for reasoning models like o1-pro, o3)
+    Responses,
+    /// Unknown or undetectable format
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+impl ProviderFormat {
+    /// Returns true if this format is a known, supported format.
+    pub fn is_known(&self) -> bool {
+        !matches!(self, ProviderFormat::Unknown)
+    }
+}
+
+impl std::fmt::Display for ProviderFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            ProviderFormat::OpenAI => "openai",
+            ProviderFormat::Anthropic => "anthropic",
+            ProviderFormat::Google => "google",
+            ProviderFormat::Mistral => "mistral",
+            ProviderFormat::Converse => "converse",
+            ProviderFormat::Responses => "responses",
+            ProviderFormat::Unknown => "unknown",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl std::str::FromStr for ProviderFormat {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "openai" => Ok(ProviderFormat::OpenAI),
+            "anthropic" => Ok(ProviderFormat::Anthropic),
+            "google" => Ok(ProviderFormat::Google),
+            "mistral" => Ok(ProviderFormat::Mistral),
+            "converse" | "bedrock" => Ok(ProviderFormat::Converse),
+            "responses" => Ok(ProviderFormat::Responses),
+            _ => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_str() {
+        assert_eq!(
+            "openai".parse::<ProviderFormat>().unwrap(),
+            ProviderFormat::OpenAI
+        );
+        assert_eq!(
+            "ANTHROPIC".parse::<ProviderFormat>().unwrap(),
+            ProviderFormat::Anthropic
+        );
+        assert_eq!(
+            "bedrock".parse::<ProviderFormat>().unwrap(),
+            ProviderFormat::Converse
+        );
+        assert_eq!(
+            "unknown_format"
+                .parse::<ProviderFormat>()
+                .unwrap_or_default(),
+            ProviderFormat::Unknown
+        );
+    }
+}

--- a/crates/lingua/src/capabilities/mod.rs
+++ b/crates/lingua/src/capabilities/mod.rs
@@ -3,6 +3,8 @@ Capability detection for different providers.
 */
 
 pub mod detection;
+pub mod format;
 
 // Re-export main types and functions
 pub use detection::{detect_capabilities, Capabilities, ProviderCapabilities};
+pub use format::ProviderFormat;

--- a/crates/lingua/src/lib.rs
+++ b/crates/lingua/src/lib.rs
@@ -3,6 +3,9 @@
 
 pub use big_serde_json as serde_json;
 
+// Re-export bytes::Bytes for convenience - transform functions use Bytes in/out
+pub use bytes::Bytes;
+
 pub mod capabilities;
 pub mod error;
 pub mod processing;

--- a/crates/lingua/src/processing/adapters.rs
+++ b/crates/lingua/src/processing/adapters.rs
@@ -1,0 +1,255 @@
+/*!
+Provider adapter trait and registry for unified request transformation.
+
+This module defines the `ProviderAdapter` trait that each provider implements
+to handle format detection and request conversion. The adapter pattern consolidates
+provider-specific logic into a single interface.
+
+## Adding a new provider
+
+1. Create `adapter.rs` in your provider module
+2. Implement `ProviderAdapter` for your adapter struct
+3. Register it in `adapters()` with the appropriate feature gate
+*/
+
+use std::sync::LazyLock;
+
+use crate::capabilities::ProviderFormat;
+use crate::processing::transform::TransformError;
+use crate::serde_json::{Map, Number, Value};
+use crate::universal::{FinishReason, UniversalRequest, UniversalResponse, UniversalStreamChunk};
+
+/// Trait for provider-specific request and response handling.
+///
+/// Implementations handle:
+/// - Format detection for both requests and responses
+/// - Conversion to/from universal request/response format
+/// - Provider-specific defaults and finish reason mapping
+pub trait ProviderAdapter: Send + Sync {
+    // =========================================================================
+    // Metadata
+    // =========================================================================
+
+    /// Returns the provider format this adapter handles.
+    fn format(&self) -> ProviderFormat;
+
+    /// Returns the directory name for this provider's test payloads.
+    /// Used by coverage-report to load snapshots from `payloads/snapshots/{dir_name}/`.
+    fn directory_name(&self) -> &'static str;
+
+    /// Returns the display name for this provider (used in reports/tables).
+    fn display_name(&self) -> &'static str;
+
+    // =========================================================================
+    // Request handling
+    // =========================================================================
+
+    /// Checks if a payload matches this provider's request format.
+    ///
+    /// This should delegate to existing detection logic (e.g., `try_parse_*` functions).
+    fn detect_request(&self, payload: &Value) -> bool;
+
+    /// Convert a provider-specific payload to universal request format.
+    ///
+    /// This extracts messages, params, and extras from the provider payload.
+    fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError>;
+
+    /// Convert a universal request to provider-specific format.
+    ///
+    /// This builds a complete request payload in the provider's format.
+    fn request_from_universal(&self, req: &UniversalRequest) -> Result<Value, TransformError>;
+
+    /// Apply provider-specific defaults to a universal request.
+    ///
+    /// This is called after conversion but before building the final payload.
+    /// For example, Anthropic requires `max_tokens` to be set.
+    fn apply_defaults(&self, req: &mut UniversalRequest);
+
+    // =========================================================================
+    // Response handling
+    // =========================================================================
+
+    /// Checks if a payload matches this provider's response format.
+    fn detect_response(&self, payload: &Value) -> bool;
+
+    /// Convert a provider-specific response to universal format.
+    ///
+    /// This extracts messages, usage, finish_reason, and extras from the response.
+    fn response_to_universal(&self, payload: Value) -> Result<UniversalResponse, TransformError>;
+
+    /// Convert a universal response to provider-specific format.
+    ///
+    /// This builds a complete response payload in the provider's format.
+    fn response_from_universal(&self, resp: &UniversalResponse) -> Result<Value, TransformError>;
+
+    /// Map a universal FinishReason to provider-specific string.
+    ///
+    /// Each provider uses different strings for finish reasons:
+    /// - OpenAI: "stop", "length", "tool_calls", "content_filter"
+    /// - Anthropic: "end_turn", "max_tokens", "tool_use"
+    /// - Google: "STOP", "MAX_TOKENS"
+    fn map_finish_reason(&self, reason: Option<&FinishReason>) -> Option<String>;
+
+    // =========================================================================
+    // Streaming response handling
+    // =========================================================================
+
+    /// Checks if a payload matches this provider's streaming response format.
+    ///
+    /// Streaming formats differ from non-streaming responses:
+    /// - OpenAI: `object == "chat.completion.chunk"` or has `choices` with `delta`
+    /// - Anthropic: has `type` field with streaming event types
+    /// - Google: has `candidates` array (same as non-streaming)
+    /// - Bedrock: has `messageStart`, `contentBlockDelta`, etc.
+    fn detect_stream_response(&self, payload: &Value) -> bool {
+        // Default: not implemented
+        let _ = payload;
+        false
+    }
+
+    /// Convert a provider-specific streaming chunk to universal format.
+    ///
+    /// Returns `Ok(None)` for events that don't produce output (keep-alive, metadata).
+    /// Returns `Ok(Some(chunk))` with `chunk.is_keep_alive() == true` for events
+    /// that should be acknowledged but not forwarded to clients.
+    fn stream_to_universal(
+        &self,
+        _payload: Value,
+    ) -> Result<Option<UniversalStreamChunk>, TransformError> {
+        Err(TransformError::StreamingNotImplemented(
+            self.display_name().to_string(),
+        ))
+    }
+
+    /// Convert a universal streaming chunk to provider-specific format.
+    ///
+    /// This builds a streaming chunk payload in the provider's format.
+    fn stream_from_universal(&self, chunk: &UniversalStreamChunk) -> Result<Value, TransformError> {
+        let _ = chunk;
+        Err(TransformError::StreamingNotImplemented(
+            self.display_name().to_string(),
+        ))
+    }
+}
+
+// ============================================================================
+// Helper functions for adapter implementations
+// ============================================================================
+
+/// Collect fields not in the known keys list into an extras map.
+///
+/// This preserves provider-specific fields for round-trip transformation.
+pub fn collect_extras(payload: &Value, known_keys: &[&str]) -> Map<String, Value> {
+    let mut extras = Map::new();
+    let Some(obj) = payload.as_object() else {
+        return extras;
+    };
+    for (k, v) in obj {
+        if !known_keys.contains(&k.as_str()) {
+            extras.insert(k.clone(), v.clone());
+        }
+    }
+    extras
+}
+
+/// Insert an optional Value into a map if present.
+pub fn insert_opt_value(obj: &mut Map<String, Value>, key: &str, value: Option<Value>) {
+    if let Some(v) = value {
+        obj.insert(key.into(), v);
+    }
+}
+
+/// Insert an optional i64 into a map if present.
+pub fn insert_opt_i64(obj: &mut Map<String, Value>, key: &str, value: Option<i64>) {
+    if let Some(v) = value {
+        obj.insert(key.into(), Value::Number(v.into()));
+    }
+}
+
+/// Insert an optional f64 into a map if present.
+pub fn insert_opt_f64(obj: &mut Map<String, Value>, key: &str, value: Option<f64>) {
+    if let Some(v) = value {
+        if let Some(n) = Number::from_f64(v) {
+            obj.insert(key.into(), Value::Number(n));
+        }
+    }
+}
+
+/// Insert an optional bool into a map if present.
+pub fn insert_opt_bool(obj: &mut Map<String, Value>, key: &str, value: Option<bool>) {
+    if let Some(v) = value {
+        obj.insert(key.into(), Value::Bool(v));
+    }
+}
+
+/// Insert an optional string into a map if present.
+pub fn insert_opt_string(obj: &mut Map<String, Value>, key: &str, value: Option<&str>) {
+    if let Some(v) = value {
+        obj.insert(key.into(), Value::String(v.to_string()));
+    }
+}
+
+// ============================================================================
+// Adapter registry
+// ============================================================================
+
+/// Static adapter storage - initialized once, reused for all calls.
+#[allow(clippy::vec_init_then_push)] // Can't use vec![] with conditional cfg attributes
+static ADAPTERS: LazyLock<Vec<Box<dyn ProviderAdapter>>> = LazyLock::new(|| {
+    let mut list: Vec<Box<dyn ProviderAdapter>> = Vec::new();
+
+    // Note: Order matters for detection - more specific formats first
+    #[cfg(feature = "openai")]
+    list.push(Box::new(crate::providers::openai::ResponsesAdapter));
+
+    #[cfg(feature = "bedrock")]
+    list.push(Box::new(crate::providers::bedrock::BedrockAdapter));
+
+    #[cfg(feature = "google")]
+    list.push(Box::new(crate::providers::google::GoogleAdapter));
+
+    #[cfg(feature = "anthropic")]
+    list.push(Box::new(crate::providers::anthropic::AnthropicAdapter));
+
+    #[cfg(feature = "openai")]
+    list.push(Box::new(crate::providers::openai::OpenAIAdapter));
+
+    list
+});
+
+/// Get all registered adapters in detection priority order.
+///
+/// Returns a reference to a static slice - no allocation occurs after first call.
+///
+/// Priority order (most specific first):
+/// 1. Responses API (has unique `input` field)
+/// 2. Bedrock (has unique `modelId` field)
+/// 3. Google
+/// 4. Anthropic
+/// 5. OpenAI (most permissive, fallback)
+pub fn adapters() -> &'static [Box<dyn ProviderAdapter>] {
+    &ADAPTERS
+}
+
+/// Get the adapter for a specific provider format.
+///
+/// Returns a reference to the static adapter instance - no allocation.
+pub fn adapter_for_format(format: ProviderFormat) -> Option<&'static dyn ProviderAdapter> {
+    ADAPTERS
+        .iter()
+        .find(|a| a.format() == format)
+        .map(|a| a.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "openai")]
+    #[test]
+    fn test_adapter_caching_is_stable() {
+        let a1 = adapter_for_format(ProviderFormat::OpenAI).unwrap();
+        let a2 = adapter_for_format(ProviderFormat::OpenAI).unwrap();
+        assert!(std::ptr::eq(a1, a2));
+    }
+}

--- a/crates/lingua/src/processing/mod.rs
+++ b/crates/lingua/src/processing/mod.rs
@@ -1,5 +1,16 @@
+pub mod adapters;
 pub mod dedup;
 pub mod import;
+pub mod transform;
 
+pub use adapters::{
+    adapter_for_format, adapters, collect_extras, insert_opt_bool, insert_opt_f64, insert_opt_i64,
+    insert_opt_string, insert_opt_value, ProviderAdapter,
+};
 pub use dedup::deduplicate_messages;
 pub use import::{import_and_deduplicate_messages, import_messages_from_spans, Span};
+pub use transform::{
+    extract_model, from_universal_request, from_universal_response, parse_stream_event,
+    sanitize_payload, to_universal_request, to_universal_response, transform_request,
+    transform_response, transform_stream_chunk, ParsedStreamEvent, TransformError, TransformResult,
+};

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -1,0 +1,677 @@
+/*!
+Unified payload transformation API with bytes in/out.
+
+This module provides a single entry point for validating and transforming
+payloads between different provider formats. The key principle is:
+
+**If a payload can be deserialized into the target provider struct, use it as-is (pass-through).**
+**Otherwise, detect the source format, convert to universal, and transform to target format.**
+
+All public functions take `Bytes` input and return `Bytes` output for zero-copy
+passthrough in async contexts.
+*/
+
+use bytes::Bytes;
+
+use crate::capabilities::ProviderFormat;
+use crate::processing::adapters::{adapter_for_format, adapters, ProviderAdapter};
+use crate::serde_json::Value;
+use crate::universal::{UniversalRequest, UniversalResponse, UniversalStreamChunk};
+use thiserror::Error;
+
+/// Static empty JSON object bytes for terminal/keep-alive events.
+/// Using `Bytes::from_static` avoids allocation; `.clone()` is a cheap refcount bump.
+static EMPTY_JSON: Bytes = Bytes::from_static(b"{}");
+
+/// Error type for transformation operations
+#[derive(Debug, Error)]
+pub enum TransformError {
+    #[error("Unable to detect source format")]
+    UnableToDetectFormat,
+
+    #[error("Validation failed for target format {target:?}: {reason}")]
+    ValidationFailed {
+        target: ProviderFormat,
+        reason: String,
+    },
+
+    #[error("Conversion to universal format failed: {0}")]
+    ToUniversalFailed(String),
+
+    #[error("Conversion from universal format failed: {0}")]
+    FromUniversalFailed(String),
+
+    #[error("Serialization failed: {0}")]
+    SerializationFailed(String),
+
+    #[error("Deserialization failed: {0}")]
+    DeserializationFailed(String),
+
+    #[error("Unsupported target format: {0:?}")]
+    UnsupportedTargetFormat(ProviderFormat),
+
+    #[error("Unsupported source format: {0:?}")]
+    UnsupportedSourceFormat(ProviderFormat),
+
+    #[error("Streaming not implemented: {0}")]
+    StreamingNotImplemented(String),
+}
+
+/// Result of a transformation operation.
+///
+/// Contains either the original bytes (passthrough) or transformed bytes.
+/// `Bytes::clone()` is O(1) - just a refcount bump - making this efficient
+/// for async contexts where payloads are passed to multiple tasks.
+#[derive(Debug, Clone)]
+pub enum TransformResult {
+    /// Payload was already valid for target format - returns the original bytes unchanged.
+    /// This is the zero-copy path: no serialization occurred.
+    PassThrough(Bytes),
+
+    /// Payload was transformed to target format.
+    Transformed {
+        /// The transformed payload as bytes
+        bytes: Bytes,
+        /// The detected source format
+        source_format: ProviderFormat,
+    },
+}
+
+impl TransformResult {
+    /// Check if this is a pass-through result (no transformation occurred).
+    pub fn is_passthrough(&self) -> bool {
+        matches!(self, TransformResult::PassThrough(_))
+    }
+
+    /// Consume the result and return the final bytes.
+    ///
+    /// Returns the original bytes for PassThrough, or the transformed bytes for Transformed.
+    pub fn into_bytes(self) -> Bytes {
+        match self {
+            TransformResult::PassThrough(bytes) => bytes,
+            TransformResult::Transformed { bytes, .. } => bytes,
+        }
+    }
+
+    /// Get a reference to the final bytes.
+    pub fn as_bytes(&self) -> &Bytes {
+        match self {
+            TransformResult::PassThrough(bytes) => bytes,
+            TransformResult::Transformed { bytes, .. } => bytes,
+        }
+    }
+
+    /// Get the source format if transformation occurred.
+    ///
+    /// Returns `None` for passthrough (source format == target format).
+    pub fn source_format(&self) -> Option<ProviderFormat> {
+        match self {
+            TransformResult::PassThrough(_) => None,
+            TransformResult::Transformed { source_format, .. } => Some(*source_format),
+        }
+    }
+}
+
+// ============================================================================
+// Model extraction
+// ============================================================================
+
+/// Extract model name from request bytes without full transformation.
+///
+/// This is a fast path for routing decisions that only need the model name.
+/// Parses just enough to find the model field.
+///
+/// # Returns
+///
+/// - `Some(model)` if a model field was found
+/// - `None` if parsing fails or no model field exists (e.g., Google format has model in URL)
+///
+/// # Examples
+///
+/// ```
+/// use lingua::processing::transform::extract_model;
+/// use bytes::Bytes;
+///
+/// let openai = Bytes::from(r#"{"model": "gpt-4", "messages": []}"#);
+/// assert_eq!(extract_model(&openai), Some("gpt-4".to_string()));
+///
+/// let bedrock = Bytes::from(r#"{"modelId": "anthropic.claude-3", "messages": []}"#);
+/// assert_eq!(extract_model(&bedrock), Some("anthropic.claude-3".to_string()));
+/// ```
+pub fn extract_model(input: &[u8]) -> Option<String> {
+    let payload: Value = crate::serde_json::from_slice(input).ok()?;
+
+    // Try common model field names across providers
+    payload
+        .get("model") // OpenAI, Anthropic
+        .or_else(|| payload.get("modelId")) // Bedrock
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+// ============================================================================
+// Request transformation
+// ============================================================================
+
+/// Transform a request payload to the target format.
+///
+/// This is the main entry point for request transformation. It:
+/// 1. Parses the input bytes to detect the format
+/// 2. If already valid for target format, returns the original bytes (zero-copy passthrough)
+/// 3. Otherwise, transforms via universal format and serializes to bytes
+///
+/// # Arguments
+///
+/// * `input` - The incoming request as bytes
+/// * `target_format` - The target provider format
+/// * `model` - Optional model name to inject if source doesn't have one (for Google/Bedrock)
+///
+/// # Returns
+///
+/// * `Ok(TransformResult::PassThrough(bytes))` - Payload is already valid, returns original bytes
+/// * `Ok(TransformResult::Transformed { bytes, source_format })` - Transformed to target format
+/// * `Err(TransformError)` - If transformation fails
+///
+/// # Examples
+///
+/// ```
+/// use lingua::processing::transform::transform_request;
+/// use lingua::capabilities::ProviderFormat;
+/// use bytes::Bytes;
+///
+/// let openai_payload = Bytes::from(r#"{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}"#);
+///
+/// // Transform to Anthropic format
+/// let result = transform_request(openai_payload, ProviderFormat::Anthropic, None).unwrap();
+/// let output_bytes = result.into_bytes();
+/// ```
+pub fn transform_request(
+    input: Bytes,
+    target_format: ProviderFormat,
+    model: Option<&str>,
+) -> Result<TransformResult, TransformError> {
+    let payload: Value = crate::serde_json::from_slice(&input)
+        .map_err(|e| TransformError::DeserializationFailed(e.to_string()))?;
+
+    let source_adapter = detect_adapter(&payload, DetectKind::Request)?;
+
+    if source_adapter.format() == target_format {
+        return Ok(TransformResult::PassThrough(input));
+    }
+
+    let source_format = source_adapter.format();
+    let target_adapter = adapter_for_format(target_format)
+        .ok_or(TransformError::UnsupportedTargetFormat(target_format))?;
+
+    let mut universal = source_adapter.request_to_universal(payload)?;
+
+    // Inject model from parameter if not present
+    if model.is_some() && universal.model.is_none() {
+        universal.model = model.map(String::from);
+    }
+
+    // Apply target provider defaults (e.g., Anthropic's required max_tokens)
+    target_adapter.apply_defaults(&mut universal);
+
+    let transformed = target_adapter.request_from_universal(&universal)?;
+
+    let bytes = crate::serde_json::to_vec(&transformed)
+        .map_err(|e| TransformError::SerializationFailed(e.to_string()))?;
+
+    Ok(TransformResult::Transformed {
+        bytes: Bytes::from(bytes),
+        source_format,
+    })
+}
+
+// ============================================================================
+// Response transformation
+// ============================================================================
+
+/// Transform a response payload from one format to another.
+///
+/// # Arguments
+///
+/// * `input` - The source response as bytes
+/// * `target_format` - The target provider format
+///
+/// # Returns
+///
+/// * `Ok(TransformResult::PassThrough(bytes))` - Response is already valid for target format
+/// * `Ok(TransformResult::Transformed { bytes, source_format })` - Transformed response
+/// * `Err(TransformError)` - If transformation fails
+pub fn transform_response(
+    input: Bytes,
+    target_format: ProviderFormat,
+) -> Result<TransformResult, TransformError> {
+    let response: Value = crate::serde_json::from_slice(&input)
+        .map_err(|e| TransformError::DeserializationFailed(e.to_string()))?;
+
+    let source_adapter = detect_adapter(&response, DetectKind::Response)?;
+
+    if source_adapter.format() == target_format {
+        return Ok(TransformResult::PassThrough(input));
+    }
+
+    let source_format = source_adapter.format();
+    let target_adapter = adapter_for_format(target_format)
+        .ok_or(TransformError::UnsupportedTargetFormat(target_format))?;
+
+    let universal_resp = source_adapter.response_to_universal(response)?;
+    let transformed = target_adapter.response_from_universal(&universal_resp)?;
+
+    let bytes = crate::serde_json::to_vec(&transformed)
+        .map_err(|e| TransformError::SerializationFailed(e.to_string()))?;
+
+    Ok(TransformResult::Transformed {
+        bytes: Bytes::from(bytes),
+        source_format,
+    })
+}
+
+// ============================================================================
+// Streaming transformation
+// ============================================================================
+
+/// Transform a streaming chunk from one format to another.
+///
+/// This handles per-event transformation for streaming responses. Each event
+/// is processed independently (stateless).
+///
+/// # Arguments
+///
+/// * `input` - The source streaming chunk as bytes
+/// * `target_format` - The target provider format
+///
+/// # Returns
+///
+/// * `Ok(TransformResult::PassThrough(bytes))` - Chunk is already valid for target format
+/// * `Ok(TransformResult::Transformed { bytes, source_format })` - Transformed chunk
+/// * `Err(TransformError)` - If transformation fails
+pub fn transform_stream_chunk(
+    input: Bytes,
+    target_format: ProviderFormat,
+) -> Result<TransformResult, TransformError> {
+    let chunk: Value = crate::serde_json::from_slice(&input)
+        .map_err(|e| TransformError::DeserializationFailed(e.to_string()))?;
+
+    let source_adapter = detect_adapter(&chunk, DetectKind::Stream)?;
+
+    if source_adapter.format() == target_format {
+        return Ok(TransformResult::PassThrough(input));
+    }
+
+    let source_format = source_adapter.format();
+    let target_adapter = adapter_for_format(target_format)
+        .ok_or(TransformError::UnsupportedTargetFormat(target_format))?;
+
+    let stream_universal = source_adapter.stream_to_universal(chunk)?;
+
+    let bytes = match stream_universal {
+        Some(universal_chunk) => {
+            let transformed = target_adapter.stream_from_universal(&universal_chunk)?;
+            Bytes::from(
+                crate::serde_json::to_vec(&transformed)
+                    .map_err(|e| TransformError::SerializationFailed(e.to_string()))?,
+            )
+        }
+        None => EMPTY_JSON.clone(), // Terminal event - cheap refcount bump
+    };
+
+    Ok(TransformResult::Transformed {
+        bytes,
+        source_format,
+    })
+}
+
+// ============================================================================
+// Stream event parsing (for router integration)
+// ============================================================================
+
+/// Result of parsing a streaming event.
+///
+/// Contains the transformed bytes, metadata about the event, and optionally
+/// the universal representation for further processing.
+#[derive(Debug, Clone)]
+pub struct ParsedStreamEvent {
+    /// The payload to forward (original if pass-through, transformed otherwise)
+    pub bytes: Bytes,
+    /// The detected source format
+    pub source_format: ProviderFormat,
+    /// The target format requested
+    pub target_format: ProviderFormat,
+    /// The universal representation of the stream chunk (if transformation occurred)
+    pub universal: Option<UniversalStreamChunk>,
+    /// Whether this is a keep-alive event (no content, just maintains connection)
+    pub is_keep_alive: bool,
+    /// Whether this event contains a finish_reason (indicates end of generation)
+    pub is_final: bool,
+}
+
+/// Parse a streaming event, transforming if needed and extracting metadata.
+///
+/// This is the main entry point for the router to process streaming events. It:
+/// 1. Detects the source format of the stream chunk
+/// 2. Transforms to target format if needed (pass-through if formats match)
+/// 3. Extracts metadata like keep_alive and finish_reason
+///
+/// # Arguments
+///
+/// * `input` - The streaming chunk as bytes
+/// * `source_format` - The expected source format (from the provider being called)
+/// * `target_format` - The target format to transform to
+///
+/// # Returns
+///
+/// A `ParsedStreamEvent` containing the bytes and metadata.
+pub fn parse_stream_event(
+    input: Bytes,
+    source_format: ProviderFormat,
+    target_format: ProviderFormat,
+) -> Result<ParsedStreamEvent, TransformError> {
+    let chunk: Value = crate::serde_json::from_slice(&input)
+        .map_err(|e| TransformError::DeserializationFailed(e.to_string()))?;
+
+    let source_adapter = adapter_for_format(source_format)
+        .ok_or(TransformError::UnsupportedSourceFormat(source_format))?;
+
+    let universal_opt = source_adapter.stream_to_universal(chunk)?;
+
+    let (is_keep_alive, is_final) = match &universal_opt {
+        Some(universal) => {
+            let is_keep_alive = universal.is_keep_alive();
+            let is_final = universal.choices.iter().any(|c| c.finish_reason.is_some());
+            (is_keep_alive, is_final)
+        }
+        None => (true, false), // None means terminal/keep-alive event
+    };
+
+    if source_format == target_format {
+        return Ok(ParsedStreamEvent {
+            bytes: input,
+            source_format,
+            target_format,
+            universal: universal_opt,
+            is_keep_alive,
+            is_final,
+        });
+    }
+
+    let target_adapter = adapter_for_format(target_format)
+        .ok_or(TransformError::UnsupportedTargetFormat(target_format))?;
+
+    let bytes = match &universal_opt {
+        Some(universal) => {
+            let transformed = target_adapter.stream_from_universal(universal)?;
+            Bytes::from(
+                crate::serde_json::to_vec(&transformed)
+                    .map_err(|e| TransformError::SerializationFailed(e.to_string()))?,
+            )
+        }
+        None => EMPTY_JSON.clone(), // Terminal event - cheap refcount bump
+    };
+
+    Ok(ParsedStreamEvent {
+        bytes,
+        source_format,
+        target_format,
+        universal: universal_opt,
+        is_keep_alive,
+        is_final,
+    })
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+#[derive(Copy, Clone)]
+enum DetectKind {
+    Request,
+    Response,
+    Stream,
+}
+
+fn detect_adapter(
+    payload: &Value,
+    kind: DetectKind,
+) -> Result<&'static dyn ProviderAdapter, TransformError> {
+    adapters()
+        .iter()
+        .find(|a| match kind {
+            DetectKind::Request => a.detect_request(payload),
+            DetectKind::Response => a.detect_response(payload),
+            DetectKind::Stream => a.detect_stream_response(payload),
+        })
+        .map(|a| a.as_ref())
+        .ok_or(TransformError::UnableToDetectFormat)
+}
+
+// ============================================================================
+// Helper APIs for direct adapter access (internal use)
+// ============================================================================
+
+/// Convert a request payload to UniversalRequest using the specified format's adapter.
+pub fn to_universal_request(
+    payload: Value,
+    format: ProviderFormat,
+) -> Result<UniversalRequest, TransformError> {
+    let adapter =
+        adapter_for_format(format).ok_or(TransformError::UnsupportedSourceFormat(format))?;
+    adapter.request_to_universal(payload)
+}
+
+/// Convert a UniversalRequest to a provider-specific payload.
+pub fn from_universal_request(
+    universal: &UniversalRequest,
+    format: ProviderFormat,
+) -> Result<Value, TransformError> {
+    let adapter =
+        adapter_for_format(format).ok_or(TransformError::UnsupportedTargetFormat(format))?;
+    adapter.request_from_universal(universal)
+}
+
+/// Convert a response payload to UniversalResponse using the specified format's adapter.
+pub fn to_universal_response(
+    payload: Value,
+    format: ProviderFormat,
+) -> Result<UniversalResponse, TransformError> {
+    let adapter =
+        adapter_for_format(format).ok_or(TransformError::UnsupportedSourceFormat(format))?;
+    adapter.response_to_universal(payload)
+}
+
+/// Convert a UniversalResponse to a provider-specific payload.
+pub fn from_universal_response(
+    universal: &UniversalResponse,
+    format: ProviderFormat,
+) -> Result<Value, TransformError> {
+    let adapter =
+        adapter_for_format(format).ok_or(TransformError::UnsupportedTargetFormat(format))?;
+    adapter.response_from_universal(universal)
+}
+
+/// Sanitize a payload for a target format by parsing and re-serializing.
+///
+/// This strips unknown fields that strict providers (like Anthropic) would reject.
+pub fn sanitize_payload(input: Bytes, format: ProviderFormat) -> Result<Bytes, TransformError> {
+    use crate::providers::anthropic::try_parse_anthropic;
+
+    let payload: Value = crate::serde_json::from_slice(&input)
+        .map_err(|e| TransformError::DeserializationFailed(e.to_string()))?;
+
+    let sanitized = match format {
+        ProviderFormat::Anthropic => {
+            let parsed = try_parse_anthropic(&payload)
+                .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+            crate::serde_json::to_value(parsed)
+                .map_err(|e| TransformError::SerializationFailed(e.to_string()))?
+        }
+        _ => payload,
+    };
+
+    let bytes = crate::serde_json::to_vec(&sanitized)
+        .map_err(|e| TransformError::SerializationFailed(e.to_string()))?;
+
+    Ok(Bytes::from(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_json::json;
+
+    fn to_bytes(value: &Value) -> Bytes {
+        Bytes::from(crate::serde_json::to_vec(value).unwrap())
+    }
+
+    #[test]
+    fn test_extract_model_openai() {
+        let input = br#"{"model": "gpt-4", "messages": []}"#;
+        assert_eq!(extract_model(input), Some("gpt-4".to_string()));
+    }
+
+    #[test]
+    fn test_extract_model_bedrock() {
+        let input = br#"{"modelId": "anthropic.claude-3", "messages": []}"#;
+        assert_eq!(extract_model(input), Some("anthropic.claude-3".to_string()));
+    }
+
+    #[test]
+    fn test_extract_model_google() {
+        // Google format doesn't have model in body
+        let input = br#"{"contents": []}"#;
+        assert_eq!(extract_model(input), None);
+    }
+
+    #[test]
+    fn test_extract_model_invalid_json() {
+        let input = br#"not valid json"#;
+        assert_eq!(extract_model(input), None);
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
+    fn test_transform_request_passthrough() {
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        let input = to_bytes(&payload);
+        let input_ptr = input.as_ptr();
+
+        let result = transform_request(input, ProviderFormat::OpenAI, None).unwrap();
+
+        // Should be passthrough
+        assert!(result.is_passthrough());
+
+        // Should return the exact same bytes (pointer equality)
+        let output = result.into_bytes();
+        assert_eq!(output.as_ptr(), input_ptr);
+    }
+
+    #[test]
+    #[cfg(all(feature = "openai", feature = "anthropic"))]
+    fn test_transform_request_openai_to_anthropic() {
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        let input = to_bytes(&payload);
+
+        let result = transform_request(input, ProviderFormat::Anthropic, None).unwrap();
+
+        // Should be transformed
+        assert!(!result.is_passthrough());
+        assert_eq!(result.source_format(), Some(ProviderFormat::OpenAI));
+
+        // Parse output and verify
+        let output_bytes = result.into_bytes();
+        let output: Value = crate::serde_json::from_slice(&output_bytes).unwrap();
+
+        // Should have max_tokens added (Anthropic default)
+        assert!(output.get("max_tokens").is_some());
+        // Should have messages
+        assert!(output.get("messages").is_some());
+    }
+
+    #[test]
+    #[cfg(feature = "anthropic")]
+    fn test_transform_request_anthropic_passthrough() {
+        let payload = json!({
+            "model": "claude-3-5-sonnet",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        let input = to_bytes(&payload);
+
+        let result = transform_request(input, ProviderFormat::Anthropic, None).unwrap();
+
+        // Should be passthrough
+        assert!(result.is_passthrough());
+    }
+
+    #[test]
+    fn test_transform_request_invalid_json() {
+        let input = Bytes::from("not valid json");
+
+        let result = transform_request(input, ProviderFormat::OpenAI, None);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            TransformError::DeserializationFailed(_)
+        ));
+    }
+
+    #[test]
+    #[cfg(all(feature = "openai", feature = "anthropic"))]
+    fn test_transform_response() {
+        // OpenAI response format
+        let payload = json!({
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "model": "gpt-4",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop"
+            }]
+        });
+        let input = to_bytes(&payload);
+
+        // Transform to Anthropic format
+        let result = transform_response(input, ProviderFormat::Anthropic).unwrap();
+
+        assert!(!result.is_passthrough());
+        assert_eq!(result.source_format(), Some(ProviderFormat::OpenAI));
+
+        // Verify output is valid JSON
+        let output_bytes = result.into_bytes();
+        let output: Value = crate::serde_json::from_slice(&output_bytes).unwrap();
+        assert!(output.get("content").is_some() || output.get("choices").is_some());
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
+    fn test_transform_response_passthrough() {
+        let payload = json!({
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "model": "gpt-4",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop"
+            }]
+        });
+        let input = to_bytes(&payload);
+        let input_ptr = input.as_ptr();
+
+        let result = transform_response(input, ProviderFormat::OpenAI).unwrap();
+
+        // Should be passthrough with same bytes
+        assert!(result.is_passthrough());
+        assert_eq!(result.into_bytes().as_ptr(), input_ptr);
+    }
+}

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -1,0 +1,587 @@
+/*!
+Anthropic provider adapter for Messages API.
+
+Anthropic's Messages API has some unique requirements:
+- `max_tokens` is required (we use a default of 4096)
+- System messages use a separate `system` parameter, not in `messages` array
+*/
+
+use crate::capabilities::ProviderFormat;
+use crate::processing::adapters::{
+    collect_extras, insert_opt_bool, insert_opt_f64, insert_opt_i64, insert_opt_value,
+    ProviderAdapter,
+};
+use crate::processing::transform::TransformError;
+use crate::providers::anthropic::generated::{ContentBlock, CreateMessageParams, InputMessage};
+use crate::providers::anthropic::try_parse_anthropic;
+use crate::serde_json::{self, Map, Value};
+use crate::universal::convert::TryFromLLM;
+use crate::universal::message::{Message, UserContent};
+use crate::universal::transform::extract_system_messages;
+use crate::universal::{
+    FinishReason, UniversalParams, UniversalRequest, UniversalResponse, UniversalStreamChoice,
+    UniversalStreamChunk, UniversalUsage,
+};
+
+/// Default max_tokens for Anthropic requests (matches legacy proxy behavior).
+pub const DEFAULT_MAX_TOKENS: i64 = 4096;
+
+/// Known request fields for Anthropic Messages API.
+/// Fields not in this list go into `extras`.
+const ANTHROPIC_KNOWN_KEYS: &[&str] = &[
+    "model",
+    "messages",
+    "system",
+    "max_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
+    "stop_sequences",
+    "stream",
+    "metadata",
+    "tools",
+    "tool_choice",
+];
+
+/// Adapter for Anthropic Messages API.
+pub struct AnthropicAdapter;
+
+impl ProviderAdapter for AnthropicAdapter {
+    fn format(&self) -> ProviderFormat {
+        ProviderFormat::Anthropic
+    }
+
+    fn directory_name(&self) -> &'static str {
+        "anthropic"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Anthropic"
+    }
+
+    fn detect_request(&self, payload: &Value) -> bool {
+        try_parse_anthropic(payload).is_ok()
+    }
+
+    fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
+        let extras = collect_extras(&payload, ANTHROPIC_KNOWN_KEYS);
+        let stop = payload.get("stop_sequences").cloned();
+
+        let request: CreateMessageParams = serde_json::from_value(payload)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let messages = <Vec<Message> as TryFromLLM<Vec<_>>>::try_from(request.messages)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let params = UniversalParams {
+            temperature: request.temperature,
+            top_p: request.top_p,
+            top_k: request.top_k,
+            max_tokens: Some(request.max_tokens),
+            stop,
+            tools: request.tools.and_then(|t| serde_json::to_value(t).ok()),
+            tool_choice: request
+                .tool_choice
+                .and_then(|t| serde_json::to_value(t).ok()),
+            response_format: None,  // Anthropic doesn't use response_format
+            seed: None,             // Anthropic doesn't support seed
+            presence_penalty: None, // Anthropic doesn't support these
+            frequency_penalty: None,
+            stream: request.stream,
+        };
+
+        Ok(UniversalRequest {
+            model: Some(request.model),
+            messages,
+            params,
+            extras,
+        })
+    }
+
+    fn request_from_universal(&self, req: &UniversalRequest) -> Result<Value, TransformError> {
+        let model = req.model.as_ref().ok_or(TransformError::ValidationFailed {
+            target: ProviderFormat::Anthropic,
+            reason: "missing model".to_string(),
+        })?;
+
+        // Clone messages and extract system messages (Anthropic uses separate `system` param)
+        let mut msgs = req.messages.clone();
+        let system_contents = extract_system_messages(&mut msgs);
+
+        // Convert remaining messages
+        let anthropic_messages: Vec<InputMessage> =
+            <Vec<InputMessage> as TryFromLLM<Vec<Message>>>::try_from(msgs)
+                .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+        let mut obj = Map::new();
+        obj.insert("model".into(), Value::String(model.clone()));
+        obj.insert(
+            "messages".into(),
+            serde_json::to_value(anthropic_messages)
+                .map_err(|e| TransformError::SerializationFailed(e.to_string()))?,
+        );
+
+        // Add system message if present
+        if !system_contents.is_empty() {
+            let system_text: String = system_contents
+                .iter()
+                .filter_map(|c| match c {
+                    UserContent::String(s) => Some(s.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            obj.insert("system".into(), Value::String(system_text));
+        }
+
+        // max_tokens is required for Anthropic - use the value from params or default
+        let max_tokens = req.params.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
+        obj.insert("max_tokens".into(), Value::Number(max_tokens.into()));
+
+        // Insert other params
+        insert_opt_f64(&mut obj, "temperature", req.params.temperature);
+        insert_opt_f64(&mut obj, "top_p", req.params.top_p);
+        insert_opt_i64(&mut obj, "top_k", req.params.top_k);
+
+        // Anthropic uses stop_sequences instead of stop
+        if let Some(stop) = &req.params.stop {
+            obj.insert("stop_sequences".into(), stop.clone());
+        }
+
+        insert_opt_value(&mut obj, "tools", req.params.tools.clone());
+        insert_opt_value(&mut obj, "tool_choice", req.params.tool_choice.clone());
+        insert_opt_bool(&mut obj, "stream", req.params.stream);
+
+        // Merge extras - only include Anthropic-known fields
+        // This filters out OpenAI-specific fields like stream_options that would cause
+        // Anthropic to reject the request with "extra inputs are not permitted"
+        for (k, v) in &req.extras {
+            if ANTHROPIC_KNOWN_KEYS.contains(&k.as_str()) {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+
+        Ok(Value::Object(obj))
+    }
+
+    fn apply_defaults(&self, req: &mut UniversalRequest) {
+        // Anthropic requires max_tokens - set default if not provided
+        if req.params.max_tokens.is_none() {
+            req.params.max_tokens = Some(DEFAULT_MAX_TOKENS);
+        }
+    }
+
+    fn detect_response(&self, payload: &Value) -> bool {
+        // Anthropic response has content[] array and type="message"
+        payload.get("content").and_then(Value::as_array).is_some()
+            && payload
+                .get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|t| t == "message")
+    }
+
+    fn response_to_universal(&self, payload: Value) -> Result<UniversalResponse, TransformError> {
+        let content = payload
+            .get("content")
+            .and_then(Value::as_array)
+            .ok_or_else(|| TransformError::ToUniversalFailed("missing content".to_string()))?;
+
+        let content_blocks: Vec<ContentBlock> = content
+            .iter()
+            .map(|v| {
+                serde_json::from_value(v.clone())
+                    .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let messages = <Vec<Message> as TryFromLLM<Vec<ContentBlock>>>::try_from(content_blocks)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let finish_reason = payload
+            .get("stop_reason")
+            .and_then(Value::as_str)
+            .map(|s| s.parse().unwrap());
+
+        let usage = payload.get("usage").map(|u| UniversalUsage {
+            prompt_tokens: u.get("input_tokens").and_then(Value::as_i64),
+            completion_tokens: u.get("output_tokens").and_then(Value::as_i64),
+            prompt_cached_tokens: u.get("cache_read_input_tokens").and_then(Value::as_i64),
+            prompt_cache_creation_tokens: u
+                .get("cache_creation_input_tokens")
+                .and_then(Value::as_i64),
+            completion_reasoning_tokens: None, // Anthropic doesn't expose thinking tokens separately
+        });
+
+        Ok(UniversalResponse {
+            model: payload
+                .get("model")
+                .and_then(Value::as_str)
+                .map(String::from),
+            messages,
+            usage,
+            finish_reason,
+            extras: Map::new(),
+        })
+    }
+
+    fn response_from_universal(&self, resp: &UniversalResponse) -> Result<Value, TransformError> {
+        let content_blocks =
+            <Vec<ContentBlock> as TryFromLLM<Vec<Message>>>::try_from(resp.messages.clone())
+                .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+        let content_value = serde_json::to_value(&content_blocks)
+            .map_err(|e| TransformError::SerializationFailed(e.to_string()))?;
+
+        let stop_reason = self
+            .map_finish_reason(resp.finish_reason.as_ref())
+            .unwrap_or_else(|| "end_turn".to_string());
+
+        let mut obj = serde_json::json!({
+            "id": resp.extras.get("id").and_then(Value::as_str).unwrap_or("transformed"),
+            "type": "message",
+            "role": "assistant",
+            "content": content_value,
+            "model": resp.model.as_deref().unwrap_or("transformed"),
+            "stop_reason": stop_reason
+        });
+
+        if let Some(usage) = &resp.usage {
+            obj.as_object_mut().unwrap().insert(
+                "usage".into(),
+                serde_json::json!({
+                    "input_tokens": usage.prompt_tokens.unwrap_or(0),
+                    "output_tokens": usage.completion_tokens.unwrap_or(0)
+                }),
+            );
+        }
+
+        Ok(obj)
+    }
+
+    fn map_finish_reason(&self, reason: Option<&FinishReason>) -> Option<String> {
+        reason.map(|r| match r {
+            FinishReason::Stop => "end_turn".to_string(),
+            FinishReason::Length => "max_tokens".to_string(),
+            FinishReason::ToolCalls => "tool_use".to_string(),
+            FinishReason::ContentFilter => "content_filter".to_string(),
+            FinishReason::Other(s) => s.clone(),
+        })
+    }
+
+    // =========================================================================
+    // Streaming response handling
+    // =========================================================================
+
+    fn detect_stream_response(&self, payload: &Value) -> bool {
+        // Anthropic streaming has type field with specific event types
+        if let Some(event_type) = payload.get("type").and_then(Value::as_str) {
+            matches!(
+                event_type,
+                "message_start"
+                    | "content_block_start"
+                    | "content_block_delta"
+                    | "content_block_stop"
+                    | "message_delta"
+                    | "message_stop"
+                    | "ping"
+            )
+        } else {
+            false
+        }
+    }
+
+    fn stream_to_universal(
+        &self,
+        payload: Value,
+    ) -> Result<Option<UniversalStreamChunk>, TransformError> {
+        let event_type = payload
+            .get("type")
+            .and_then(Value::as_str)
+            .ok_or_else(|| TransformError::ToUniversalFailed("missing type field".to_string()))?;
+
+        match event_type {
+            "content_block_delta" => {
+                // Extract text delta - only handle text_delta type for basic text support
+                let delta = payload.get("delta");
+                let delta_type = delta.and_then(|d| d.get("type")).and_then(Value::as_str);
+
+                if delta_type == Some("text_delta") {
+                    let text = delta
+                        .and_then(|d| d.get("text"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+
+                    let index = payload.get("index").and_then(Value::as_u64).unwrap_or(0) as u32;
+
+                    return Ok(Some(UniversalStreamChunk::new(
+                        None,
+                        None,
+                        vec![UniversalStreamChoice {
+                            index,
+                            delta: Some(serde_json::json!({
+                                "role": "assistant",
+                                "content": text
+                            })),
+                            finish_reason: None,
+                        }],
+                        None,
+                        None,
+                    )));
+                }
+
+                // For non-text deltas (tool_use, etc.), return keep-alive
+                Ok(Some(UniversalStreamChunk::keep_alive()))
+            }
+
+            "message_delta" => {
+                // Contains stop_reason and final usage
+                let stop_reason = payload
+                    .get("delta")
+                    .and_then(|d| d.get("stop_reason"))
+                    .and_then(Value::as_str);
+
+                let finish_reason = stop_reason.map(|r| match r {
+                    "end_turn" | "stop_sequence" => "stop".to_string(),
+                    "max_tokens" => "length".to_string(),
+                    "tool_use" => "tool_calls".to_string(),
+                    other => other.to_string(),
+                });
+
+                let usage = payload.get("usage").map(|u| UniversalUsage {
+                    prompt_tokens: u.get("input_tokens").and_then(Value::as_i64),
+                    completion_tokens: u.get("output_tokens").and_then(Value::as_i64),
+                    prompt_cached_tokens: u.get("cache_read_input_tokens").and_then(Value::as_i64),
+                    prompt_cache_creation_tokens: u
+                        .get("cache_creation_input_tokens")
+                        .and_then(Value::as_i64),
+                    completion_reasoning_tokens: None,
+                });
+
+                if finish_reason.is_some() || usage.is_some() {
+                    return Ok(Some(UniversalStreamChunk::new(
+                        None,
+                        None,
+                        vec![UniversalStreamChoice {
+                            index: 0,
+                            delta: Some(serde_json::json!({})),
+                            finish_reason,
+                        }],
+                        None,
+                        usage,
+                    )));
+                }
+
+                Ok(Some(UniversalStreamChunk::keep_alive()))
+            }
+
+            "message_start" => {
+                // Extract initial usage and model info
+                let message = payload.get("message");
+                let model = message
+                    .and_then(|m| m.get("model"))
+                    .and_then(Value::as_str)
+                    .map(String::from);
+                let id = message
+                    .and_then(|m| m.get("id"))
+                    .and_then(Value::as_str)
+                    .map(String::from);
+                let usage = message
+                    .and_then(|m| m.get("usage"))
+                    .map(|u| UniversalUsage {
+                        prompt_tokens: u.get("input_tokens").and_then(Value::as_i64),
+                        completion_tokens: u.get("output_tokens").and_then(Value::as_i64),
+                        prompt_cached_tokens: u
+                            .get("cache_read_input_tokens")
+                            .and_then(Value::as_i64),
+                        prompt_cache_creation_tokens: u
+                            .get("cache_creation_input_tokens")
+                            .and_then(Value::as_i64),
+                        completion_reasoning_tokens: None,
+                    });
+
+                // Return chunk with metadata but mark as role initialization
+                Ok(Some(UniversalStreamChunk::new(
+                    id,
+                    model,
+                    vec![UniversalStreamChoice {
+                        index: 0,
+                        delta: Some(serde_json::json!({"role": "assistant", "content": ""})),
+                        finish_reason: None,
+                    }],
+                    None,
+                    usage,
+                )))
+            }
+
+            "message_stop" => {
+                // Terminal event - don't emit any chunk
+                Ok(None)
+            }
+
+            "content_block_start" | "content_block_stop" | "ping" => {
+                // Metadata events - return keep-alive
+                Ok(Some(UniversalStreamChunk::keep_alive()))
+            }
+
+            _ => {
+                // Unknown event type - return keep-alive
+                Ok(Some(UniversalStreamChunk::keep_alive()))
+            }
+        }
+    }
+
+    fn stream_from_universal(&self, chunk: &UniversalStreamChunk) -> Result<Value, TransformError> {
+        if chunk.is_keep_alive() {
+            // Return a ping event for keep-alive
+            return Ok(serde_json::json!({"type": "ping"}));
+        }
+
+        // Check if this is a finish chunk
+        let has_finish = chunk
+            .choices
+            .first()
+            .and_then(|c| c.finish_reason.as_ref())
+            .is_some();
+
+        if has_finish {
+            // Generate message_delta with stop_reason
+            let finish_reason = chunk.choices.first().and_then(|c| c.finish_reason.as_ref());
+            let stop_reason = finish_reason.map(|r| match r.as_str() {
+                "stop" => "end_turn",
+                "length" => "max_tokens",
+                "tool_calls" => "tool_use",
+                other => other,
+            });
+
+            let mut obj = serde_json::json!({
+                "type": "message_delta",
+                "delta": {
+                    "stop_reason": stop_reason
+                }
+            });
+
+            if let Some(usage) = &chunk.usage {
+                obj.as_object_mut().unwrap().insert(
+                    "usage".into(),
+                    serde_json::json!({
+                        "input_tokens": usage.prompt_tokens.unwrap_or(0),
+                        "output_tokens": usage.completion_tokens.unwrap_or(0)
+                    }),
+                );
+            }
+
+            return Ok(obj);
+        }
+
+        // Check if this is a content delta
+        if let Some(choice) = chunk.choices.first() {
+            if let Some(delta) = &choice.delta {
+                if let Some(content) = delta.get("content").and_then(Value::as_str) {
+                    return Ok(serde_json::json!({
+                        "type": "content_block_delta",
+                        "index": choice.index,
+                        "delta": {
+                            "type": "text_delta",
+                            "text": content
+                        }
+                    }));
+                }
+
+                // Role-only delta (initial chunk) - return content_block_start
+                if delta.get("role").is_some() && delta.get("content").is_none() {
+                    return Ok(serde_json::json!({
+                        "type": "content_block_start",
+                        "index": choice.index,
+                        "content_block": {
+                            "type": "text",
+                            "text": ""
+                        }
+                    }));
+                }
+            }
+        }
+
+        // Fallback - return content_block_delta with empty text
+        Ok(serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "text_delta",
+                "text": ""
+            }
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_json::json;
+
+    #[test]
+    fn test_anthropic_detect_request() {
+        let adapter = AnthropicAdapter;
+        let payload = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(adapter.detect_request(&payload));
+    }
+
+    #[test]
+    fn test_anthropic_passthrough() {
+        let adapter = AnthropicAdapter;
+        let payload = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let universal = adapter.request_to_universal(payload).unwrap();
+        assert_eq!(
+            universal.model,
+            Some("claude-3-5-sonnet-20241022".to_string())
+        );
+        assert_eq!(universal.params.max_tokens, Some(1024));
+
+        let reconstructed = adapter.request_from_universal(&universal).unwrap();
+        assert_eq!(
+            reconstructed.get("model").unwrap(),
+            "claude-3-5-sonnet-20241022"
+        );
+        assert_eq!(reconstructed.get("max_tokens").unwrap(), 1024);
+    }
+
+    #[test]
+    fn test_anthropic_apply_defaults() {
+        let adapter = AnthropicAdapter;
+        let mut req = UniversalRequest {
+            model: Some("claude-3-5-sonnet-20241022".to_string()),
+            messages: vec![],
+            params: UniversalParams::default(),
+            extras: Map::new(),
+        };
+
+        assert!(req.params.max_tokens.is_none());
+        adapter.apply_defaults(&mut req);
+        assert_eq!(req.params.max_tokens, Some(DEFAULT_MAX_TOKENS));
+    }
+
+    #[test]
+    fn test_anthropic_preserves_existing_max_tokens() {
+        let adapter = AnthropicAdapter;
+        let mut req = UniversalRequest {
+            model: Some("claude-3-5-sonnet-20241022".to_string()),
+            messages: vec![],
+            params: UniversalParams {
+                max_tokens: Some(8192),
+                ..Default::default()
+            },
+            extras: Map::new(),
+        };
+
+        adapter.apply_defaults(&mut req);
+        assert_eq!(req.params.max_tokens, Some(8192));
+    }
+}

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -20,7 +20,7 @@ use crate::universal::message::{Message, UserContent};
 use crate::universal::transform::extract_system_messages;
 use crate::universal::{
     FinishReason, UniversalParams, UniversalRequest, UniversalResponse, UniversalStreamChoice,
-    UniversalStreamChunk, UniversalUsage,
+    UniversalStreamChunk, UniversalUsage, PLACEHOLDER_ID, PLACEHOLDER_MODEL,
 };
 
 /// Default max_tokens for Anthropic requests (matches legacy proxy behavior).
@@ -220,7 +220,6 @@ impl ProviderAdapter for AnthropicAdapter {
             messages,
             usage,
             finish_reason,
-            extras: Map::new(),
         })
     }
 
@@ -237,11 +236,11 @@ impl ProviderAdapter for AnthropicAdapter {
             .unwrap_or_else(|| "end_turn".to_string());
 
         let mut obj = serde_json::json!({
-            "id": resp.extras.get("id").and_then(Value::as_str).unwrap_or("transformed"),
+            "id": format!("msg_{}", PLACEHOLDER_ID),
             "type": "message",
             "role": "assistant",
             "content": content_value,
-            "model": resp.model.as_deref().unwrap_or("transformed"),
+            "model": resp.model.as_deref().unwrap_or(PLACEHOLDER_MODEL),
             "stop_reason": stop_reason
         });
 

--- a/crates/lingua/src/providers/anthropic/detect.rs
+++ b/crates/lingua/src/providers/anthropic/detect.rs
@@ -1,0 +1,191 @@
+/*!
+Anthropic format detection.
+
+This module provides functions to detect if a payload is already in
+Anthropic-compatible format by attempting to deserialize into the
+Anthropic struct types. This replaces heuristic-based detection with
+actual struct validation.
+*/
+
+use crate::providers::anthropic::generated::CreateMessageParams;
+use crate::serde_json::{self, Value};
+use thiserror::Error;
+
+/// Attempt to parse a JSON Value as Anthropic CreateMessageParams.
+///
+/// Returns the parsed struct if successful, or an error if the payload
+/// is not valid Anthropic format.
+pub fn try_parse_anthropic(payload: &Value) -> Result<CreateMessageParams, DetectionError> {
+    serde_json::from_value(payload.clone())
+        .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))
+}
+
+/// Error type for payload detection
+#[derive(Debug, Error)]
+pub enum DetectionError {
+    #[error("Deserialization failed: {0}")]
+    DeserializationFailed(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_json::json;
+
+    #[test]
+    fn test_try_parse_anthropic_valid() {
+        let payload = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello"
+                }
+            ],
+            "max_tokens": 1024
+        });
+
+        assert!(try_parse_anthropic(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_anthropic_with_tool_use() {
+        let payload = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_123",
+                            "name": "get_weather",
+                            "input": {"location": "SF"}
+                        }
+                    ]
+                }
+            ],
+            "max_tokens": 1024
+        });
+
+        assert!(try_parse_anthropic(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_anthropic_with_tool_result() {
+        let payload = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_123",
+                            "content": "72°F"
+                        }
+                    ]
+                }
+            ],
+            "max_tokens": 1024
+        });
+
+        assert!(try_parse_anthropic(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_anthropic_with_image() {
+        let payload = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+                                "media_type": "image/png"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "max_tokens": 1024
+        });
+
+        assert!(try_parse_anthropic(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_anthropic_missing_max_tokens() {
+        // max_tokens is required in CreateMessageParams
+        let payload = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello"
+                }
+            ]
+        });
+
+        // Deserialization fails because max_tokens is required
+        assert!(try_parse_anthropic(&payload).is_err());
+    }
+
+    #[test]
+    fn test_try_parse_anthropic_success() {
+        let payload = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+
+        assert!(try_parse_anthropic(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_anthropic_fails_for_openai_format() {
+        // OpenAI-style payload with system role in messages - won't parse as Anthropic
+        // because Anthropic's MessageRole enum only has User and Assistant
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": [
+                {"role": "system", "content": "You are helpful"},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+
+        // This should fail because "system" is not a valid Anthropic role
+        assert!(try_parse_anthropic(&payload).is_err());
+    }
+
+    #[test]
+    fn test_try_parse_anthropic_with_system_field() {
+        // Valid Anthropic payload with system as top-level field
+        let payload = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 1024,
+            "system": "You are helpful",
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+
+        assert!(try_parse_anthropic(&payload).is_ok());
+
+        // Invalid - missing max_tokens
+        let invalid_payload = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+
+        assert!(try_parse_anthropic(&invalid_payload).is_err());
+    }
+}

--- a/crates/lingua/src/providers/anthropic/mod.rs
+++ b/crates/lingua/src/providers/anthropic/mod.rs
@@ -5,11 +5,19 @@ This module contains type definitions for Anthropic's messages API
 generated from the OpenAPI specification using quicktype.
 */
 
+pub mod adapter;
 pub mod convert;
+pub mod detect;
 pub mod generated;
 
 #[cfg(test)]
 pub mod test_anthropic;
+
+// Re-export adapter
+pub use adapter::AnthropicAdapter;
+
+// Re-export detection functions
+pub use detect::{try_parse_anthropic, DetectionError};
 
 // Re-export key generated types (automated approach with proper request/response separation)
 // Temporarily disabled while testing generation

--- a/crates/lingua/src/providers/bedrock/adapter.rs
+++ b/crates/lingua/src/providers/bedrock/adapter.rs
@@ -219,7 +219,6 @@ impl ProviderAdapter for BedrockAdapter {
             messages,
             usage,
             finish_reason,
-            extras: Map::new(),
         })
     }
 

--- a/crates/lingua/src/providers/bedrock/adapter.rs
+++ b/crates/lingua/src/providers/bedrock/adapter.rs
@@ -1,0 +1,544 @@
+/*!
+Amazon Bedrock provider adapter for Converse API.
+
+Bedrock's Converse API has some unique characteristics:
+- Uses `modelId` instead of `model`
+- Inference params are in `inferenceConfig` object
+- Uses camelCase field names
+- System messages are in a separate `system` array
+*/
+
+use crate::capabilities::ProviderFormat;
+use crate::processing::adapters::{collect_extras, ProviderAdapter};
+use crate::processing::transform::TransformError;
+use crate::providers::bedrock::request::{
+    BedrockInferenceConfiguration, BedrockMessage, ConverseRequest,
+};
+use crate::providers::bedrock::try_parse_bedrock;
+use crate::serde_json::{self, Map, Value};
+use crate::universal::convert::TryFromLLM;
+use crate::universal::message::Message;
+use crate::universal::{
+    FinishReason, UniversalParams, UniversalRequest, UniversalResponse, UniversalStreamChoice,
+    UniversalStreamChunk, UniversalUsage,
+};
+
+/// Known request fields for Bedrock Converse API.
+/// Fields not in this list go into `extras`.
+const BEDROCK_KNOWN_KEYS: &[&str] = &[
+    "modelId",
+    "messages",
+    "system",
+    "inferenceConfig",
+    "toolConfig",
+    "guardrailConfig",
+    "additionalModelRequestFields",
+    "additionalModelResponseFieldPaths",
+    "promptVariables",
+];
+
+/// Adapter for Amazon Bedrock Converse API.
+pub struct BedrockAdapter;
+
+impl ProviderAdapter for BedrockAdapter {
+    fn format(&self) -> ProviderFormat {
+        ProviderFormat::Converse
+    }
+
+    fn directory_name(&self) -> &'static str {
+        "bedrock"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Bedrock"
+    }
+
+    fn detect_request(&self, payload: &Value) -> bool {
+        try_parse_bedrock(payload).is_ok()
+    }
+
+    fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
+        let extras = collect_extras(&payload, BEDROCK_KNOWN_KEYS);
+
+        let request: ConverseRequest = serde_json::from_value(payload)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let messages =
+            <Vec<Message> as TryFromLLM<Vec<BedrockMessage>>>::try_from(request.messages)
+                .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        // Extract params from inferenceConfig
+        let (temperature, top_p, max_tokens, stop) = if let Some(config) = &request.inference_config
+        {
+            (
+                config.temperature,
+                config.top_p,
+                config.max_tokens.map(|t| t as i64),
+                config
+                    .stop_sequences
+                    .as_ref()
+                    .and_then(|s| serde_json::to_value(s).ok()),
+            )
+        } else {
+            (None, None, None, None)
+        };
+
+        let params = UniversalParams {
+            temperature,
+            top_p,
+            top_k: None, // Bedrock doesn't expose top_k in Converse API
+            max_tokens,
+            stop,
+            tools: request
+                .tool_config
+                .and_then(|t| serde_json::to_value(t).ok()),
+            tool_choice: None, // Tool choice is inside tool_config
+            response_format: None,
+            seed: None, // Bedrock doesn't support seed
+            presence_penalty: None,
+            frequency_penalty: None,
+            stream: None, // Bedrock uses separate endpoint for streaming
+        };
+
+        Ok(UniversalRequest {
+            model: Some(request.model_id),
+            messages,
+            params,
+            extras,
+        })
+    }
+
+    fn request_from_universal(&self, req: &UniversalRequest) -> Result<Value, TransformError> {
+        let model_id = req.model.as_ref().ok_or(TransformError::ValidationFailed {
+            target: ProviderFormat::Converse,
+            reason: "missing model".to_string(),
+        })?;
+
+        // Convert messages to Bedrock format
+        let bedrock_messages: Vec<BedrockMessage> =
+            <Vec<BedrockMessage> as TryFromLLM<Vec<Message>>>::try_from(req.messages.clone())
+                .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+        let mut obj = Map::new();
+        obj.insert("modelId".into(), Value::String(model_id.clone()));
+        obj.insert(
+            "messages".into(),
+            serde_json::to_value(bedrock_messages)
+                .map_err(|e| TransformError::SerializationFailed(e.to_string()))?,
+        );
+
+        // Build inferenceConfig if any params are set
+        let has_params = req.params.temperature.is_some()
+            || req.params.top_p.is_some()
+            || req.params.max_tokens.is_some()
+            || req.params.stop.is_some();
+
+        if has_params {
+            let config = BedrockInferenceConfiguration {
+                temperature: req.params.temperature,
+                top_p: req.params.top_p,
+                max_tokens: req.params.max_tokens.map(|t| t as i32),
+                stop_sequences: req.params.stop.as_ref().and_then(|v| {
+                    if let Value::Array(arr) = v {
+                        Some(
+                            arr.iter()
+                                .filter_map(|s| s.as_str().map(String::from))
+                                .collect(),
+                        )
+                    } else if let Value::String(s) = v {
+                        Some(vec![s.clone()])
+                    } else {
+                        None
+                    }
+                }),
+            };
+
+            obj.insert(
+                "inferenceConfig".into(),
+                serde_json::to_value(config)
+                    .map_err(|e| TransformError::SerializationFailed(e.to_string()))?,
+            );
+        }
+
+        // Add toolConfig if tools are present
+        if let Some(tools) = &req.params.tools {
+            obj.insert("toolConfig".into(), tools.clone());
+        }
+
+        // Merge extras
+        for (k, v) in &req.extras {
+            obj.insert(k.clone(), v.clone());
+        }
+
+        Ok(Value::Object(obj))
+    }
+
+    fn apply_defaults(&self, _req: &mut UniversalRequest) {
+        // Bedrock doesn't require any specific defaults
+    }
+
+    fn detect_response(&self, payload: &Value) -> bool {
+        // Bedrock response has output.message structure
+        payload
+            .get("output")
+            .and_then(|o| o.get("message"))
+            .is_some()
+    }
+
+    fn response_to_universal(&self, payload: Value) -> Result<UniversalResponse, TransformError> {
+        let output = payload
+            .get("output")
+            .ok_or_else(|| TransformError::ToUniversalFailed("missing output".to_string()))?;
+
+        let message_val = output.get("message").ok_or_else(|| {
+            TransformError::ToUniversalFailed("missing output.message".to_string())
+        })?;
+
+        let bedrock_message: BedrockMessage = serde_json::from_value(message_val.clone())
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let messages =
+            <Vec<Message> as TryFromLLM<Vec<BedrockMessage>>>::try_from(vec![bedrock_message])
+                .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let finish_reason = payload
+            .get("stopReason")
+            .and_then(Value::as_str)
+            .map(|s| s.parse().unwrap());
+
+        let usage = payload.get("usage").map(|u| UniversalUsage {
+            prompt_tokens: u.get("inputTokens").and_then(Value::as_i64),
+            completion_tokens: u.get("outputTokens").and_then(Value::as_i64),
+            prompt_cached_tokens: u.get("cacheReadInputTokens").and_then(Value::as_i64),
+            prompt_cache_creation_tokens: u.get("cacheWriteInputTokens").and_then(Value::as_i64),
+            completion_reasoning_tokens: None, // Bedrock doesn't expose thinking tokens separately
+        });
+
+        Ok(UniversalResponse {
+            model: None, // Bedrock doesn't include model in response
+            messages,
+            usage,
+            finish_reason,
+            extras: Map::new(),
+        })
+    }
+
+    fn response_from_universal(&self, resp: &UniversalResponse) -> Result<Value, TransformError> {
+        let bedrock_messages: Vec<BedrockMessage> =
+            <Vec<BedrockMessage> as TryFromLLM<Vec<Message>>>::try_from(resp.messages.clone())
+                .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+        // Take first message for output
+        let message = bedrock_messages
+            .into_iter()
+            .next()
+            .ok_or_else(|| TransformError::FromUniversalFailed("no messages".to_string()))?;
+
+        let message_value = serde_json::to_value(message)
+            .map_err(|e| TransformError::SerializationFailed(e.to_string()))?;
+
+        let stop_reason = self
+            .map_finish_reason(resp.finish_reason.as_ref())
+            .unwrap_or_else(|| "end_turn".to_string());
+
+        let mut obj = serde_json::json!({
+            "output": {
+                "message": message_value
+            },
+            "stopReason": stop_reason
+        });
+
+        if let Some(usage) = &resp.usage {
+            obj.as_object_mut().unwrap().insert(
+                "usage".into(),
+                serde_json::json!({
+                    "inputTokens": usage.prompt_tokens.unwrap_or(0),
+                    "outputTokens": usage.completion_tokens.unwrap_or(0)
+                }),
+            );
+        }
+
+        Ok(obj)
+    }
+
+    fn map_finish_reason(&self, reason: Option<&FinishReason>) -> Option<String> {
+        reason.map(|r| match r {
+            FinishReason::Stop => "end_turn".to_string(),
+            FinishReason::Length => "max_tokens".to_string(),
+            FinishReason::ToolCalls => "tool_use".to_string(),
+            FinishReason::ContentFilter => "content_filtered".to_string(),
+            FinishReason::Other(s) => s.clone(),
+        })
+    }
+
+    // =========================================================================
+    // Streaming response handling
+    // =========================================================================
+
+    fn detect_stream_response(&self, payload: &Value) -> bool {
+        // Bedrock streaming has unique top-level keys
+        payload.get("messageStart").is_some()
+            || payload.get("contentBlockDelta").is_some()
+            || payload.get("contentBlockStop").is_some()
+            || payload.get("messageStop").is_some()
+            || payload.get("metadata").is_some()
+    }
+
+    fn stream_to_universal(
+        &self,
+        payload: Value,
+    ) -> Result<Option<UniversalStreamChunk>, TransformError> {
+        // Handle contentBlockDelta - text content
+        if let Some(delta_event) = payload.get("contentBlockDelta") {
+            let index = delta_event
+                .get("contentBlockIndex")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32;
+
+            // Only handle text deltas for basic text support
+            if let Some(text) = delta_event
+                .get("delta")
+                .and_then(|d| d.get("text"))
+                .and_then(Value::as_str)
+            {
+                return Ok(Some(UniversalStreamChunk::new(
+                    None,
+                    None,
+                    vec![UniversalStreamChoice {
+                        index,
+                        delta: Some(serde_json::json!({
+                            "role": "assistant",
+                            "content": text
+                        })),
+                        finish_reason: None,
+                    }],
+                    None,
+                    None,
+                )));
+            }
+
+            // Non-text delta (tool use) - return keep-alive
+            return Ok(Some(UniversalStreamChunk::keep_alive()));
+        }
+
+        // Handle messageStop - finish reason
+        if let Some(stop_event) = payload.get("messageStop") {
+            let stop_reason = stop_event.get("stopReason").and_then(Value::as_str);
+            let finish_reason = stop_reason.map(|r| match r {
+                "end_turn" | "stop_sequence" => "stop".to_string(),
+                "max_tokens" => "length".to_string(),
+                "tool_use" => "tool_calls".to_string(),
+                "content_filtered" => "content_filter".to_string(),
+                other => other.to_string(),
+            });
+
+            return Ok(Some(UniversalStreamChunk::new(
+                None,
+                None,
+                vec![UniversalStreamChoice {
+                    index: 0,
+                    delta: Some(serde_json::json!({})),
+                    finish_reason,
+                }],
+                None,
+                None,
+            )));
+        }
+
+        // Handle metadata - usage info
+        if let Some(meta) = payload.get("metadata") {
+            let usage = meta.get("usage").map(|u| UniversalUsage {
+                prompt_tokens: u.get("inputTokens").and_then(Value::as_i64),
+                completion_tokens: u.get("outputTokens").and_then(Value::as_i64),
+                prompt_cached_tokens: u.get("cacheReadInputTokens").and_then(Value::as_i64),
+                prompt_cache_creation_tokens: u
+                    .get("cacheWriteInputTokens")
+                    .and_then(Value::as_i64),
+                completion_reasoning_tokens: None,
+            });
+
+            if usage.is_some() {
+                return Ok(Some(UniversalStreamChunk::new(
+                    None,
+                    None,
+                    vec![],
+                    None,
+                    usage,
+                )));
+            }
+        }
+
+        // Handle messageStart - role initialization
+        if payload.get("messageStart").is_some() {
+            return Ok(Some(UniversalStreamChunk::new(
+                None,
+                None,
+                vec![UniversalStreamChoice {
+                    index: 0,
+                    delta: Some(serde_json::json!({"role": "assistant", "content": ""})),
+                    finish_reason: None,
+                }],
+                None,
+                None,
+            )));
+        }
+
+        // Other events (contentBlockStart, contentBlockStop) - keep-alive
+        Ok(Some(UniversalStreamChunk::keep_alive()))
+    }
+
+    fn stream_from_universal(&self, chunk: &UniversalStreamChunk) -> Result<Value, TransformError> {
+        if chunk.is_keep_alive() {
+            // Return empty contentBlockStop for keep-alive
+            return Ok(serde_json::json!({
+                "contentBlockStop": {"contentBlockIndex": 0}
+            }));
+        }
+
+        // Check for finish chunk
+        let has_finish = chunk
+            .choices
+            .first()
+            .and_then(|c| c.finish_reason.as_ref())
+            .is_some();
+
+        if has_finish {
+            let finish_reason = chunk.choices.first().and_then(|c| c.finish_reason.as_ref());
+            let stop_reason = finish_reason.map(|r| match r.as_str() {
+                "stop" => "end_turn",
+                "length" => "max_tokens",
+                "tool_calls" => "tool_use",
+                "content_filter" => "content_filtered",
+                other => other,
+            });
+
+            return Ok(serde_json::json!({
+                "messageStop": {
+                    "stopReason": stop_reason
+                }
+            }));
+        }
+
+        // Check for usage-only chunk
+        if chunk.choices.is_empty() && chunk.usage.is_some() {
+            let usage = chunk.usage.as_ref().unwrap();
+            return Ok(serde_json::json!({
+                "metadata": {
+                    "usage": {
+                        "inputTokens": usage.prompt_tokens.unwrap_or(0),
+                        "outputTokens": usage.completion_tokens.unwrap_or(0)
+                    }
+                }
+            }));
+        }
+
+        // Check for content delta
+        if let Some(choice) = chunk.choices.first() {
+            if let Some(delta) = &choice.delta {
+                if let Some(content) = delta.get("content").and_then(Value::as_str) {
+                    return Ok(serde_json::json!({
+                        "contentBlockDelta": {
+                            "contentBlockIndex": choice.index,
+                            "delta": {
+                                "text": content
+                            }
+                        }
+                    }));
+                }
+
+                // Role-only delta - messageStart
+                if delta.get("role").is_some() && delta.get("content").is_none() {
+                    return Ok(serde_json::json!({
+                        "messageStart": {
+                            "role": "assistant"
+                        }
+                    }));
+                }
+            }
+        }
+
+        // Fallback - return contentBlockDelta with empty text
+        Ok(serde_json::json!({
+            "contentBlockDelta": {
+                "contentBlockIndex": 0,
+                "delta": {
+                    "text": ""
+                }
+            }
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_json::json;
+
+    #[test]
+    fn test_bedrock_detect_request() {
+        let adapter = BedrockAdapter;
+        let payload = json!({
+            "modelId": "anthropic.claude-3-sonnet",
+            "messages": [{
+                "role": "user",
+                "content": [{"text": "Hello"}]
+            }]
+        });
+        assert!(adapter.detect_request(&payload));
+    }
+
+    #[test]
+    fn test_bedrock_passthrough() {
+        let adapter = BedrockAdapter;
+        let payload = json!({
+            "modelId": "anthropic.claude-3-sonnet",
+            "messages": [{
+                "role": "user",
+                "content": [{"text": "Hello"}]
+            }],
+            "inferenceConfig": {
+                "temperature": 0.7,
+                "maxTokens": 1024
+            }
+        });
+
+        let universal = adapter.request_to_universal(payload).unwrap();
+        assert_eq!(
+            universal.model,
+            Some("anthropic.claude-3-sonnet".to_string())
+        );
+        assert_eq!(universal.params.temperature, Some(0.7));
+        assert_eq!(universal.params.max_tokens, Some(1024));
+
+        let reconstructed = adapter.request_from_universal(&universal).unwrap();
+        assert_eq!(
+            reconstructed.get("modelId").unwrap(),
+            "anthropic.claude-3-sonnet"
+        );
+        assert!(reconstructed.get("messages").is_some());
+        assert!(reconstructed.get("inferenceConfig").is_some());
+    }
+
+    #[test]
+    fn test_bedrock_preserves_extras() {
+        let adapter = BedrockAdapter;
+        let payload = json!({
+            "modelId": "anthropic.claude-3-sonnet",
+            "messages": [{
+                "role": "user",
+                "content": [{"text": "Hello"}]
+            }],
+            "guardrailConfig": {
+                "guardrailIdentifier": "test",
+                "guardrailVersion": "1"
+            }
+        });
+
+        let universal = adapter.request_to_universal(payload).unwrap();
+        // guardrailConfig is a known key, so it won't be in extras
+
+        let reconstructed = adapter.request_from_universal(&universal).unwrap();
+        assert!(reconstructed.get("modelId").is_some());
+        assert!(reconstructed.get("messages").is_some());
+    }
+}

--- a/crates/lingua/src/providers/bedrock/convert.rs
+++ b/crates/lingua/src/providers/bedrock/convert.rs
@@ -1,0 +1,639 @@
+/*!
+Bedrock Converse format conversions.
+
+This module provides TryFromLLM trait implementations for converting between
+AWS Bedrock's Converse API format and Lingua's universal message format.
+*/
+
+use crate::error::ConvertError;
+use crate::providers::bedrock::request::{
+    BedrockContentBlock, BedrockConversationRole, BedrockImageBlock, BedrockImageFormat,
+    BedrockImageSource, BedrockMessage, BedrockToolResultBlock, BedrockToolResultContent,
+    BedrockToolUseBlock, ConverseRequest,
+};
+use crate::providers::bedrock::response::{BedrockOutputContentBlock, BedrockOutputMessage};
+use crate::serde_json::{self, Value};
+use crate::universal::convert::TryFromLLM;
+use crate::universal::message::{
+    AssistantContent, AssistantContentPart, Message, TextContentPart, ToolCallArguments,
+    ToolContentPart, ToolResultContentPart, UserContent, UserContentPart,
+};
+
+// ============================================================================
+// Bedrock Message -> Universal Message
+// ============================================================================
+
+impl TryFromLLM<BedrockMessage> for Message {
+    type Error = ConvertError;
+
+    fn try_from(msg: BedrockMessage) -> Result<Self, Self::Error> {
+        match msg.role {
+            BedrockConversationRole::User => {
+                let mut has_tool_results = false;
+                let mut tool_results = Vec::new();
+                let mut text_parts = Vec::new();
+
+                for block in msg.content {
+                    match block {
+                        BedrockContentBlock::Text { text } => {
+                            text_parts.push(text);
+                        }
+                        BedrockContentBlock::ToolResult { tool_result } => {
+                            has_tool_results = true;
+                            let output = tool_result
+                                .content
+                                .into_iter()
+                                .next()
+                                .map(|c| match c {
+                                    BedrockToolResultContent::Text { text } => Value::String(text),
+                                    BedrockToolResultContent::Json { json } => json,
+                                    BedrockToolResultContent::Image { .. } => {
+                                        Value::String("[image]".to_string())
+                                    }
+                                })
+                                .unwrap_or(Value::Null);
+
+                            tool_results.push(ToolContentPart::ToolResult(ToolResultContentPart {
+                                tool_call_id: tool_result.tool_use_id,
+                                tool_name: String::new(),
+                                output,
+                                provider_options: None,
+                            }));
+                        }
+                        BedrockContentBlock::Image { .. } => {
+                            // Skip images for now
+                        }
+                        BedrockContentBlock::ToolUse { .. } => {
+                            // Tool use shouldn't be in user messages
+                        }
+                    }
+                }
+
+                if has_tool_results {
+                    Ok(Message::Tool {
+                        content: tool_results,
+                    })
+                } else {
+                    Ok(Message::User {
+                        content: UserContent::String(text_parts.join("")),
+                    })
+                }
+            }
+            BedrockConversationRole::Assistant => {
+                let mut content_parts = Vec::new();
+
+                for block in msg.content {
+                    match block {
+                        BedrockContentBlock::Text { text } => {
+                            content_parts.push(AssistantContentPart::Text(TextContentPart {
+                                text,
+                                provider_options: None,
+                            }));
+                        }
+                        BedrockContentBlock::ToolUse { tool_use } => {
+                            content_parts.push(AssistantContentPart::ToolCall {
+                                tool_call_id: tool_use.tool_use_id,
+                                tool_name: tool_use.name,
+                                arguments: ToolCallArguments::from(
+                                    serde_json::to_string(&tool_use.input).unwrap_or_default(),
+                                ),
+                                provider_options: None,
+                                provider_executed: None,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+
+                if content_parts.is_empty() {
+                    content_parts.push(AssistantContentPart::Text(TextContentPart {
+                        text: String::new(),
+                        provider_options: None,
+                    }));
+                }
+
+                Ok(Message::Assistant {
+                    content: AssistantContent::Array(content_parts),
+                    id: None,
+                })
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Universal Message -> Bedrock Message
+// ============================================================================
+
+impl TryFromLLM<Message> for BedrockMessage {
+    type Error = ConvertError;
+
+    fn try_from(message: Message) -> Result<Self, Self::Error> {
+        let (role, content) = match message {
+            Message::System { content } => {
+                let text = match content {
+                    UserContent::String(s) => format!("System: {}", s),
+                    UserContent::Array(parts) => {
+                        let texts: Vec<String> = parts
+                            .into_iter()
+                            .filter_map(|p| match p {
+                                UserContentPart::Text(t) => Some(t.text),
+                                _ => None,
+                            })
+                            .collect();
+                        format!("System: {}", texts.join(""))
+                    }
+                };
+                (
+                    BedrockConversationRole::User,
+                    vec![BedrockContentBlock::Text { text }],
+                )
+            }
+            Message::User { content } => {
+                let blocks = match content {
+                    UserContent::String(s) => vec![BedrockContentBlock::Text { text: s }],
+                    UserContent::Array(parts) => parts
+                        .into_iter()
+                        .filter_map(|p| match p {
+                            UserContentPart::Text(t) => {
+                                Some(BedrockContentBlock::Text { text: t.text })
+                            }
+                            UserContentPart::Image {
+                                image, media_type, ..
+                            } => {
+                                if let Value::String(data) = image {
+                                    let format = media_type
+                                        .as_deref()
+                                        .and_then(|mt| mt.strip_prefix("image/"))
+                                        .map(|f| match f {
+                                            "png" => BedrockImageFormat::Png,
+                                            "gif" => BedrockImageFormat::Gif,
+                                            "webp" => BedrockImageFormat::Webp,
+                                            _ => BedrockImageFormat::Jpeg,
+                                        })
+                                        .unwrap_or(BedrockImageFormat::Jpeg);
+                                    Some(BedrockContentBlock::Image {
+                                        image: BedrockImageBlock {
+                                            format,
+                                            source: BedrockImageSource { bytes: data },
+                                        },
+                                    })
+                                } else {
+                                    None
+                                }
+                            }
+                            _ => None,
+                        })
+                        .collect(),
+                };
+                (BedrockConversationRole::User, blocks)
+            }
+            Message::Assistant { content, .. } => {
+                let blocks = match content {
+                    AssistantContent::String(s) => vec![BedrockContentBlock::Text { text: s }],
+                    AssistantContent::Array(parts) => parts
+                        .into_iter()
+                        .filter_map(|p| match p {
+                            AssistantContentPart::Text(t) => {
+                                Some(BedrockContentBlock::Text { text: t.text })
+                            }
+                            AssistantContentPart::ToolCall {
+                                tool_call_id,
+                                tool_name,
+                                arguments,
+                                ..
+                            } => {
+                                let input: Value = match arguments {
+                                    ToolCallArguments::Valid(map) => serde_json::to_value(map)
+                                        .unwrap_or(Value::Object(Default::default())),
+                                    ToolCallArguments::Invalid(s) => serde_json::from_str(&s)
+                                        .unwrap_or(Value::Object(Default::default())),
+                                };
+                                Some(BedrockContentBlock::ToolUse {
+                                    tool_use: BedrockToolUseBlock {
+                                        tool_use_id: tool_call_id,
+                                        name: tool_name,
+                                        input,
+                                    },
+                                })
+                            }
+                            _ => None,
+                        })
+                        .collect(),
+                };
+                (BedrockConversationRole::Assistant, blocks)
+            }
+            Message::Tool { content } => {
+                let blocks: Vec<BedrockContentBlock> = content
+                    .into_iter()
+                    .map(|part| {
+                        let ToolContentPart::ToolResult(result) = part;
+                        let content_text = match result.output {
+                            Value::String(s) => s,
+                            other => serde_json::to_string(&other).unwrap_or_default(),
+                        };
+                        BedrockContentBlock::ToolResult {
+                            tool_result: BedrockToolResultBlock {
+                                tool_use_id: result.tool_call_id,
+                                content: vec![BedrockToolResultContent::Text {
+                                    text: content_text,
+                                }],
+                                status: None,
+                            },
+                        }
+                    })
+                    .collect();
+                (BedrockConversationRole::User, blocks)
+            }
+        };
+
+        Ok(BedrockMessage { role, content })
+    }
+}
+
+// ============================================================================
+// Convenience functions using trait implementations
+// ============================================================================
+
+/// Convert Bedrock ConverseRequest to universal messages.
+pub fn bedrock_to_universal(request: &ConverseRequest) -> Result<Vec<Message>, ConvertError> {
+    <Vec<Message> as TryFromLLM<Vec<BedrockMessage>>>::try_from(request.messages.clone())
+}
+
+/// Convert universal messages to Bedrock messages.
+pub fn universal_to_bedrock_messages(
+    messages: &[Message],
+) -> Result<Vec<BedrockMessage>, ConvertError> {
+    <Vec<BedrockMessage> as TryFromLLM<Vec<Message>>>::try_from(messages.to_vec())
+}
+
+/// Convert universal messages to Bedrock Converse format as JSON Value.
+///
+/// This serializes the converted BedrockMessage structs to JSON for use
+/// in contexts where a Value is needed (e.g., when building full requests).
+pub fn universal_to_bedrock(messages: &[Message]) -> Result<Value, ConvertError> {
+    let bedrock_messages = universal_to_bedrock_messages(messages)?;
+    serde_json::to_value(bedrock_messages).map_err(|e| ConvertError::JsonSerializationFailed {
+        field: "messages".to_string(),
+        error: e.to_string(),
+    })
+}
+
+// ============================================================================
+// BedrockOutputMessage (Response) -> Universal Message
+// ============================================================================
+
+impl TryFromLLM<BedrockOutputMessage> for Message {
+    type Error = ConvertError;
+
+    fn try_from(msg: BedrockOutputMessage) -> Result<Self, Self::Error> {
+        // Output messages are always from the assistant
+        let mut content_parts = Vec::new();
+
+        for block in msg.content {
+            match block {
+                BedrockOutputContentBlock::Text { text } => {
+                    content_parts.push(AssistantContentPart::Text(TextContentPart {
+                        text,
+                        provider_options: None,
+                    }));
+                }
+                BedrockOutputContentBlock::ToolUse { tool_use } => {
+                    content_parts.push(AssistantContentPart::ToolCall {
+                        tool_call_id: tool_use.tool_use_id,
+                        tool_name: tool_use.name,
+                        arguments: ToolCallArguments::from(
+                            serde_json::to_string(&tool_use.input).unwrap_or_default(),
+                        ),
+                        provider_options: None,
+                        provider_executed: None,
+                    });
+                }
+            }
+        }
+
+        if content_parts.is_empty() {
+            content_parts.push(AssistantContentPart::Text(TextContentPart {
+                text: String::new(),
+                provider_options: None,
+            }));
+        }
+
+        Ok(Message::Assistant {
+            content: AssistantContent::Array(content_parts),
+            id: None,
+        })
+    }
+}
+
+// ============================================================================
+// Universal Message -> BedrockOutputMessage (Response)
+// ============================================================================
+
+impl TryFromLLM<Message> for BedrockOutputMessage {
+    type Error = ConvertError;
+
+    fn try_from(message: Message) -> Result<Self, Self::Error> {
+        match message {
+            Message::Assistant { content, .. } => {
+                let blocks = match content {
+                    AssistantContent::String(s) => {
+                        vec![BedrockOutputContentBlock::Text { text: s }]
+                    }
+                    AssistantContent::Array(parts) => parts
+                        .into_iter()
+                        .filter_map(|p| match p {
+                            AssistantContentPart::Text(t) => {
+                                Some(BedrockOutputContentBlock::Text { text: t.text })
+                            }
+                            AssistantContentPart::ToolCall {
+                                tool_call_id,
+                                tool_name,
+                                arguments,
+                                ..
+                            } => {
+                                use crate::providers::bedrock::response::BedrockOutputToolUse;
+                                let input: Value = match arguments {
+                                    ToolCallArguments::Valid(map) => serde_json::to_value(map)
+                                        .unwrap_or(Value::Object(Default::default())),
+                                    ToolCallArguments::Invalid(s) => serde_json::from_str(&s)
+                                        .unwrap_or(Value::Object(Default::default())),
+                                };
+                                Some(BedrockOutputContentBlock::ToolUse {
+                                    tool_use: BedrockOutputToolUse {
+                                        tool_use_id: tool_call_id,
+                                        name: tool_name,
+                                        input,
+                                    },
+                                })
+                            }
+                            _ => None,
+                        })
+                        .collect(),
+                };
+                Ok(BedrockOutputMessage {
+                    role: "assistant".to_string(),
+                    content: blocks,
+                })
+            }
+            _ => Err(ConvertError::UnsupportedInputType {
+                type_info: "Only Assistant messages can be converted to BedrockOutputMessage"
+                    .to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_json::json;
+
+    #[test]
+    fn test_bedrock_message_to_universal_user() {
+        let msg = BedrockMessage {
+            role: BedrockConversationRole::User,
+            content: vec![BedrockContentBlock::Text {
+                text: "Hello".to_string(),
+            }],
+        };
+
+        let message = <Message as TryFromLLM<BedrockMessage>>::try_from(msg).unwrap();
+        match message {
+            Message::User { content } => match content {
+                UserContent::String(s) => assert_eq!(s, "Hello"),
+                _ => panic!("Expected string content"),
+            },
+            _ => panic!("Expected user message"),
+        }
+    }
+
+    #[test]
+    fn test_bedrock_message_to_universal_assistant() {
+        let msg = BedrockMessage {
+            role: BedrockConversationRole::Assistant,
+            content: vec![BedrockContentBlock::Text {
+                text: "Hi there!".to_string(),
+            }],
+        };
+
+        let message = <Message as TryFromLLM<BedrockMessage>>::try_from(msg).unwrap();
+        match message {
+            Message::Assistant { content, .. } => match content {
+                AssistantContent::Array(parts) => {
+                    assert_eq!(parts.len(), 1);
+                    match &parts[0] {
+                        AssistantContentPart::Text(t) => assert_eq!(t.text, "Hi there!"),
+                        _ => panic!("Expected text part"),
+                    }
+                }
+                _ => panic!("Expected array content"),
+            },
+            _ => panic!("Expected assistant message"),
+        }
+    }
+
+    #[test]
+    fn test_bedrock_message_to_universal_tool_use() {
+        let msg = BedrockMessage {
+            role: BedrockConversationRole::Assistant,
+            content: vec![BedrockContentBlock::ToolUse {
+                tool_use: BedrockToolUseBlock {
+                    tool_use_id: "tool_123".to_string(),
+                    name: "get_weather".to_string(),
+                    input: json!({"location": "SF"}),
+                },
+            }],
+        };
+
+        let message = <Message as TryFromLLM<BedrockMessage>>::try_from(msg).unwrap();
+        match message {
+            Message::Assistant { content, .. } => match content {
+                AssistantContent::Array(parts) => {
+                    assert_eq!(parts.len(), 1);
+                    match &parts[0] {
+                        AssistantContentPart::ToolCall {
+                            tool_call_id,
+                            tool_name,
+                            ..
+                        } => {
+                            assert_eq!(tool_call_id, "tool_123");
+                            assert_eq!(tool_name, "get_weather");
+                        }
+                        _ => panic!("Expected tool call part"),
+                    }
+                }
+                _ => panic!("Expected array content"),
+            },
+            _ => panic!("Expected assistant message"),
+        }
+    }
+
+    #[test]
+    fn test_message_to_bedrock_user() {
+        let message = Message::User {
+            content: UserContent::String("Hello".to_string()),
+        };
+
+        let msg = <BedrockMessage as TryFromLLM<Message>>::try_from(message).unwrap();
+        assert_eq!(msg.role, BedrockConversationRole::User);
+        assert_eq!(msg.content.len(), 1);
+        match &msg.content[0] {
+            BedrockContentBlock::Text { text } => assert_eq!(text, "Hello"),
+            _ => panic!("Expected text block"),
+        }
+    }
+
+    #[test]
+    fn test_message_to_bedrock_assistant() {
+        let message = Message::Assistant {
+            content: AssistantContent::String("Hi there!".to_string()),
+            id: None,
+        };
+
+        let msg = <BedrockMessage as TryFromLLM<Message>>::try_from(message).unwrap();
+        assert_eq!(msg.role, BedrockConversationRole::Assistant);
+        assert_eq!(msg.content.len(), 1);
+        match &msg.content[0] {
+            BedrockContentBlock::Text { text } => assert_eq!(text, "Hi there!"),
+            _ => panic!("Expected text block"),
+        }
+    }
+
+    #[test]
+    fn test_message_to_bedrock_tool_call() {
+        let message = Message::Assistant {
+            content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
+                tool_call_id: "tool_123".to_string(),
+                tool_name: "get_weather".to_string(),
+                arguments: ToolCallArguments::from(r#"{"location":"SF"}"#.to_string()),
+                provider_options: None,
+                provider_executed: None,
+            }]),
+            id: None,
+        };
+
+        let msg = <BedrockMessage as TryFromLLM<Message>>::try_from(message).unwrap();
+        assert_eq!(msg.role, BedrockConversationRole::Assistant);
+        assert_eq!(msg.content.len(), 1);
+        match &msg.content[0] {
+            BedrockContentBlock::ToolUse { tool_use } => {
+                assert_eq!(tool_use.tool_use_id, "tool_123");
+                assert_eq!(tool_use.name, "get_weather");
+            }
+            _ => panic!("Expected tool use block"),
+        }
+    }
+
+    #[test]
+    fn test_bedrock_to_universal_simple() {
+        let request = ConverseRequest {
+            model_id: "test-model".to_string(),
+            messages: vec![BedrockMessage {
+                role: BedrockConversationRole::User,
+                content: vec![BedrockContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            }],
+            system: None,
+            inference_config: None,
+            tool_config: None,
+            guardrail_config: None,
+            additional_model_request_fields: None,
+            additional_model_response_field_paths: None,
+            prompt_variables: None,
+        };
+
+        let messages = bedrock_to_universal(&request).unwrap();
+        assert_eq!(messages.len(), 1);
+        match &messages[0] {
+            Message::User { content } => match content {
+                UserContent::String(s) => assert_eq!(s, "Hello"),
+                _ => panic!("Expected string content"),
+            },
+            _ => panic!("Expected user message"),
+        }
+    }
+
+    #[test]
+    fn test_bedrock_to_universal_with_tool_use() {
+        let request = ConverseRequest {
+            model_id: "test-model".to_string(),
+            messages: vec![BedrockMessage {
+                role: BedrockConversationRole::Assistant,
+                content: vec![BedrockContentBlock::ToolUse {
+                    tool_use: BedrockToolUseBlock {
+                        tool_use_id: "tool_123".to_string(),
+                        name: "get_weather".to_string(),
+                        input: json!({"location": "SF"}),
+                    },
+                }],
+            }],
+            system: None,
+            inference_config: None,
+            tool_config: None,
+            guardrail_config: None,
+            additional_model_request_fields: None,
+            additional_model_response_field_paths: None,
+            prompt_variables: None,
+        };
+
+        let messages = bedrock_to_universal(&request).unwrap();
+        assert_eq!(messages.len(), 1);
+        match &messages[0] {
+            Message::Assistant { content, .. } => match content {
+                AssistantContent::Array(parts) => {
+                    assert_eq!(parts.len(), 1);
+                    match &parts[0] {
+                        AssistantContentPart::ToolCall {
+                            tool_call_id,
+                            tool_name,
+                            ..
+                        } => {
+                            assert_eq!(tool_call_id, "tool_123");
+                            assert_eq!(tool_name, "get_weather");
+                        }
+                        _ => panic!("Expected tool call"),
+                    }
+                }
+                _ => panic!("Expected array content"),
+            },
+            _ => panic!("Expected assistant message"),
+        }
+    }
+
+    #[test]
+    fn test_universal_to_bedrock_simple() {
+        let messages = vec![Message::User {
+            content: UserContent::String("Hello".to_string()),
+        }];
+
+        let result = universal_to_bedrock(&messages).unwrap();
+        let expected = json!([{
+            "role": "user",
+            "content": [{"text": "Hello"}]
+        }]);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_universal_to_bedrock_with_tool_call() {
+        let messages = vec![Message::Assistant {
+            content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
+                tool_call_id: "tool_123".to_string(),
+                tool_name: "get_weather".to_string(),
+                arguments: ToolCallArguments::from(r#"{"location":"SF"}"#.to_string()),
+                provider_options: None,
+                provider_executed: None,
+            }]),
+            id: None,
+        }];
+
+        let result = universal_to_bedrock(&messages).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["role"], "assistant");
+        assert!(arr[0]["content"][0].get("toolUse").is_some());
+    }
+}

--- a/crates/lingua/src/providers/bedrock/detect.rs
+++ b/crates/lingua/src/providers/bedrock/detect.rs
@@ -1,0 +1,216 @@
+/*!
+Bedrock Converse format detection.
+
+This module provides functions to detect if a payload is in
+AWS Bedrock Converse API format by attempting to deserialize
+into the Bedrock struct types.
+*/
+
+use crate::providers::bedrock::request::ConverseRequest;
+use crate::serde_json::{self, Value};
+use thiserror::Error;
+
+/// Error type for Bedrock payload detection
+#[derive(Debug, Error)]
+pub enum DetectionError {
+    #[error("Deserialization failed: {0}")]
+    DeserializationFailed(String),
+}
+
+/// Attempt to parse a JSON Value as Bedrock ConverseRequest.
+///
+/// Returns the parsed struct if successful, or an error if the payload
+/// is not valid Bedrock Converse format.
+///
+/// # Examples
+///
+/// ```rust
+/// use lingua::serde_json::json;
+/// use lingua::providers::bedrock::detect::try_parse_bedrock;
+///
+/// let bedrock_payload = json!({
+///     "modelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+///     "messages": [{
+///         "role": "user",
+///         "content": [{"text": "Hello"}]
+///     }],
+///     "inferenceConfig": {
+///         "maxTokens": 1024
+///     }
+/// });
+///
+/// assert!(try_parse_bedrock(&bedrock_payload).is_ok());
+/// ```
+pub fn try_parse_bedrock(payload: &Value) -> Result<ConverseRequest, DetectionError> {
+    serde_json::from_value(payload.clone())
+        .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::bedrock::request::{
+        BedrockContentBlock, BedrockConversationRole, BedrockInferenceConfiguration,
+        BedrockMessage, BedrockToolResultBlock, BedrockToolResultContent, BedrockToolUseBlock,
+        ConverseRequest,
+    };
+    use crate::serde_json::{self, json};
+
+    #[test]
+    fn test_try_parse_bedrock_with_model_id() {
+        let request = ConverseRequest {
+            model_id: "anthropic.claude-3-sonnet-20240229-v1:0".to_string(),
+            messages: vec![BedrockMessage {
+                role: BedrockConversationRole::User,
+                content: vec![BedrockContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            }],
+            system: None,
+            inference_config: None,
+            tool_config: None,
+            guardrail_config: None,
+            additional_model_request_fields: None,
+            additional_model_response_field_paths: None,
+            prompt_variables: None,
+        };
+
+        let payload = serde_json::to_value(&request).unwrap();
+        assert!(try_parse_bedrock(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_bedrock_with_inference_config() {
+        let request = ConverseRequest {
+            model_id: "anthropic.claude-3-sonnet-20240229-v1:0".to_string(),
+            messages: vec![BedrockMessage {
+                role: BedrockConversationRole::User,
+                content: vec![BedrockContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            }],
+            system: None,
+            inference_config: Some(BedrockInferenceConfiguration {
+                max_tokens: Some(1024),
+                temperature: None,
+                top_p: None,
+                stop_sequences: None,
+            }),
+            tool_config: None,
+            guardrail_config: None,
+            additional_model_request_fields: None,
+            additional_model_response_field_paths: None,
+            prompt_variables: None,
+        };
+
+        let payload = serde_json::to_value(&request).unwrap();
+        assert!(try_parse_bedrock(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_bedrock_with_tool_use() {
+        let request = ConverseRequest {
+            model_id: "anthropic.claude-3-sonnet-20240229-v1:0".to_string(),
+            messages: vec![BedrockMessage {
+                role: BedrockConversationRole::Assistant,
+                content: vec![BedrockContentBlock::ToolUse {
+                    tool_use: BedrockToolUseBlock {
+                        tool_use_id: "tool_123".to_string(),
+                        name: "get_weather".to_string(),
+                        input: json!({"location": "SF"}),
+                    },
+                }],
+            }],
+            system: None,
+            inference_config: None,
+            tool_config: None,
+            guardrail_config: None,
+            additional_model_request_fields: None,
+            additional_model_response_field_paths: None,
+            prompt_variables: None,
+        };
+
+        let payload = serde_json::to_value(&request).unwrap();
+        assert!(try_parse_bedrock(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_bedrock_with_tool_result() {
+        let request = ConverseRequest {
+            model_id: "anthropic.claude-3-sonnet-20240229-v1:0".to_string(),
+            messages: vec![BedrockMessage {
+                role: BedrockConversationRole::User,
+                content: vec![BedrockContentBlock::ToolResult {
+                    tool_result: BedrockToolResultBlock {
+                        tool_use_id: "tool_123".to_string(),
+                        content: vec![BedrockToolResultContent::Text {
+                            text: "72°F".to_string(),
+                        }],
+                        status: None,
+                    },
+                }],
+            }],
+            system: None,
+            inference_config: None,
+            tool_config: None,
+            guardrail_config: None,
+            additional_model_request_fields: None,
+            additional_model_response_field_paths: None,
+            prompt_variables: None,
+        };
+
+        let payload = serde_json::to_value(&request).unwrap();
+        assert!(try_parse_bedrock(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_bedrock_fails_for_openai_format() {
+        // OpenAI format uses "model" not "modelId" - should fail struct deserialization
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(try_parse_bedrock(&payload).is_err());
+    }
+
+    #[test]
+    fn test_try_parse_bedrock_fails_for_anthropic_format() {
+        // Anthropic format uses "model" not "modelId" - should fail struct deserialization
+        let payload = json!({
+            "model": "claude-3-5-sonnet",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(try_parse_bedrock(&payload).is_err());
+    }
+
+    #[test]
+    fn test_try_parse_bedrock_success() {
+        let payload = json!({
+            "modelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "messages": [{
+                "role": "user",
+                "content": [{"text": "Hello"}]
+            }]
+        });
+
+        let result = try_parse_bedrock(&payload);
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.model_id, "anthropic.claude-3-sonnet-20240229-v1:0");
+    }
+
+    #[test]
+    fn test_try_parse_bedrock_fails_without_model_id() {
+        // Missing modelId - required field
+        let payload = json!({
+            "messages": [{
+                "role": "user",
+                "content": [{"text": "Hello"}]
+            }]
+        });
+
+        let result = try_parse_bedrock(&payload);
+        assert!(result.is_err());
+    }
+}

--- a/crates/lingua/src/providers/bedrock/mod.rs
+++ b/crates/lingua/src/providers/bedrock/mod.rs
@@ -5,15 +5,26 @@ This module contains type definitions for Amazon Bedrock's Converse API
 using the official AWS SDK types for maximum compatibility.
 */
 
+pub mod adapter;
+pub mod convert;
+pub mod detect;
 pub mod request;
 pub mod response;
+
+// Re-export adapter
+pub use adapter::BedrockAdapter;
 
 // Re-export commonly used AWS SDK types (note: these don't have Serde by default)
 pub use aws_sdk_bedrockruntime::types::{
     ContentBlock, ConversationRole, Message, SystemContentBlock,
 };
 
+// Re-export detection functions
+pub use detect::{try_parse_bedrock, DetectionError};
+
+// Re-export conversion functions
+pub use convert::{bedrock_to_universal, universal_to_bedrock};
+
 // Re-export our custom request/response wrappers
 pub use request::{ConverseRequest, ConverseStreamRequest};
-
 pub use response::{ConverseResponse, ConverseStreamResponse};

--- a/crates/lingua/src/providers/bedrock/request.rs
+++ b/crates/lingua/src/providers/bedrock/request.rs
@@ -12,6 +12,7 @@ use ts_rs::TS;
 
 /// Main Converse API request parameters
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct ConverseRequest {
     /// Model identifier for the foundation model
@@ -52,6 +53,7 @@ pub struct ConverseRequest {
 
 /// Streaming Converse API request parameters
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct ConverseStreamRequest {
     /// Model identifier for the foundation model
@@ -111,21 +113,32 @@ pub enum BedrockConversationRole {
 }
 
 /// Content block types
+///
+/// Bedrock uses an untagged format where the key name indicates the type:
+/// - `{"text": "Hello"}` for text content
+/// - `{"toolUse": {...}}` for tool use blocks
+/// - `{"toolResult": {...}}` for tool result blocks
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 // #[ts(export, export_to = "bindings/typescript/")]
-#[serde(tag = "type")]
+#[serde(untagged)]
 pub enum BedrockContentBlock {
-    #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+    },
 
-    #[serde(rename = "image")]
-    Image { image: BedrockImageBlock },
+    Image {
+        image: BedrockImageBlock,
+    },
 
-    #[serde(rename = "toolUse")]
-    ToolUse { tool_use: BedrockToolUseBlock },
+    ToolUse {
+        #[serde(rename = "toolUse")]
+        tool_use: BedrockToolUseBlock,
+    },
 
-    #[serde(rename = "toolResult")]
-    ToolResult { tool_result: BedrockToolResultBlock },
+    ToolResult {
+        #[serde(rename = "toolResult")]
+        tool_result: BedrockToolResultBlock,
+    },
 }
 
 /// Image content block
@@ -160,6 +173,7 @@ pub struct BedrockImageSource {
 
 /// Tool use content block
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockToolUseBlock {
     /// Unique identifier for the tool use
@@ -175,6 +189,7 @@ pub struct BedrockToolUseBlock {
 
 /// Tool result content block
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockToolResultBlock {
     /// Tool use ID this result corresponds to
@@ -191,19 +206,20 @@ pub struct BedrockToolResultBlock {
 /// Tool result content
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 // #[ts(export, export_to = "bindings/typescript/")]
-#[serde(tag = "type")]
+#[serde(untagged)]
 pub enum BedrockToolResultContent {
-    #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+    },
 
-    #[serde(rename = "json")]
     Json {
         #[ts(type = "any")]
         json: serde_json::Value,
     },
 
-    #[serde(rename = "image")]
-    Image { image: BedrockImageBlock },
+    Image {
+        image: BedrockImageBlock,
+    },
 }
 
 /// Tool result status
@@ -225,6 +241,7 @@ pub struct BedrockSystemContentBlock {
 
 /// Inference configuration
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockInferenceConfiguration {
     /// Maximum number of tokens to generate
@@ -246,6 +263,7 @@ pub struct BedrockInferenceConfiguration {
 
 /// Tool configuration
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockToolConfiguration {
     /// Available tools
@@ -258,6 +276,7 @@ pub struct BedrockToolConfiguration {
 
 /// Tool definition
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockTool {
     /// Tool specification
@@ -266,6 +285,7 @@ pub struct BedrockTool {
 
 /// Tool specification
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockToolSpec {
     /// Tool name
@@ -305,6 +325,7 @@ pub enum BedrockToolChoice {
 
 /// Guardrail configuration
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockGuardrailConfiguration {
     /// Guardrail identifier

--- a/crates/lingua/src/providers/bedrock/response.rs
+++ b/crates/lingua/src/providers/bedrock/response.rs
@@ -11,6 +11,7 @@ use ts_rs::TS;
 
 /// Main Converse API response
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct ConverseResponse {
     /// The model's response output
@@ -57,17 +58,21 @@ pub struct BedrockOutputMessage {
 /// Output content block types
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 // #[ts(export, export_to = "bindings/typescript/")]
-#[serde(tag = "type")]
+#[serde(untagged)]
 pub enum BedrockOutputContentBlock {
-    #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+    },
 
-    #[serde(rename = "toolUse")]
-    ToolUse { tool_use: BedrockOutputToolUse },
+    ToolUse {
+        #[serde(rename = "toolUse")]
+        tool_use: BedrockOutputToolUse,
+    },
 }
 
 /// Tool use in output
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockOutputToolUse {
     /// Unique identifier for the tool use
@@ -100,6 +105,7 @@ pub enum BedrockStopReason {
 
 /// Token usage statistics
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockTokenUsage {
     /// Number of input tokens
@@ -114,6 +120,7 @@ pub struct BedrockTokenUsage {
 
 /// Performance metrics for the request
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockConverseMetrics {
     /// Latency in milliseconds
@@ -122,6 +129,7 @@ pub struct BedrockConverseMetrics {
 
 /// Streaming Converse API response event
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 #[serde(tag = "type")]
 pub enum ConverseStreamResponse {
@@ -180,6 +188,7 @@ pub enum ConverseStreamResponse {
 
 /// Content block start event details
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 #[serde(tag = "type")]
 pub enum BedrockContentBlockStart {
@@ -201,6 +210,7 @@ pub enum BedrockContentBlockDelta {
 
 /// Trace information for debugging and monitoring
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockConverseTrace {
     /// Unique identifier for the trace
@@ -214,6 +224,7 @@ pub struct BedrockConverseTrace {
 
 /// Guardrail trace information
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockGuardrailTrace {
     /// Action taken by the guardrail
@@ -231,6 +242,7 @@ pub struct BedrockGuardrailTrace {
 
 /// Individual guardrail assessment
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockGuardrailAssessment {
     /// Content policy assessment
@@ -276,6 +288,7 @@ pub struct BedrockContentFilter {
 
 /// Sensitive information policy assessment
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockSensitiveInformationPolicyAssessment {
     /// PII entities detected
@@ -289,6 +302,7 @@ pub struct BedrockSensitiveInformationPolicyAssessment {
 
 /// PII entity details
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockPIIEntity {
     /// Entity type
@@ -305,6 +319,7 @@ pub struct BedrockPIIEntity {
 
 /// Regex match details
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockRegexMatch {
     /// Regex name
@@ -329,6 +344,7 @@ pub struct BedrockTopicPolicyAssessment {
 
 /// Topic details
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockTopic {
     /// Topic name
@@ -344,6 +360,7 @@ pub struct BedrockTopic {
 
 /// Word policy assessment
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockWordPolicyAssessment {
     /// Custom words that were detected
@@ -357,6 +374,7 @@ pub struct BedrockWordPolicyAssessment {
 
 /// Custom word details
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockCustomWord {
     /// Match text
@@ -369,6 +387,7 @@ pub struct BedrockCustomWord {
 
 /// Managed word list details
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 // #[ts(export, export_to = "bindings/typescript/")]
 pub struct BedrockManagedWordList {
     /// Match text

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -269,7 +269,6 @@ impl ProviderAdapter for GoogleAdapter {
             messages,
             usage,
             finish_reason,
-            extras: Map::new(),
         })
     }
 
@@ -372,7 +371,7 @@ impl ProviderAdapter for GoogleAdapter {
                 .map(|r| match r {
                     "STOP" => "stop".to_string(),
                     "MAX_TOKENS" => "length".to_string(),
-                    "SAFETY" | "RECITATION" | "OTHER" => "stop".to_string(),
+                    "SAFETY" | "RECITATION" | "OTHER" => "content_filter".to_string(),
                     other => other.to_lowercase(),
                 });
 

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -1,0 +1,548 @@
+/*!
+Google AI provider adapter for GenerateContent API.
+
+Google's API has some unique characteristics:
+- Uses `contents` instead of `messages`
+- Generation params are in `generationConfig` object
+- Uses camelCase field names (e.g., `maxOutputTokens`)
+- Streaming is endpoint-based, not parameter-based
+*/
+
+use crate::capabilities::ProviderFormat;
+use crate::processing::adapters::{collect_extras, ProviderAdapter};
+use crate::processing::transform::TransformError;
+use crate::providers::google::detect::{
+    try_parse_google, GoogleContent, GoogleGenerateContentRequest, GoogleGenerationConfig,
+};
+use crate::serde_json::{self, Map, Value};
+use crate::universal::convert::TryFromLLM;
+use crate::universal::message::Message;
+use crate::universal::{
+    extract_system_messages, flatten_consecutive_messages, FinishReason, UniversalParams,
+    UniversalRequest, UniversalResponse, UniversalStreamChoice, UniversalStreamChunk,
+    UniversalUsage, UserContent,
+};
+
+/// Known request fields for Google GenerateContent API.
+/// Fields not in this list go into `extras`.
+const GOOGLE_KNOWN_KEYS: &[&str] = &[
+    "contents",
+    "generationConfig",
+    "systemInstruction",
+    "safetySettings",
+    "tools",
+    "toolConfig",
+    "model",
+];
+
+/// Adapter for Google AI GenerateContent API.
+pub struct GoogleAdapter;
+
+impl ProviderAdapter for GoogleAdapter {
+    fn format(&self) -> ProviderFormat {
+        ProviderFormat::Google
+    }
+
+    fn directory_name(&self) -> &'static str {
+        "google"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Google"
+    }
+
+    fn detect_request(&self, payload: &Value) -> bool {
+        try_parse_google(payload).is_ok()
+    }
+
+    fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
+        let extras = collect_extras(&payload, GOOGLE_KNOWN_KEYS);
+        let model = payload
+            .get("model")
+            .and_then(Value::as_str)
+            .map(String::from);
+
+        let request: GoogleGenerateContentRequest = serde_json::from_value(payload)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let messages = <Vec<Message> as TryFromLLM<Vec<GoogleContent>>>::try_from(request.contents)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        // Extract params from generationConfig
+        let (temperature, top_p, top_k, max_tokens, stop) =
+            if let Some(config) = &request.generation_config {
+                (
+                    config.temperature,
+                    config.top_p,
+                    config.top_k.map(|k| k as i64),
+                    config.max_output_tokens.map(|t| t as i64),
+                    config
+                        .stop_sequences
+                        .as_ref()
+                        .and_then(|s| serde_json::to_value(s).ok()),
+                )
+            } else {
+                (None, None, None, None, None)
+            };
+
+        let params = UniversalParams {
+            temperature,
+            top_p,
+            top_k,
+            max_tokens,
+            stop,
+            tools: request.tools.and_then(|t| serde_json::to_value(t).ok()),
+            tool_choice: None, // Google uses different mechanism
+            response_format: None,
+            seed: None, // Google doesn't support seed
+            presence_penalty: None,
+            frequency_penalty: None,
+            stream: None, // Google uses endpoint-based streaming
+        };
+
+        Ok(UniversalRequest {
+            model,
+            messages,
+            params,
+            extras,
+        })
+    }
+
+    fn request_from_universal(&self, req: &UniversalRequest) -> Result<Value, TransformError> {
+        // Extract system messages (Google requires them in systemInstruction, not contents)
+        let mut messages = req.messages.clone();
+        let system_contents = extract_system_messages(&mut messages);
+
+        // Flatten consecutive messages of the same role (Google doesn't allow them)
+        flatten_consecutive_messages(&mut messages);
+
+        // Convert messages to Google contents
+        let google_contents: Vec<GoogleContent> =
+            <Vec<GoogleContent> as TryFromLLM<Vec<Message>>>::try_from(messages)
+                .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+        let mut obj = Map::new();
+
+        // Insert model if present (though Google often uses URL-based model selection)
+        if let Some(model) = &req.model {
+            obj.insert("model".into(), Value::String(model.clone()));
+        }
+
+        obj.insert(
+            "contents".into(),
+            serde_json::to_value(google_contents)
+                .map_err(|e| TransformError::SerializationFailed(e.to_string()))?,
+        );
+
+        // Add systemInstruction if system messages were present
+        if !system_contents.is_empty() {
+            let system_text = system_contents
+                .into_iter()
+                .map(|c| match c {
+                    UserContent::String(s) => s,
+                    UserContent::Array(parts) => parts
+                        .into_iter()
+                        .filter_map(|p| {
+                            if let crate::universal::UserContentPart::Text(t) = p {
+                                Some(t.text)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            obj.insert(
+                "systemInstruction".into(),
+                serde_json::json!({
+                    "parts": [{"text": system_text}]
+                }),
+            );
+        }
+
+        // Build generationConfig if any params are set
+        let has_params = req.params.temperature.is_some()
+            || req.params.top_p.is_some()
+            || req.params.top_k.is_some()
+            || req.params.max_tokens.is_some()
+            || req.params.stop.is_some();
+
+        if has_params {
+            let config = GoogleGenerationConfig {
+                temperature: req.params.temperature,
+                top_p: req.params.top_p,
+                top_k: req.params.top_k.map(|k| k as i32),
+                max_output_tokens: req.params.max_tokens.map(|t| t as i32),
+                stop_sequences: req.params.stop.as_ref().and_then(|v| {
+                    if let Value::Array(arr) = v {
+                        Some(
+                            arr.iter()
+                                .filter_map(|s| s.as_str().map(String::from))
+                                .collect(),
+                        )
+                    } else if let Value::String(s) = v {
+                        Some(vec![s.clone()])
+                    } else {
+                        None
+                    }
+                }),
+            };
+
+            obj.insert(
+                "generationConfig".into(),
+                serde_json::to_value(config)
+                    .map_err(|e| TransformError::SerializationFailed(e.to_string()))?,
+            );
+        }
+
+        // Add tools if present
+        if let Some(tools) = &req.params.tools {
+            obj.insert("tools".into(), tools.clone());
+        }
+
+        // Merge extras - only include Google-known fields
+        // This filters out OpenAI-specific fields like stream_options that would cause
+        // Google to reject the request with "Unknown name: stream_options"
+        for (k, v) in &req.extras {
+            if GOOGLE_KNOWN_KEYS.contains(&k.as_str()) {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+
+        Ok(Value::Object(obj))
+    }
+
+    fn apply_defaults(&self, _req: &mut UniversalRequest) {
+        // Google doesn't require any specific defaults
+    }
+
+    fn detect_response(&self, payload: &Value) -> bool {
+        // Google response has candidates[].content structure
+        payload
+            .get("candidates")
+            .and_then(Value::as_array)
+            .is_some_and(|arr| arr.first().and_then(|c| c.get("content")).is_some())
+    }
+
+    fn response_to_universal(&self, payload: Value) -> Result<UniversalResponse, TransformError> {
+        let candidates = payload
+            .get("candidates")
+            .and_then(Value::as_array)
+            .ok_or_else(|| TransformError::ToUniversalFailed("missing candidates".to_string()))?;
+
+        let mut messages = Vec::new();
+        let mut finish_reason = None;
+
+        for candidate in candidates {
+            if let Some(content_val) = candidate.get("content") {
+                let content: GoogleContent = serde_json::from_value(content_val.clone())
+                    .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+                let universal = <Message as TryFromLLM<GoogleContent>>::try_from(content)
+                    .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+                messages.push(universal);
+            }
+
+            // Get finishReason from first candidate
+            if finish_reason.is_none() {
+                if let Some(reason) = candidate.get("finishReason").and_then(Value::as_str) {
+                    finish_reason = Some(reason.parse().unwrap());
+                }
+            }
+        }
+
+        let usage = payload.get("usageMetadata").map(|u| UniversalUsage {
+            prompt_tokens: u.get("promptTokenCount").and_then(Value::as_i64),
+            completion_tokens: u.get("candidatesTokenCount").and_then(Value::as_i64),
+            prompt_cached_tokens: u.get("cachedContentTokenCount").and_then(Value::as_i64),
+            prompt_cache_creation_tokens: None, // Google doesn't report cache creation tokens
+            completion_reasoning_tokens: u.get("thoughtsTokenCount").and_then(Value::as_i64),
+        });
+
+        Ok(UniversalResponse {
+            model: payload
+                .get("modelVersion")
+                .and_then(Value::as_str)
+                .map(String::from),
+            messages,
+            usage,
+            finish_reason,
+            extras: Map::new(),
+        })
+    }
+
+    fn response_from_universal(&self, resp: &UniversalResponse) -> Result<Value, TransformError> {
+        let finish_reason = self
+            .map_finish_reason(resp.finish_reason.as_ref())
+            .unwrap_or_else(|| "STOP".to_string());
+
+        let candidates: Vec<Value> = resp
+            .messages
+            .iter()
+            .enumerate()
+            .map(|(i, msg)| {
+                let content = <GoogleContent as TryFromLLM<Message>>::try_from(msg.clone())
+                    .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+                let content_value = serde_json::to_value(&content)
+                    .map_err(|e| TransformError::SerializationFailed(e.to_string()))?;
+
+                Ok(serde_json::json!({
+                    "index": i,
+                    "content": content_value,
+                    "finishReason": finish_reason
+                }))
+            })
+            .collect::<Result<Vec<_>, TransformError>>()?;
+
+        let mut obj = serde_json::json!({
+            "candidates": candidates
+        });
+
+        if let Some(usage) = &resp.usage {
+            let prompt = usage.prompt_tokens.unwrap_or(0);
+            let completion = usage.completion_tokens.unwrap_or(0);
+            obj.as_object_mut().unwrap().insert(
+                "usageMetadata".into(),
+                serde_json::json!({
+                    "promptTokenCount": prompt,
+                    "candidatesTokenCount": completion,
+                    "totalTokenCount": prompt + completion
+                }),
+            );
+        }
+
+        Ok(obj)
+    }
+
+    fn map_finish_reason(&self, reason: Option<&FinishReason>) -> Option<String> {
+        reason.map(|r| match r {
+            FinishReason::Stop => "STOP".to_string(),
+            FinishReason::Length => "MAX_TOKENS".to_string(),
+            FinishReason::ToolCalls => "TOOL_CALLS".to_string(),
+            FinishReason::ContentFilter => "SAFETY".to_string(),
+            FinishReason::Other(s) => s.clone(),
+        })
+    }
+
+    // =========================================================================
+    // Streaming response handling
+    // =========================================================================
+
+    fn detect_stream_response(&self, payload: &Value) -> bool {
+        // Google streaming uses the same format as non-streaming (candidates array)
+        // The response_to_universal detection already handles this
+        self.detect_response(payload)
+    }
+
+    fn stream_to_universal(
+        &self,
+        payload: Value,
+    ) -> Result<Option<UniversalStreamChunk>, TransformError> {
+        let candidates = payload
+            .get("candidates")
+            .and_then(Value::as_array)
+            .ok_or_else(|| TransformError::ToUniversalFailed("missing candidates".to_string()))?;
+
+        let mut choices = Vec::new();
+
+        for candidate in candidates {
+            let index = candidate.get("index").and_then(Value::as_u64).unwrap_or(0) as u32;
+
+            // Extract text from content.parts
+            let text: String = candidate
+                .get("content")
+                .and_then(|c| c.get("parts"))
+                .and_then(Value::as_array)
+                .map(|parts| {
+                    parts
+                        .iter()
+                        .filter_map(|p| p.get("text").and_then(Value::as_str))
+                        .collect::<Vec<_>>()
+                        .join("")
+                })
+                .unwrap_or_default();
+
+            // Map finish reason
+            let finish_reason = candidate
+                .get("finishReason")
+                .and_then(Value::as_str)
+                .map(|r| match r {
+                    "STOP" => "stop".to_string(),
+                    "MAX_TOKENS" => "length".to_string(),
+                    "SAFETY" | "RECITATION" | "OTHER" => "stop".to_string(),
+                    other => other.to_lowercase(),
+                });
+
+            choices.push(UniversalStreamChoice {
+                index,
+                delta: Some(serde_json::json!({
+                    "role": "assistant",
+                    "content": text
+                })),
+                finish_reason,
+            });
+        }
+
+        // Extract usage from usageMetadata
+        let usage = payload.get("usageMetadata").map(|u| UniversalUsage {
+            prompt_tokens: u.get("promptTokenCount").and_then(Value::as_i64),
+            completion_tokens: u.get("candidatesTokenCount").and_then(Value::as_i64),
+            prompt_cached_tokens: u.get("cachedContentTokenCount").and_then(Value::as_i64),
+            prompt_cache_creation_tokens: None,
+            completion_reasoning_tokens: u.get("thoughtsTokenCount").and_then(Value::as_i64),
+        });
+
+        let model = payload
+            .get("modelVersion")
+            .and_then(Value::as_str)
+            .map(String::from);
+
+        let id = payload
+            .get("responseId")
+            .and_then(Value::as_str)
+            .map(String::from);
+
+        Ok(Some(UniversalStreamChunk::new(
+            id, model, choices, None, usage,
+        )))
+    }
+
+    fn stream_from_universal(&self, chunk: &UniversalStreamChunk) -> Result<Value, TransformError> {
+        if chunk.is_keep_alive() {
+            // Google doesn't have a keep-alive event, return empty candidates
+            return Ok(serde_json::json!({
+                "candidates": []
+            }));
+        }
+
+        let candidates: Vec<Value> = chunk
+            .choices
+            .iter()
+            .map(|c| {
+                // Extract text content from delta
+                let text = c
+                    .delta
+                    .as_ref()
+                    .and_then(|d| d.get("content"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+
+                // Map finish reason to Google format
+                let finish_reason = c.finish_reason.as_ref().map(|r| match r.as_str() {
+                    "stop" => "STOP",
+                    "length" => "MAX_TOKENS",
+                    "tool_calls" => "TOOL_CALLS",
+                    "content_filter" => "SAFETY",
+                    other => other,
+                });
+
+                let mut candidate = serde_json::json!({
+                    "index": c.index,
+                    "content": {
+                        "parts": [{"text": text}],
+                        "role": "model"
+                    }
+                });
+
+                if let Some(reason) = finish_reason {
+                    candidate
+                        .as_object_mut()
+                        .unwrap()
+                        .insert("finishReason".into(), Value::String(reason.to_string()));
+                }
+
+                candidate
+            })
+            .collect();
+
+        let mut obj = serde_json::json!({
+            "candidates": candidates
+        });
+
+        let obj_map = obj.as_object_mut().unwrap();
+
+        if let Some(ref id) = chunk.id {
+            obj_map.insert("responseId".into(), Value::String(id.clone()));
+        }
+        if let Some(ref model) = chunk.model {
+            obj_map.insert("modelVersion".into(), Value::String(model.clone()));
+        }
+        if let Some(ref usage) = chunk.usage {
+            let prompt = usage.prompt_tokens.unwrap_or(0);
+            let completion = usage.completion_tokens.unwrap_or(0);
+            obj_map.insert(
+                "usageMetadata".into(),
+                serde_json::json!({
+                    "promptTokenCount": prompt,
+                    "candidatesTokenCount": completion,
+                    "totalTokenCount": prompt + completion
+                }),
+            );
+        }
+
+        Ok(obj)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_json::json;
+
+    #[test]
+    fn test_google_detect_request() {
+        let adapter = GoogleAdapter;
+        let payload = json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "Hello"}]
+            }]
+        });
+        assert!(adapter.detect_request(&payload));
+    }
+
+    #[test]
+    fn test_google_passthrough() {
+        let adapter = GoogleAdapter;
+        let payload = json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "Hello"}]
+            }],
+            "generationConfig": {
+                "temperature": 0.7,
+                "maxOutputTokens": 1024
+            }
+        });
+
+        let universal = adapter.request_to_universal(payload).unwrap();
+        assert_eq!(universal.params.temperature, Some(0.7));
+        assert_eq!(universal.params.max_tokens, Some(1024));
+
+        let reconstructed = adapter.request_from_universal(&universal).unwrap();
+        assert!(reconstructed.get("contents").is_some());
+        assert!(reconstructed.get("generationConfig").is_some());
+    }
+
+    #[test]
+    fn test_google_preserves_extras() {
+        let adapter = GoogleAdapter;
+        let payload = json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "Hello"}]
+            }],
+            "safetySettings": [{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}]
+        });
+
+        let universal = adapter.request_to_universal(payload).unwrap();
+        // safetySettings is a known key, so it won't be in extras
+        // but it should be preserved through serialization
+
+        let reconstructed = adapter.request_from_universal(&universal).unwrap();
+        assert!(reconstructed.get("contents").is_some());
+    }
+}

--- a/crates/lingua/src/providers/google/convert.rs
+++ b/crates/lingua/src/providers/google/convert.rs
@@ -1,0 +1,495 @@
+/*!
+Google format conversions.
+
+This module provides TryFromLLM trait implementations for converting between
+Google's GenerateContent API format and Lingua's universal message format.
+*/
+
+use crate::error::ConvertError;
+use crate::providers::google::detect::{
+    GoogleBlob, GoogleContent, GoogleFunctionCall, GoogleFunctionResponse,
+    GoogleGenerateContentRequest, GooglePart,
+};
+use crate::serde_json::{self, Value};
+use crate::universal::convert::TryFromLLM;
+use crate::universal::message::{
+    AssistantContent, AssistantContentPart, Message, TextContentPart, ToolCallArguments,
+    ToolContentPart, ToolResultContentPart, UserContent, UserContentPart,
+};
+
+// ============================================================================
+// Google Content -> Universal Message
+// ============================================================================
+
+impl TryFromLLM<GoogleContent> for Message {
+    type Error = ConvertError;
+
+    fn try_from(content: GoogleContent) -> Result<Self, Self::Error> {
+        let role = content.role.as_deref().unwrap_or("user");
+
+        // Collect text parts
+        let text_parts: Vec<String> = content
+            .parts
+            .iter()
+            .filter_map(|part| part.text.clone())
+            .collect();
+        let text = text_parts.join("");
+
+        // Check for function calls/responses
+        let function_calls: Vec<_> = content
+            .parts
+            .iter()
+            .filter_map(|part| part.function_call.as_ref())
+            .collect();
+
+        let function_responses: Vec<_> = content
+            .parts
+            .iter()
+            .filter_map(|part| part.function_response.as_ref())
+            .collect();
+
+        if !function_calls.is_empty() {
+            // Model message with function calls
+            let mut parts = Vec::new();
+
+            if !text.is_empty() {
+                parts.push(AssistantContentPart::Text(TextContentPart {
+                    text,
+                    provider_options: None,
+                }));
+            }
+
+            for fc in function_calls {
+                parts.push(AssistantContentPart::ToolCall {
+                    tool_call_id: fc.name.clone(), // Google uses name as ID
+                    tool_name: fc.name.clone(),
+                    arguments: ToolCallArguments::from(
+                        serde_json::to_string(&fc.args).unwrap_or_default(),
+                    ),
+                    provider_options: None,
+                    provider_executed: None,
+                });
+            }
+
+            Ok(Message::Assistant {
+                content: AssistantContent::Array(parts),
+                id: None,
+            })
+        } else if !function_responses.is_empty() {
+            // User message with function responses (tool results)
+            let tool_parts: Vec<ToolContentPart> = function_responses
+                .iter()
+                .map(|fr| {
+                    ToolContentPart::ToolResult(ToolResultContentPart {
+                        tool_call_id: fr.name.clone(),
+                        tool_name: fr.name.clone(),
+                        output: fr.response.clone(),
+                        provider_options: None,
+                    })
+                })
+                .collect();
+
+            Ok(Message::Tool {
+                content: tool_parts,
+            })
+        } else {
+            // Regular text message
+            match role {
+                "user" => Ok(Message::User {
+                    content: UserContent::String(text),
+                }),
+                "model" => Ok(Message::Assistant {
+                    content: AssistantContent::Array(vec![AssistantContentPart::Text(
+                        TextContentPart {
+                            text,
+                            provider_options: None,
+                        },
+                    )]),
+                    id: None,
+                }),
+                _ => {
+                    // Treat unknown roles as user
+                    Ok(Message::User {
+                        content: UserContent::String(text),
+                    })
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Universal Message -> Google Content
+// ============================================================================
+
+impl TryFromLLM<Message> for GoogleContent {
+    type Error = ConvertError;
+
+    fn try_from(message: Message) -> Result<Self, Self::Error> {
+        let (role, parts) = match message {
+            Message::System { content } => {
+                let text = match content {
+                    UserContent::String(s) => format!("System: {}", s),
+                    UserContent::Array(parts) => {
+                        let texts: Vec<String> = parts
+                            .into_iter()
+                            .filter_map(|p| match p {
+                                UserContentPart::Text(t) => Some(t.text),
+                                _ => None,
+                            })
+                            .collect();
+                        format!("System: {}", texts.join(""))
+                    }
+                };
+                (
+                    "user".to_string(),
+                    vec![GooglePart {
+                        text: Some(text),
+                        inline_data: None,
+                        function_call: None,
+                        function_response: None,
+                    }],
+                )
+            }
+            Message::User { content } => {
+                let parts = match content {
+                    UserContent::String(s) => vec![GooglePart {
+                        text: Some(s),
+                        inline_data: None,
+                        function_call: None,
+                        function_response: None,
+                    }],
+                    UserContent::Array(parts) => parts
+                        .into_iter()
+                        .filter_map(|p| match p {
+                            UserContentPart::Text(t) => Some(GooglePart {
+                                text: Some(t.text),
+                                inline_data: None,
+                                function_call: None,
+                                function_response: None,
+                            }),
+                            UserContentPart::Image {
+                                image, media_type, ..
+                            } => {
+                                if let Value::String(data) = image {
+                                    Some(GooglePart {
+                                        text: None,
+                                        inline_data: Some(GoogleBlob {
+                                            mime_type: media_type
+                                                .unwrap_or_else(|| "image/jpeg".to_string()),
+                                            data,
+                                        }),
+                                        function_call: None,
+                                        function_response: None,
+                                    })
+                                } else {
+                                    None
+                                }
+                            }
+                            _ => None,
+                        })
+                        .collect(),
+                };
+                ("user".to_string(), parts)
+            }
+            Message::Assistant { content, .. } => {
+                let parts = match content {
+                    AssistantContent::String(s) => vec![GooglePart {
+                        text: Some(s),
+                        inline_data: None,
+                        function_call: None,
+                        function_response: None,
+                    }],
+                    AssistantContent::Array(parts) => parts
+                        .into_iter()
+                        .filter_map(|p| match p {
+                            AssistantContentPart::Text(t) => Some(GooglePart {
+                                text: Some(t.text),
+                                inline_data: None,
+                                function_call: None,
+                                function_response: None,
+                            }),
+                            AssistantContentPart::ToolCall {
+                                tool_name,
+                                arguments,
+                                ..
+                            } => {
+                                let args: Option<Value> = match arguments {
+                                    ToolCallArguments::Valid(map) => serde_json::to_value(map).ok(),
+                                    ToolCallArguments::Invalid(s) => serde_json::from_str(&s).ok(),
+                                };
+                                Some(GooglePart {
+                                    text: None,
+                                    inline_data: None,
+                                    function_call: Some(GoogleFunctionCall {
+                                        name: tool_name,
+                                        args,
+                                    }),
+                                    function_response: None,
+                                })
+                            }
+                            _ => None,
+                        })
+                        .collect(),
+                };
+                ("model".to_string(), parts)
+            }
+            Message::Tool { content } => {
+                let parts: Vec<GooglePart> = content
+                    .into_iter()
+                    .map(|part| {
+                        let ToolContentPart::ToolResult(result) = part;
+                        GooglePart {
+                            text: None,
+                            inline_data: None,
+                            function_call: None,
+                            function_response: Some(GoogleFunctionResponse {
+                                name: result.tool_name,
+                                response: result.output,
+                            }),
+                        }
+                    })
+                    .collect();
+                ("user".to_string(), parts)
+            }
+        };
+
+        Ok(GoogleContent {
+            role: Some(role),
+            parts,
+        })
+    }
+}
+
+// ============================================================================
+// Convenience functions using trait implementations
+// ============================================================================
+
+/// Convert Google GenerateContentRequest to universal messages.
+pub fn google_to_universal(
+    request: &GoogleGenerateContentRequest,
+) -> Result<Vec<Message>, ConvertError> {
+    <Vec<Message> as TryFromLLM<Vec<GoogleContent>>>::try_from(request.contents.clone())
+}
+
+/// Convert universal messages to Google contents.
+pub fn universal_to_google_contents(
+    messages: &[Message],
+) -> Result<Vec<GoogleContent>, ConvertError> {
+    <Vec<GoogleContent> as TryFromLLM<Vec<Message>>>::try_from(messages.to_vec())
+}
+
+/// Convert universal messages to Google GenerateContent format as JSON Value.
+///
+/// This serializes the converted GoogleContent structs to JSON for use
+/// in contexts where a Value is needed (e.g., when building full requests).
+pub fn universal_to_google(messages: &[Message]) -> Result<Value, ConvertError> {
+    let contents = universal_to_google_contents(messages)?;
+    serde_json::to_value(contents).map_err(|e| ConvertError::JsonSerializationFailed {
+        field: "contents".to_string(),
+        error: e.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_json::json;
+
+    #[test]
+    fn test_google_content_to_message_user() {
+        let content = GoogleContent {
+            role: Some("user".to_string()),
+            parts: vec![GooglePart {
+                text: Some("Hello".to_string()),
+                inline_data: None,
+                function_call: None,
+                function_response: None,
+            }],
+        };
+
+        let message = <Message as TryFromLLM<GoogleContent>>::try_from(content).unwrap();
+        match message {
+            Message::User { content } => match content {
+                UserContent::String(s) => assert_eq!(s, "Hello"),
+                _ => panic!("Expected string content"),
+            },
+            _ => panic!("Expected user message"),
+        }
+    }
+
+    #[test]
+    fn test_google_content_to_message_model() {
+        let content = GoogleContent {
+            role: Some("model".to_string()),
+            parts: vec![GooglePart {
+                text: Some("Hi there!".to_string()),
+                inline_data: None,
+                function_call: None,
+                function_response: None,
+            }],
+        };
+
+        let message = <Message as TryFromLLM<GoogleContent>>::try_from(content).unwrap();
+        match message {
+            Message::Assistant { content, .. } => match content {
+                AssistantContent::Array(parts) => {
+                    assert_eq!(parts.len(), 1);
+                    match &parts[0] {
+                        AssistantContentPart::Text(t) => assert_eq!(t.text, "Hi there!"),
+                        _ => panic!("Expected text part"),
+                    }
+                }
+                _ => panic!("Expected array content"),
+            },
+            _ => panic!("Expected assistant message"),
+        }
+    }
+
+    #[test]
+    fn test_google_content_to_message_function_call() {
+        let content = GoogleContent {
+            role: Some("model".to_string()),
+            parts: vec![GooglePart {
+                text: None,
+                inline_data: None,
+                function_call: Some(GoogleFunctionCall {
+                    name: "get_weather".to_string(),
+                    args: Some(json!({"location": "SF"})),
+                }),
+                function_response: None,
+            }],
+        };
+
+        let message = <Message as TryFromLLM<GoogleContent>>::try_from(content).unwrap();
+        match message {
+            Message::Assistant { content, .. } => match content {
+                AssistantContent::Array(parts) => {
+                    assert_eq!(parts.len(), 1);
+                    match &parts[0] {
+                        AssistantContentPart::ToolCall {
+                            tool_name,
+                            tool_call_id,
+                            ..
+                        } => {
+                            assert_eq!(tool_name, "get_weather");
+                            assert_eq!(tool_call_id, "get_weather");
+                        }
+                        _ => panic!("Expected tool call part"),
+                    }
+                }
+                _ => panic!("Expected array content"),
+            },
+            _ => panic!("Expected assistant message"),
+        }
+    }
+
+    #[test]
+    fn test_message_to_google_content_user() {
+        let message = Message::User {
+            content: UserContent::String("Hello".to_string()),
+        };
+
+        let content = <GoogleContent as TryFromLLM<Message>>::try_from(message).unwrap();
+        assert_eq!(content.role.as_deref(), Some("user"));
+        assert_eq!(content.parts.len(), 1);
+        assert_eq!(content.parts[0].text.as_deref(), Some("Hello"));
+    }
+
+    #[test]
+    fn test_message_to_google_content_assistant() {
+        let message = Message::Assistant {
+            content: AssistantContent::String("Hi there!".to_string()),
+            id: None,
+        };
+
+        let content = <GoogleContent as TryFromLLM<Message>>::try_from(message).unwrap();
+        assert_eq!(content.role.as_deref(), Some("model"));
+        assert_eq!(content.parts.len(), 1);
+        assert_eq!(content.parts[0].text.as_deref(), Some("Hi there!"));
+    }
+
+    #[test]
+    fn test_message_to_google_content_tool_call() {
+        let message = Message::Assistant {
+            content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
+                tool_call_id: "call_123".to_string(),
+                tool_name: "get_weather".to_string(),
+                arguments: ToolCallArguments::from(r#"{"location":"SF"}"#.to_string()),
+                provider_options: None,
+                provider_executed: None,
+            }]),
+            id: None,
+        };
+
+        let content = <GoogleContent as TryFromLLM<Message>>::try_from(message).unwrap();
+        assert_eq!(content.role.as_deref(), Some("model"));
+        assert_eq!(content.parts.len(), 1);
+        assert!(content.parts[0].function_call.is_some());
+        let fc = content.parts[0].function_call.as_ref().unwrap();
+        assert_eq!(fc.name, "get_weather");
+    }
+
+    #[test]
+    fn test_google_to_universal_simple() {
+        let request = GoogleGenerateContentRequest {
+            contents: vec![GoogleContent {
+                role: Some("user".to_string()),
+                parts: vec![GooglePart {
+                    text: Some("Hello".to_string()),
+                    inline_data: None,
+                    function_call: None,
+                    function_response: None,
+                }],
+            }],
+            generation_config: None,
+            system_instruction: None,
+            safety_settings: None,
+            tools: None,
+        };
+
+        let messages = google_to_universal(&request).unwrap();
+        assert_eq!(messages.len(), 1);
+        match &messages[0] {
+            Message::User { content } => match content {
+                UserContent::String(s) => assert_eq!(s, "Hello"),
+                _ => panic!("Expected string content"),
+            },
+            _ => panic!("Expected user message"),
+        }
+    }
+
+    #[test]
+    fn test_universal_to_google_simple() {
+        let messages = vec![Message::User {
+            content: UserContent::String("Hello".to_string()),
+        }];
+
+        let result = universal_to_google(&messages).unwrap();
+        let expected = json!([{
+            "role": "user",
+            "parts": [{"text": "Hello"}]
+        }]);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_universal_to_google_with_assistant() {
+        let messages = vec![
+            Message::User {
+                content: UserContent::String("Hello".to_string()),
+            },
+            Message::Assistant {
+                content: AssistantContent::String("Hi there!".to_string()),
+                id: None,
+            },
+        ];
+
+        let result = universal_to_google(&messages).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["role"], "user");
+        assert_eq!(arr[1]["role"], "model");
+    }
+}

--- a/crates/lingua/src/providers/google/convert.rs
+++ b/crates/lingua/src/providers/google/convert.rs
@@ -12,6 +12,7 @@ use crate::providers::google::detect::{
 };
 use crate::serde_json::{self, Value};
 use crate::universal::convert::TryFromLLM;
+use crate::universal::defaults::DEFAULT_MIME_TYPE;
 use crate::universal::message::{
     AssistantContent, AssistantContentPart, Message, TextContentPart, ToolCallArguments,
     ToolContentPart, ToolResultContentPart, UserContent, UserContentPart,
@@ -176,7 +177,7 @@ impl TryFromLLM<Message> for GoogleContent {
                                         text: None,
                                         inline_data: Some(GoogleBlob {
                                             mime_type: media_type
-                                                .unwrap_or_else(|| "image/jpeg".to_string()),
+                                                .unwrap_or_else(|| DEFAULT_MIME_TYPE.to_string()),
                                             data,
                                         }),
                                         function_call: None,

--- a/crates/lingua/src/providers/google/detect.rs
+++ b/crates/lingua/src/providers/google/detect.rs
@@ -1,0 +1,275 @@
+/*!
+Google format detection.
+
+This module provides functions to detect if a payload is in
+Google AI (Generative Language API) format by attempting to
+deserialize into lightweight serde structs that mirror the
+protobuf types.
+
+Note: Google's official types are protobuf-generated (prost) without
+serde support. We use custom serde structs for validation.
+*/
+
+use crate::serde_json::{self, Value};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Error type for Google payload detection
+#[derive(Debug, Error)]
+pub enum DetectionError {
+    #[error("Deserialization failed: {0}")]
+    DeserializationFailed(String),
+}
+
+/// Lightweight serde struct for Google GenerateContent request validation.
+///
+/// This mirrors the structure of Google's protobuf GenerateContentRequest
+/// but uses serde for JSON deserialization.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GoogleGenerateContentRequest {
+    /// The content of the conversation
+    pub contents: Vec<GoogleContent>,
+
+    /// Generation configuration (optional)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation_config: Option<GoogleGenerationConfig>,
+
+    /// System instruction (optional)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_instruction: Option<GoogleContent>,
+
+    /// Safety settings (optional)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub safety_settings: Option<Vec<GoogleSafetySetting>>,
+
+    /// Tools for function calling (optional)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<GoogleTool>>,
+}
+
+/// Content in a Google conversation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoogleContent {
+    /// Role: "user" or "model"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+
+    /// Content parts
+    #[serde(default)]
+    pub parts: Vec<GooglePart>,
+}
+
+/// A part of content (text, image, etc.)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GooglePart {
+    /// Text content
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+
+    /// Inline data (images, etc.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inline_data: Option<GoogleBlob>,
+
+    /// Function call
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub function_call: Option<GoogleFunctionCall>,
+
+    /// Function response
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub function_response: Option<GoogleFunctionResponse>,
+}
+
+/// Inline binary data
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GoogleBlob {
+    pub mime_type: String,
+    pub data: String,
+}
+
+/// Function call from the model
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoogleFunctionCall {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args: Option<Value>,
+}
+
+/// Response to a function call
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoogleFunctionResponse {
+    pub name: String,
+    pub response: Value,
+}
+
+/// Generation configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GoogleGenerationConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_sequences: Option<Vec<String>>,
+}
+
+/// Safety setting
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoogleSafetySetting {
+    pub category: String,
+    pub threshold: String,
+}
+
+/// Tool definition
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GoogleTool {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub function_declarations: Option<Vec<GoogleFunctionDeclaration>>,
+}
+
+/// Function declaration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoogleFunctionDeclaration {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Value>,
+}
+
+/// Attempt to parse a JSON Value as Google GenerateContentRequest.
+///
+/// Returns the parsed struct if successful, or an error if the payload
+/// is not valid Google format.
+///
+/// # Examples
+///
+/// ```rust
+/// use lingua::serde_json::json;
+/// use lingua::providers::google::detect::try_parse_google;
+///
+/// let google_payload = json!({
+///     "contents": [{
+///         "role": "user",
+///         "parts": [{"text": "Hello"}]
+///     }]
+/// });
+///
+/// assert!(try_parse_google(&google_payload).is_ok());
+/// ```
+pub fn try_parse_google(payload: &Value) -> Result<GoogleGenerateContentRequest, DetectionError> {
+    serde_json::from_value(payload.clone())
+        .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_json::json;
+
+    #[test]
+    fn test_try_parse_google_with_contents_and_parts() {
+        let payload = json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "Hello"}]
+            }]
+        });
+        assert!(try_parse_google(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_google_with_generation_config() {
+        let payload = json!({
+            "contents": [{"parts": [{"text": "Hello"}]}],
+            "generationConfig": {
+                "temperature": 0.7
+            }
+        });
+        assert!(try_parse_google(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_google_with_model_role() {
+        let payload = json!({
+            "contents": [
+                {"role": "user", "parts": [{"text": "Hello"}]},
+                {"role": "model", "parts": [{"text": "Hi there!"}]}
+            ]
+        });
+        assert!(try_parse_google(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_google_fails_for_openai() {
+        // OpenAI uses "messages" not "contents" - should fail struct deserialization
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(try_parse_google(&payload).is_err());
+    }
+
+    #[test]
+    fn test_try_parse_google_empty_contents() {
+        // Empty contents array is technically valid but unusual
+        let payload = json!({
+            "contents": []
+        });
+        // Empty contents array may pass validation depending on struct definition
+        let _ = try_parse_google(&payload);
+    }
+
+    #[test]
+    fn test_try_parse_google_success() {
+        let payload = json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "Hello"}]
+            }]
+        });
+
+        let result = try_parse_google(&payload);
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.contents.len(), 1);
+        assert_eq!(parsed.contents[0].role.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn test_try_parse_google_with_function_call() {
+        let payload = json!({
+            "contents": [{
+                "role": "model",
+                "parts": [{
+                    "functionCall": {
+                        "name": "get_weather",
+                        "args": {"location": "SF"}
+                    }
+                }]
+            }]
+        });
+
+        let result = try_parse_google(&payload);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_google_fails_without_contents() {
+        // Missing contents - required field
+        let payload = json!({
+            "generationConfig": {"temperature": 0.7}
+        });
+
+        let result = try_parse_google(&payload);
+        assert!(result.is_err());
+    }
+}

--- a/crates/lingua/src/providers/google/mod.rs
+++ b/crates/lingua/src/providers/google/mod.rs
@@ -1,7 +1,19 @@
 // Google AI Generative Language API types
 // Generated from official protobuf files
 
+pub mod adapter;
+pub mod convert;
+pub mod detect;
 pub mod generated;
+
+// Re-export adapter
+pub use adapter::GoogleAdapter;
+
+// Re-export detection functions
+pub use detect::{try_parse_google, DetectionError, GoogleGenerateContentRequest};
+
+// Re-export conversion functions
+pub use convert::{google_to_universal, universal_to_google};
 
 // Re-export the most commonly used Google AI types for convenience
 pub use generated::{

--- a/crates/lingua/src/providers/openai/adapter.rs
+++ b/crates/lingua/src/providers/openai/adapter.rs
@@ -1,0 +1,1439 @@
+/*!
+OpenAI provider adapters for chat completions and responses API.
+
+This module provides two adapters:
+- `OpenAIAdapter` for the standard Chat Completions API
+- `ResponsesAdapter` for the Responses API (used by reasoning models like o1)
+*/
+
+use crate::capabilities::ProviderFormat;
+use crate::processing::adapters::{
+    collect_extras, insert_opt_bool, insert_opt_f64, insert_opt_i64, insert_opt_value,
+    ProviderAdapter,
+};
+use crate::processing::transform::TransformError;
+use crate::providers::openai::capabilities::{OpenAICapabilities, TargetProvider};
+use crate::providers::openai::generated::{
+    AllowedToolsFunction, ChatCompletionRequestMessage, ChatCompletionRequestMessageContent,
+    ChatCompletionRequestMessageContentPart, ChatCompletionRequestMessageRole,
+    ChatCompletionResponseMessage, ChatCompletionToolChoiceOption,
+    CreateChatCompletionRequestClass, CreateResponseClass, File, FunctionObject,
+    FunctionToolChoiceClass, FunctionToolChoiceType, InputItem, InputItemContent, InputItemRole,
+    InputItemType, Instructions, PurpleType, ResponseFormatType, ToolElement, ToolType,
+};
+use crate::providers::openai::{
+    try_parse_openai, try_parse_responses, universal_to_responses_input,
+};
+use crate::serde_json::{self, Map, Value};
+use crate::universal::convert::TryFromLLM;
+use crate::universal::message::{AssistantContent, Message, UserContent};
+use crate::universal::{
+    FinishReason, UniversalParams, UniversalRequest, UniversalResponse, UniversalStreamChoice,
+    UniversalStreamChunk, UniversalUsage,
+};
+use crate::util::media::parse_base64_data_url;
+
+/// Known request fields for OpenAI Chat Completions API.
+/// These are fields extracted into UniversalRequest/UniversalParams.
+/// Fields not in this list go into `extras` for passthrough.
+const OPENAI_KNOWN_KEYS: &[&str] = &[
+    "model",
+    "messages",
+    "temperature",
+    "top_p",
+    "max_tokens",
+    "max_completion_tokens",
+    "stop",
+    "tools",
+    "tool_choice",
+    "response_format",
+    "seed",
+    "presence_penalty",
+    "frequency_penalty",
+    "stream",
+    // OpenAI-specific fields (not in UniversalParams) go to extras:
+    // stream_options, n, logprobs, top_logprobs, logit_bias,
+    // user, store, metadata, parallel_tool_calls, service_tier
+];
+
+/// Known request fields for OpenAI Responses API.
+/// These are fields extracted into UniversalRequest/UniversalParams.
+/// Fields not in this list go into `extras` for passthrough.
+const RESPONSES_KNOWN_KEYS: &[&str] = &[
+    "model",
+    "input",
+    "temperature",
+    "top_p",
+    "max_output_tokens",
+    "tools",
+    "tool_choice",
+    "stream",
+    // Responses-specific fields (not in UniversalParams) go to extras:
+    // instructions, stop, response_format, seed, presence_penalty,
+    // frequency_penalty, reasoning, truncation, user, store,
+    // metadata, parallel_tool_calls
+];
+
+/// Adapter for OpenAI Chat Completions API.
+pub struct OpenAIAdapter;
+
+impl ProviderAdapter for OpenAIAdapter {
+    fn format(&self) -> ProviderFormat {
+        ProviderFormat::OpenAI
+    }
+
+    fn directory_name(&self) -> &'static str {
+        "chat-completions"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "ChatCompletions"
+    }
+
+    fn detect_request(&self, payload: &Value) -> bool {
+        try_parse_openai(payload).is_ok()
+    }
+
+    fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
+        let extras = collect_extras(&payload, OPENAI_KNOWN_KEYS);
+        let request: CreateChatCompletionRequestClass = serde_json::from_value(payload)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let messages = <Vec<Message> as TryFromLLM<Vec<_>>>::try_from(request.messages)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let params = UniversalParams {
+            temperature: request.temperature,
+            top_p: request.top_p,
+            top_k: None, // OpenAI doesn't support top_k
+            max_tokens: request.max_tokens.or(request.max_completion_tokens),
+            stop: request.stop.and_then(|s| serde_json::to_value(s).ok()),
+            tools: request.tools.and_then(|t| serde_json::to_value(t).ok()),
+            tool_choice: request
+                .tool_choice
+                .and_then(|t| serde_json::to_value(t).ok()),
+            response_format: request
+                .response_format
+                .and_then(|r| serde_json::to_value(r).ok()),
+            seed: request.seed,
+            presence_penalty: request.presence_penalty,
+            frequency_penalty: request.frequency_penalty,
+            stream: request.stream,
+        };
+
+        Ok(UniversalRequest {
+            model: Some(request.model),
+            messages,
+            params,
+            extras,
+        })
+    }
+
+    fn request_from_universal(&self, req: &UniversalRequest) -> Result<Value, TransformError> {
+        let model = req.model.as_ref().ok_or(TransformError::ValidationFailed {
+            target: ProviderFormat::OpenAI,
+            reason: "missing model".to_string(),
+        })?;
+
+        let openai_messages: Vec<ChatCompletionRequestMessage> =
+            <Vec<ChatCompletionRequestMessage> as TryFromLLM<Vec<Message>>>::try_from(
+                req.messages.clone(),
+            )
+            .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+        let mut obj = Map::new();
+        obj.insert("model".into(), Value::String(model.clone()));
+        obj.insert(
+            "messages".into(),
+            serde_json::to_value(openai_messages)
+                .map_err(|e| TransformError::SerializationFailed(e.to_string()))?,
+        );
+
+        // Insert params
+        insert_opt_f64(&mut obj, "temperature", req.params.temperature);
+        insert_opt_f64(&mut obj, "top_p", req.params.top_p);
+        insert_opt_i64(&mut obj, "max_completion_tokens", req.params.max_tokens);
+        insert_opt_value(&mut obj, "stop", req.params.stop.clone());
+        insert_opt_value(&mut obj, "tools", req.params.tools.clone());
+        insert_opt_value(&mut obj, "tool_choice", req.params.tool_choice.clone());
+        insert_opt_value(
+            &mut obj,
+            "response_format",
+            req.params.response_format.clone(),
+        );
+        insert_opt_i64(&mut obj, "seed", req.params.seed);
+        insert_opt_f64(&mut obj, "presence_penalty", req.params.presence_penalty);
+        insert_opt_f64(&mut obj, "frequency_penalty", req.params.frequency_penalty);
+        insert_opt_bool(&mut obj, "stream", req.params.stream);
+
+        // If streaming, ensure stream_options.include_usage is set for usage reporting
+        if req.params.stream == Some(true) {
+            let stream_options = obj
+                .entry("stream_options")
+                .or_insert_with(|| serde_json::json!({}));
+            if let Value::Object(opts) = stream_options {
+                opts.insert("include_usage".into(), Value::Bool(true));
+            }
+        }
+
+        // Merge extras (provider-specific fields)
+        for (k, v) in &req.extras {
+            obj.insert(k.clone(), v.clone());
+        }
+
+        Ok(Value::Object(obj))
+    }
+
+    fn apply_defaults(&self, _req: &mut UniversalRequest) {
+        // OpenAI doesn't require any specific defaults
+    }
+
+    fn detect_response(&self, payload: &Value) -> bool {
+        // OpenAI chat completion response has choices[].message and object="chat.completion"
+        payload.get("choices").and_then(Value::as_array).is_some()
+            && payload
+                .get("object")
+                .and_then(Value::as_str)
+                .is_some_and(|o| o == "chat.completion")
+    }
+
+    fn response_to_universal(&self, payload: Value) -> Result<UniversalResponse, TransformError> {
+        let choices = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .ok_or_else(|| TransformError::ToUniversalFailed("missing choices".to_string()))?;
+
+        let mut messages = Vec::new();
+        let mut finish_reason = None;
+
+        for choice in choices {
+            if let Some(msg_val) = choice.get("message") {
+                let response_msg: ChatCompletionResponseMessage =
+                    serde_json::from_value(msg_val.clone())
+                        .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+                let universal = <Message as TryFromLLM<&ChatCompletionResponseMessage>>::try_from(
+                    &response_msg,
+                )
+                .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+                messages.push(universal);
+            }
+
+            // Get finish_reason from first choice
+            if finish_reason.is_none() {
+                if let Some(reason) = choice.get("finish_reason").and_then(Value::as_str) {
+                    finish_reason = Some(reason.parse().unwrap());
+                }
+            }
+        }
+
+        let usage = payload.get("usage").map(|u| UniversalUsage {
+            prompt_tokens: u.get("prompt_tokens").and_then(Value::as_i64),
+            completion_tokens: u.get("completion_tokens").and_then(Value::as_i64),
+            prompt_cached_tokens: u
+                .get("prompt_tokens_details")
+                .and_then(|d| d.get("cached_tokens"))
+                .and_then(Value::as_i64),
+            prompt_cache_creation_tokens: None, // OpenAI doesn't report cache creation tokens
+            completion_reasoning_tokens: u
+                .get("completion_tokens_details")
+                .and_then(|d| d.get("reasoning_tokens"))
+                .and_then(Value::as_i64),
+        });
+
+        Ok(UniversalResponse {
+            model: payload
+                .get("model")
+                .and_then(Value::as_str)
+                .map(String::from),
+            messages,
+            usage,
+            finish_reason,
+            extras: Map::new(), // TODO: preserve extras if needed
+        })
+    }
+
+    fn response_from_universal(&self, resp: &UniversalResponse) -> Result<Value, TransformError> {
+        let finish_reason = self
+            .map_finish_reason(resp.finish_reason.as_ref())
+            .unwrap_or_else(|| "stop".to_string());
+
+        let choices: Vec<Value> = resp
+            .messages
+            .iter()
+            .enumerate()
+            .map(|(i, msg)| {
+                let response_msg =
+                    <ChatCompletionResponseMessage as TryFromLLM<&Message>>::try_from(msg)
+                        .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+                let message_value = serde_json::to_value(&response_msg)
+                    .map_err(|e| TransformError::SerializationFailed(e.to_string()))?;
+
+                Ok(serde_json::json!({
+                    "index": i,
+                    "message": message_value,
+                    "finish_reason": finish_reason
+                }))
+            })
+            .collect::<Result<Vec<_>, TransformError>>()?;
+
+        let usage = resp.usage.as_ref().map(|u| {
+            let input = u.prompt_tokens.unwrap_or(0);
+            let output = u.completion_tokens.unwrap_or(0);
+            serde_json::json!({
+                "prompt_tokens": input,
+                "completion_tokens": output,
+                "total_tokens": input + output
+            })
+        });
+
+        let mut obj = serde_json::json!({
+            "id": resp.extras.get("id").and_then(Value::as_str).unwrap_or("transformed"),
+            "object": "chat.completion",
+            "created": resp.extras.get("created").and_then(Value::as_i64).unwrap_or(0),
+            "model": resp.model.as_deref().unwrap_or("transformed"),
+            "choices": choices
+        });
+
+        if let Some(usage_val) = usage {
+            obj.as_object_mut()
+                .unwrap()
+                .insert("usage".into(), usage_val);
+        }
+
+        Ok(obj)
+    }
+
+    fn map_finish_reason(&self, reason: Option<&FinishReason>) -> Option<String> {
+        reason.map(|r| match r {
+            FinishReason::Stop => "stop".to_string(),
+            FinishReason::Length => "length".to_string(),
+            FinishReason::ToolCalls => "tool_calls".to_string(),
+            FinishReason::ContentFilter => "content_filter".to_string(),
+            FinishReason::Other(s) => s.clone(),
+        })
+    }
+
+    // =========================================================================
+    // Streaming response handling
+    // =========================================================================
+
+    fn detect_stream_response(&self, payload: &Value) -> bool {
+        // OpenAI streaming chunk has object="chat.completion.chunk"
+        // or has choices array with delta field
+        if let Some(obj) = payload.get("object").and_then(Value::as_str) {
+            if obj == "chat.completion.chunk" {
+                return true;
+            }
+        }
+
+        // Fallback: check for choices with delta
+        if let Some(choices) = payload.get("choices").and_then(Value::as_array) {
+            if choices.iter().any(|c| c.get("delta").is_some()) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn stream_to_universal(
+        &self,
+        payload: Value,
+    ) -> Result<Option<UniversalStreamChunk>, TransformError> {
+        // OpenAI is the canonical format, so this is mostly direct mapping
+        let choices = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .map(|c| {
+                        let index = c.get("index").and_then(Value::as_u64).unwrap_or(0) as u32;
+                        let delta = c.get("delta").cloned();
+                        let finish_reason = c
+                            .get("finish_reason")
+                            .and_then(Value::as_str)
+                            .map(String::from);
+                        UniversalStreamChoice {
+                            index,
+                            delta,
+                            finish_reason,
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        // Extract usage if present (usually only on final chunk)
+        let usage = payload.get("usage").map(|u| UniversalUsage {
+            prompt_tokens: u.get("prompt_tokens").and_then(Value::as_i64),
+            completion_tokens: u.get("completion_tokens").and_then(Value::as_i64),
+            prompt_cached_tokens: u
+                .get("prompt_tokens_details")
+                .and_then(|d| d.get("cached_tokens"))
+                .and_then(Value::as_i64),
+            prompt_cache_creation_tokens: None,
+            completion_reasoning_tokens: u
+                .get("completion_tokens_details")
+                .and_then(|d| d.get("reasoning_tokens"))
+                .and_then(Value::as_i64),
+        });
+
+        Ok(Some(UniversalStreamChunk::new(
+            payload.get("id").and_then(Value::as_str).map(String::from),
+            payload
+                .get("model")
+                .and_then(Value::as_str)
+                .map(String::from),
+            choices,
+            payload.get("created").and_then(Value::as_u64),
+            usage,
+        )))
+    }
+
+    fn stream_from_universal(&self, chunk: &UniversalStreamChunk) -> Result<Value, TransformError> {
+        // Convert back to OpenAI streaming format
+        if chunk.is_keep_alive() {
+            // Return empty chunk for keep-alive
+            return Ok(serde_json::json!({
+                "object": "chat.completion.chunk",
+                "choices": []
+            }));
+        }
+
+        let choices: Vec<Value> = chunk
+            .choices
+            .iter()
+            .map(|c| {
+                let mut choice = serde_json::json!({
+                    "index": c.index,
+                    "delta": c.delta.clone().unwrap_or(Value::Object(Map::new()))
+                });
+                if let Some(ref reason) = c.finish_reason {
+                    choice
+                        .as_object_mut()
+                        .unwrap()
+                        .insert("finish_reason".into(), Value::String(reason.clone()));
+                } else {
+                    choice
+                        .as_object_mut()
+                        .unwrap()
+                        .insert("finish_reason".into(), Value::Null);
+                }
+                choice
+            })
+            .collect();
+
+        let mut obj = serde_json::json!({
+            "object": "chat.completion.chunk",
+            "choices": choices
+        });
+
+        let obj_map = obj.as_object_mut().unwrap();
+        if let Some(ref id) = chunk.id {
+            obj_map.insert("id".into(), Value::String(id.clone()));
+        }
+        if let Some(ref model) = chunk.model {
+            obj_map.insert("model".into(), Value::String(model.clone()));
+        }
+        if let Some(created) = chunk.created {
+            obj_map.insert("created".into(), Value::Number(created.into()));
+        }
+        if let Some(ref usage) = chunk.usage {
+            let prompt = usage.prompt_tokens.unwrap_or(0);
+            let completion = usage.completion_tokens.unwrap_or(0);
+            obj_map.insert(
+                "usage".into(),
+                serde_json::json!({
+                    "prompt_tokens": prompt,
+                    "completion_tokens": completion,
+                    "total_tokens": prompt + completion
+                }),
+            );
+        }
+
+        Ok(obj)
+    }
+}
+
+/// Adapter for OpenAI Responses API (used by reasoning models like o1).
+pub struct ResponsesAdapter;
+
+impl ProviderAdapter for ResponsesAdapter {
+    fn format(&self) -> ProviderFormat {
+        ProviderFormat::Responses
+    }
+
+    fn directory_name(&self) -> &'static str {
+        "responses"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Responses"
+    }
+
+    fn detect_request(&self, payload: &Value) -> bool {
+        try_parse_responses(payload).is_ok()
+    }
+
+    fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
+        let extras = collect_extras(&payload, RESPONSES_KNOWN_KEYS);
+        let request: CreateResponseClass = serde_json::from_value(payload)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        // Extract input items from the request
+        let input_items: Vec<InputItem> = match request.input {
+            Some(Instructions::InputItemArray(items)) => items,
+            Some(Instructions::String(s)) => {
+                // Single string input - create a user message InputItem
+                vec![InputItem {
+                    input_item_type: Some(InputItemType::Message),
+                    role: Some(InputItemRole::User),
+                    content: Some(InputItemContent::String(s)),
+                    ..Default::default()
+                }]
+            }
+            None => vec![],
+        };
+
+        let messages = <Vec<Message> as TryFromLLM<Vec<InputItem>>>::try_from(input_items)
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+        let params = UniversalParams {
+            temperature: request.temperature,
+            top_p: request.top_p,
+            top_k: None,
+            max_tokens: request.max_output_tokens,
+            stop: None, // Responses API doesn't use stop
+            tools: request.tools.and_then(|t| serde_json::to_value(t).ok()),
+            tool_choice: request
+                .tool_choice
+                .and_then(|t| serde_json::to_value(t).ok()),
+            response_format: None,  // Different structure in Responses API
+            seed: None,             // Responses API uses different randomness control
+            presence_penalty: None, // Responses API doesn't support penalties
+            frequency_penalty: None,
+            stream: request.stream,
+        };
+
+        Ok(UniversalRequest {
+            model: request.model, // Already Option<String> in CreateResponseClass
+            messages,
+            params,
+            extras,
+        })
+    }
+
+    fn request_from_universal(&self, req: &UniversalRequest) -> Result<Value, TransformError> {
+        let model = req.model.as_ref().ok_or(TransformError::ValidationFailed {
+            target: ProviderFormat::Responses,
+            reason: "missing model".to_string(),
+        })?;
+
+        // Use existing conversion with 1:N Tool message expansion
+        let input_items = universal_to_responses_input(&req.messages)
+            .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+
+        let mut obj = Map::new();
+        obj.insert("model".into(), Value::String(model.clone()));
+        obj.insert(
+            "input".into(),
+            serde_json::to_value(input_items)
+                .map_err(|e| TransformError::SerializationFailed(e.to_string()))?,
+        );
+
+        // Note: temperature is intentionally NOT included for Responses API
+        // as reasoning models (o1, o3) don't support it
+        insert_opt_f64(&mut obj, "top_p", req.params.top_p);
+        insert_opt_i64(&mut obj, "max_output_tokens", req.params.max_tokens);
+        insert_opt_f64(&mut obj, "presence_penalty", req.params.presence_penalty);
+        insert_opt_f64(&mut obj, "frequency_penalty", req.params.frequency_penalty);
+        insert_opt_bool(&mut obj, "stream", req.params.stream);
+
+        // Transform tools from OpenAI Chat format to Responses API format
+        // {type: "function", function: {name, description, parameters}}
+        // → {type: "function", name, description, parameters, strict: false}
+        // Tools can come from params.tools or extras.tools depending on how the request was built
+        let tools_value = req
+            .params
+            .tools
+            .as_ref()
+            .or_else(|| req.extras.get("tools"));
+        if let Some(Value::Array(tools)) = tools_value {
+            let response_tools: Vec<Value> = tools
+                .iter()
+                .filter_map(|tool| {
+                    if tool.get("type").and_then(Value::as_str) == Some("function") {
+                        let func = tool.get("function")?;
+                        Some(serde_json::json!({
+                            "type": "function",
+                            "name": func.get("name")?,
+                            "description": func.get("description"),
+                            "parameters": func.get("parameters").cloned().unwrap_or(serde_json::json!({})),
+                            "strict": false
+                        }))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if !response_tools.is_empty() {
+                obj.insert("tools".into(), Value::Array(response_tools));
+            }
+        }
+
+        // Transform tool_choice from OpenAI Chat format to Responses API format
+        // {function: {name: "foo"}} → {type: "function", name: "foo"}
+        // tool_choice can come from params or extras depending on how the request was built
+        let tool_choice_value = req
+            .params
+            .tool_choice
+            .as_ref()
+            .or_else(|| req.extras.get("tool_choice"));
+        if let Some(tool_choice) = tool_choice_value {
+            let converted = match tool_choice {
+                Value::String(s) if s == "none" || s == "auto" || s == "required" => {
+                    Value::String(s.clone())
+                }
+                Value::Object(obj_tc) if obj_tc.contains_key("function") => {
+                    if let Some(func) = obj_tc.get("function") {
+                        if let Some(name) = func.get("name").and_then(Value::as_str) {
+                            serde_json::json!({ "type": "function", "name": name })
+                        } else {
+                            Value::String("auto".into())
+                        }
+                    } else {
+                        Value::String("auto".into())
+                    }
+                }
+                _ => Value::String("auto".into()),
+            };
+            obj.insert("tool_choice".into(), converted);
+        }
+
+        // Transform response_format to nested text.format structure for Responses API
+        if let Some(response_format) = req.extras.get("response_format") {
+            let text_format = match response_format.get("type").and_then(Value::as_str) {
+                Some("text") | Some("json_object") => {
+                    Some(serde_json::json!({ "format": response_format }))
+                }
+                Some("json_schema") => response_format.get("json_schema").map(|json_schema| {
+                    serde_json::json!({
+                        "format": {
+                            "type": "json_schema",
+                            "schema": json_schema.get("schema").cloned().unwrap_or(serde_json::json!({})),
+                            "name": json_schema.get("name"),
+                            "description": json_schema.get("description"),
+                            "strict": json_schema.get("strict")
+                        }
+                    })
+                }),
+                _ => None,
+            };
+            if let Some(tf) = text_format {
+                obj.insert("text".into(), tf);
+            }
+        }
+
+        // Transform reasoning_effort to nested reasoning.effort structure
+        if let Some(effort) = req.extras.get("reasoning_effort") {
+            obj.insert(
+                "reasoning".into(),
+                serde_json::json!({ "effort": effort.clone() }),
+            );
+        }
+
+        // Pass through parallel_tool_calls
+        if let Some(Value::Bool(parallel)) = req.extras.get("parallel_tool_calls") {
+            obj.insert("parallel_tool_calls".into(), Value::Bool(*parallel));
+        }
+
+        // Merge remaining extras (except those we handled specially)
+        for (k, v) in &req.extras {
+            if !matches!(
+                k.as_str(),
+                "tools"
+                    | "tool_choice"
+                    | "response_format"
+                    | "reasoning_effort"
+                    | "parallel_tool_calls"
+            ) {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+
+        Ok(Value::Object(obj))
+    }
+
+    fn apply_defaults(&self, _req: &mut UniversalRequest) {
+        // Responses API doesn't require any specific defaults
+    }
+
+    fn detect_response(&self, payload: &Value) -> bool {
+        // Responses API response has output[] array and object="response"
+        payload.get("output").and_then(Value::as_array).is_some()
+            && payload
+                .get("object")
+                .and_then(Value::as_str)
+                .is_some_and(|o| o == "response")
+    }
+
+    fn response_to_universal(&self, payload: Value) -> Result<UniversalResponse, TransformError> {
+        let output = payload
+            .get("output")
+            .and_then(Value::as_array)
+            .ok_or_else(|| TransformError::ToUniversalFailed("missing output".to_string()))?;
+
+        // Convert output items to messages
+        // Responses API has multiple output types: message, function_call, reasoning, etc.
+        let mut messages: Vec<Message> = Vec::new();
+        let mut tool_calls: Vec<Value> = Vec::new();
+
+        for item in output {
+            let item_type = item.get("type").and_then(Value::as_str);
+
+            match item_type {
+                Some("message") => {
+                    // Message type - extract text content
+                    if let Some(content) = item.get("content") {
+                        if let Some(content_arr) = content.as_array() {
+                            let text: String = content_arr
+                                .iter()
+                                .filter_map(|c| {
+                                    if c.get("type").and_then(Value::as_str) == Some("output_text")
+                                    {
+                                        c.get("text").and_then(Value::as_str).map(String::from)
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                                .join("");
+                            if !text.is_empty() {
+                                messages.push(Message::Assistant {
+                                    content: AssistantContent::String(text),
+                                    id: None,
+                                });
+                            }
+                        }
+                    }
+                }
+                Some("function_call") => {
+                    // Function call - collect for later conversion to tool calls
+                    tool_calls.push(item.clone());
+                }
+                _ => {
+                    // Skip reasoning and other types for now
+                }
+            }
+        }
+
+        // If we have tool calls but no messages, create an assistant message with tool calls
+        if !tool_calls.is_empty() && messages.is_empty() {
+            // Convert function_call items to tool call format
+            use crate::universal::message::{AssistantContentPart, ToolCallArguments};
+            let parts: Vec<AssistantContentPart> = tool_calls
+                .iter()
+                .filter_map(|tc| {
+                    let name = tc.get("name").and_then(Value::as_str)?;
+                    let call_id = tc.get("call_id").and_then(Value::as_str)?;
+                    let arguments = tc.get("arguments").and_then(Value::as_str)?;
+
+                    // Try to parse arguments as JSON, fall back to invalid string
+                    let args = serde_json::from_str::<Map<String, Value>>(arguments)
+                        .map(ToolCallArguments::Valid)
+                        .unwrap_or_else(|_| ToolCallArguments::Invalid(arguments.to_string()));
+
+                    Some(AssistantContentPart::ToolCall {
+                        tool_call_id: call_id.to_string(),
+                        tool_name: name.to_string(),
+                        arguments: args,
+                        provider_options: None,
+                        provider_executed: None,
+                    })
+                })
+                .collect();
+
+            if !parts.is_empty() {
+                messages.push(Message::Assistant {
+                    content: AssistantContent::Array(parts),
+                    id: None,
+                });
+            }
+        }
+
+        // If still no messages, try output_text field as fallback
+        if messages.is_empty() {
+            if let Some(text) = payload.get("output_text").and_then(Value::as_str) {
+                if !text.is_empty() {
+                    messages.push(Message::Assistant {
+                        content: AssistantContent::String(text.to_string()),
+                        id: None,
+                    });
+                }
+            }
+        }
+
+        // Map status to finish_reason
+        let finish_reason = payload
+            .get("status")
+            .and_then(Value::as_str)
+            .map(|s| s.parse().unwrap());
+
+        let usage = payload.get("usage").map(|u| UniversalUsage {
+            prompt_tokens: u.get("input_tokens").and_then(Value::as_i64),
+            completion_tokens: u.get("output_tokens").and_then(Value::as_i64),
+            prompt_cached_tokens: u
+                .get("input_tokens_details")
+                .and_then(|d| d.get("cached_tokens"))
+                .and_then(Value::as_i64),
+            prompt_cache_creation_tokens: None,
+            completion_reasoning_tokens: u
+                .get("output_tokens_details")
+                .and_then(|d| d.get("reasoning_tokens"))
+                .and_then(Value::as_i64),
+        });
+
+        Ok(UniversalResponse {
+            model: payload
+                .get("model")
+                .and_then(Value::as_str)
+                .map(String::from),
+            messages,
+            usage,
+            finish_reason,
+            extras: Map::new(),
+        })
+    }
+
+    fn response_from_universal(&self, resp: &UniversalResponse) -> Result<Value, TransformError> {
+        // Build Responses API response format
+        let output: Vec<Value> = resp
+            .messages
+            .iter()
+            .map(|msg| {
+                let text = match msg {
+                    Message::Assistant { content, .. } => match content {
+                        AssistantContent::String(s) => s.clone(),
+                        AssistantContent::Array(_) => String::new(), // TODO: extract text from parts
+                    },
+                    Message::User { content } => match content {
+                        UserContent::String(s) => s.clone(),
+                        UserContent::Array(_) => String::new(),
+                    },
+                    _ => String::new(),
+                };
+
+                serde_json::json!({
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{
+                        "type": "output_text",
+                        "text": text
+                    }]
+                })
+            })
+            .collect();
+
+        let status = self
+            .map_finish_reason(resp.finish_reason.as_ref())
+            .unwrap_or_else(|| "completed".to_string());
+
+        // Build response with all required fields for TheResponseObject
+        let mut obj = serde_json::json!({
+            "id": resp.extras.get("id").and_then(Value::as_str).unwrap_or("resp_transformed"),
+            "object": "response",
+            "model": resp.model.as_deref().unwrap_or("transformed"),
+            "output": output,
+            "status": status,
+            "created_at": 0.0,
+            "tool_choice": "none",
+            "tools": [],
+            "parallel_tool_calls": false
+        });
+
+        if let Some(usage) = &resp.usage {
+            let input = usage.prompt_tokens.unwrap_or(0);
+            let output = usage.completion_tokens.unwrap_or(0);
+            obj.as_object_mut().unwrap().insert(
+                "usage".into(),
+                serde_json::json!({
+                    "input_tokens": input,
+                    "output_tokens": output,
+                    "total_tokens": input + output,
+                    "input_tokens_details": {
+                        "cached_tokens": usage.prompt_cached_tokens.unwrap_or(0)
+                    },
+                    "output_tokens_details": {
+                        "reasoning_tokens": usage.completion_reasoning_tokens.unwrap_or(0)
+                    }
+                }),
+            );
+        }
+
+        Ok(obj)
+    }
+
+    fn map_finish_reason(&self, reason: Option<&FinishReason>) -> Option<String> {
+        reason.map(|r| match r {
+            FinishReason::Stop => "completed".to_string(),
+            FinishReason::Length => "incomplete".to_string(),
+            FinishReason::ToolCalls => "completed".to_string(), // Tool calls also complete
+            FinishReason::ContentFilter => "incomplete".to_string(),
+            FinishReason::Other(s) => s.clone(),
+        })
+    }
+
+    // =========================================================================
+    // Streaming response handling
+    // =========================================================================
+
+    fn detect_stream_response(&self, payload: &Value) -> bool {
+        // Responses API streaming has type field starting with "response."
+        payload
+            .get("type")
+            .and_then(Value::as_str)
+            .is_some_and(|t| t.starts_with("response."))
+    }
+
+    fn stream_to_universal(
+        &self,
+        payload: Value,
+    ) -> Result<Option<UniversalStreamChunk>, TransformError> {
+        let event_type = payload
+            .get("type")
+            .and_then(Value::as_str)
+            .ok_or_else(|| TransformError::ToUniversalFailed("missing type field".to_string()))?;
+
+        match event_type {
+            "response.output_text.delta" => {
+                // Text delta - extract from delta field
+                let text = payload.get("delta").and_then(Value::as_str).unwrap_or("");
+                let output_index = payload
+                    .get("output_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as u32;
+
+                Ok(Some(UniversalStreamChunk::new(
+                    None,
+                    None,
+                    vec![UniversalStreamChoice {
+                        index: output_index,
+                        delta: Some(serde_json::json!({
+                            "role": "assistant",
+                            "content": text
+                        })),
+                        finish_reason: None,
+                    }],
+                    None,
+                    None,
+                )))
+            }
+
+            "response.completed" => {
+                // Final event with usage
+                let response = payload.get("response");
+                let usage = response
+                    .and_then(|r| r.get("usage"))
+                    .map(|u| UniversalUsage {
+                        prompt_tokens: u.get("input_tokens").and_then(Value::as_i64),
+                        completion_tokens: u.get("output_tokens").and_then(Value::as_i64),
+                        prompt_cached_tokens: u
+                            .get("input_tokens_details")
+                            .and_then(|d| d.get("cached_tokens"))
+                            .and_then(Value::as_i64),
+                        prompt_cache_creation_tokens: None,
+                        completion_reasoning_tokens: u
+                            .get("output_tokens_details")
+                            .and_then(|d| d.get("reasoning_tokens"))
+                            .and_then(Value::as_i64),
+                    });
+
+                let model = response
+                    .and_then(|r| r.get("model"))
+                    .and_then(Value::as_str)
+                    .map(String::from);
+
+                let id = response
+                    .and_then(|r| r.get("id"))
+                    .and_then(Value::as_str)
+                    .map(String::from);
+
+                Ok(Some(UniversalStreamChunk::new(
+                    id,
+                    model,
+                    vec![UniversalStreamChoice {
+                        index: 0,
+                        delta: Some(serde_json::json!({})),
+                        finish_reason: Some("stop".to_string()),
+                    }],
+                    None,
+                    usage,
+                )))
+            }
+
+            "response.incomplete" => {
+                // Incomplete response - typically due to length
+                let response = payload.get("response");
+                let usage = response
+                    .and_then(|r| r.get("usage"))
+                    .map(|u| UniversalUsage {
+                        prompt_tokens: u.get("input_tokens").and_then(Value::as_i64),
+                        completion_tokens: u.get("output_tokens").and_then(Value::as_i64),
+                        prompt_cached_tokens: u
+                            .get("input_tokens_details")
+                            .and_then(|d| d.get("cached_tokens"))
+                            .and_then(Value::as_i64),
+                        prompt_cache_creation_tokens: None,
+                        completion_reasoning_tokens: u
+                            .get("output_tokens_details")
+                            .and_then(|d| d.get("reasoning_tokens"))
+                            .and_then(Value::as_i64),
+                    });
+
+                Ok(Some(UniversalStreamChunk::new(
+                    None,
+                    None,
+                    vec![UniversalStreamChoice {
+                        index: 0,
+                        delta: Some(serde_json::json!({})),
+                        finish_reason: Some("length".to_string()),
+                    }],
+                    None,
+                    usage,
+                )))
+            }
+
+            "response.created" | "response.in_progress" => {
+                // Initial metadata events - extract model/id
+                let response = payload.get("response");
+                let model = response
+                    .and_then(|r| r.get("model"))
+                    .and_then(Value::as_str)
+                    .map(String::from);
+                let id = response
+                    .and_then(|r| r.get("id"))
+                    .and_then(Value::as_str)
+                    .map(String::from);
+
+                Ok(Some(UniversalStreamChunk::new(
+                    id,
+                    model,
+                    vec![UniversalStreamChoice {
+                        index: 0,
+                        delta: Some(serde_json::json!({"role": "assistant", "content": ""})),
+                        finish_reason: None,
+                    }],
+                    None,
+                    None,
+                )))
+            }
+
+            // All other events are metadata/keep-alive
+            _ => Ok(Some(UniversalStreamChunk::keep_alive())),
+        }
+    }
+
+    fn stream_from_universal(&self, chunk: &UniversalStreamChunk) -> Result<Value, TransformError> {
+        if chunk.is_keep_alive() {
+            // Return a generic in_progress event
+            return Ok(serde_json::json!({
+                "type": "response.in_progress",
+                "sequence_number": 0
+            }));
+        }
+
+        // Check for finish chunk
+        let has_finish = chunk
+            .choices
+            .first()
+            .and_then(|c| c.finish_reason.as_ref())
+            .is_some();
+
+        if has_finish {
+            let finish_reason = chunk.choices.first().and_then(|c| c.finish_reason.as_ref());
+            let status = match finish_reason.map(|r| r.as_str()) {
+                Some("stop") => "completed",
+                Some("length") => "incomplete",
+                _ => "completed",
+            };
+
+            let mut response = serde_json::json!({
+                "id": chunk.id.as_deref().unwrap_or("resp_transformed"),
+                "object": "response",
+                "model": chunk.model.as_deref().unwrap_or("transformed"),
+                "status": status,
+                "output": []
+            });
+
+            if let Some(usage) = &chunk.usage {
+                response.as_object_mut().unwrap().insert(
+                    "usage".into(),
+                    serde_json::json!({
+                        "input_tokens": usage.prompt_tokens.unwrap_or(0),
+                        "output_tokens": usage.completion_tokens.unwrap_or(0),
+                        "total_tokens": usage.prompt_tokens.unwrap_or(0) + usage.completion_tokens.unwrap_or(0)
+                    }),
+                );
+            }
+
+            return Ok(serde_json::json!({
+                "type": if status == "completed" { "response.completed" } else { "response.incomplete" },
+                "response": response
+            }));
+        }
+
+        // Check for content delta
+        if let Some(choice) = chunk.choices.first() {
+            if let Some(delta) = &choice.delta {
+                if let Some(content) = delta.get("content").and_then(Value::as_str) {
+                    return Ok(serde_json::json!({
+                        "type": "response.output_text.delta",
+                        "output_index": choice.index,
+                        "content_index": 0,
+                        "delta": content
+                    }));
+                }
+            }
+        }
+
+        // Fallback - return output_text.delta with empty content
+        Ok(serde_json::json!({
+            "type": "response.output_text.delta",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": ""
+        }))
+    }
+}
+
+// =============================================================================
+// OpenAI Target-Specific Transformations
+// =============================================================================
+
+/// Error type for transformation operations.
+#[derive(Debug, thiserror::Error)]
+pub enum OpenAITransformError {
+    #[error("missing required field: {field}")]
+    MissingField { field: &'static str },
+    #[error("invalid value: {message}")]
+    InvalidValue { message: String },
+    #[error("unsupported feature: {feature}")]
+    Unsupported { feature: String },
+    #[error("serialization failed: {0}")]
+    SerializationFailed(String),
+}
+
+/// Apply target-specific transformations to an OpenAI-format request payload.
+///
+/// This function applies transformations needed to make an OpenAI-format request
+/// work with different target providers (Azure, Vertex, Mistral, etc.).
+///
+/// # Arguments
+///
+/// * `payload` - The OpenAI-format request payload (modified in place)
+/// * `target_provider` - The target provider that will receive the request
+/// * `provider_metadata` - Optional provider-specific metadata (e.g., api_version for Azure)
+///
+/// # Returns
+///
+/// The transformed payload, or an error if transformation fails.
+pub fn apply_target_transforms(
+    payload: &Value,
+    target_provider: TargetProvider,
+    provider_metadata: Option<&Map<String, Value>>,
+) -> Result<Value, OpenAITransformError> {
+    // Parse as OpenAI request
+    let mut request: CreateChatCompletionRequestClass = serde_json::from_value(payload.clone())
+        .map_err(|e| OpenAITransformError::SerializationFailed(e.to_string()))?;
+
+    // Detect capabilities based on request and target
+    let capabilities = OpenAICapabilities::detect(&request, target_provider);
+
+    // Apply reasoning model transformations
+    if capabilities.requires_reasoning_transforms() {
+        apply_reasoning_transforms(&mut request, &capabilities);
+    }
+
+    // Apply provider-specific field sanitization
+    apply_provider_sanitization(
+        &mut request,
+        &capabilities,
+        target_provider,
+        provider_metadata,
+    );
+
+    // Apply model name normalization if needed
+    if capabilities.requires_model_normalization {
+        apply_model_normalization(&mut request, target_provider);
+    }
+
+    // Normalize user messages (handle non-image base64 content)
+    normalize_user_messages(&mut request)?;
+
+    // Apply response format transformations
+    apply_response_format(&mut request, &capabilities)?;
+
+    // Serialize back to Value
+    serde_json::to_value(&request)
+        .map_err(|e| OpenAITransformError::SerializationFailed(e.to_string()))
+}
+
+fn apply_reasoning_transforms(
+    request: &mut CreateChatCompletionRequestClass,
+    capabilities: &OpenAICapabilities,
+) {
+    // Remove unsupported fields for reasoning models
+    request.temperature = None;
+    request.parallel_tool_calls = None;
+
+    // For legacy o1 models, convert system messages to user messages
+    if capabilities.is_legacy_o1_model {
+        for message in &mut request.messages {
+            if matches!(message.role, ChatCompletionRequestMessageRole::System) {
+                message.role = ChatCompletionRequestMessageRole::User;
+            }
+        }
+    }
+}
+
+fn apply_provider_sanitization(
+    request: &mut CreateChatCompletionRequestClass,
+    capabilities: &OpenAICapabilities,
+    target_provider: TargetProvider,
+    provider_metadata: Option<&Map<String, Value>>,
+) {
+    // Remove stream_options for providers that don't support it
+    if !capabilities.supports_stream_options {
+        request.stream_options = None;
+    }
+
+    // Remove parallel_tool_calls for providers that don't support it
+    if !capabilities.supports_parallel_tools {
+        request.parallel_tool_calls = None;
+    }
+
+    // Remove seed field for Azure with API version
+    let has_api_version = provider_metadata
+        .and_then(|meta| meta.get("api_version"))
+        .is_some();
+
+    if capabilities.should_remove_seed_for_azure(target_provider, has_api_version) {
+        request.seed = None;
+    }
+}
+
+fn apply_model_normalization(
+    request: &mut CreateChatCompletionRequestClass,
+    target_provider: TargetProvider,
+) {
+    // Normalize Vertex model names
+    if target_provider == TargetProvider::Vertex {
+        if request.model.starts_with("publishers/meta/models/") {
+            // Strip to "meta/..." format
+            request.model = request
+                .model
+                .strip_prefix("publishers/")
+                .and_then(|s| s.strip_prefix("meta/models/"))
+                .map(|s| format!("meta/{}", s))
+                .unwrap_or_else(|| request.model.clone());
+        } else if let Some(stripped) = request.model.strip_prefix("publishers/") {
+            // Strip "publishers/X/models/Y" to "Y"
+            if let Some(model_part) = stripped.split("/models/").nth(1) {
+                request.model = model_part.to_string();
+            }
+        }
+    }
+}
+
+fn normalize_user_messages(
+    request: &mut CreateChatCompletionRequestClass,
+) -> Result<(), OpenAITransformError> {
+    for message in &mut request.messages {
+        if matches!(message.role, ChatCompletionRequestMessageRole::User) {
+            if let Some(
+                ChatCompletionRequestMessageContent::ChatCompletionRequestMessageContentPartArray(
+                    parts,
+                ),
+            ) = message.content.as_mut()
+            {
+                for part in parts.iter_mut() {
+                    normalize_content_part(part)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn normalize_content_part(
+    part: &mut ChatCompletionRequestMessageContentPart,
+) -> Result<(), OpenAITransformError> {
+    if !matches!(
+        part.chat_completion_request_message_content_part_type,
+        PurpleType::ImageUrl
+    ) {
+        return Ok(());
+    }
+
+    let Some(image_url_value) = part
+        .image_url
+        .as_ref()
+        .map(|image_url| image_url.url.clone())
+    else {
+        return Ok(());
+    };
+
+    // Handle base64 data URLs - convert non-images to file type
+    if let Some(data_url) = parse_base64_data_url(&image_url_value) {
+        if !data_url.media_type.starts_with("image/") {
+            part.chat_completion_request_message_content_part_type = PurpleType::File;
+            part.image_url = None;
+            part.file = Some(File {
+                file_data: Some(image_url_value),
+                file_id: None,
+                filename: Some(if data_url.media_type == "application/pdf" {
+                    "file_from_base64.pdf".to_string()
+                } else {
+                    "file_from_base64".to_string()
+                }),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_response_format(
+    request: &mut CreateChatCompletionRequestClass,
+    capabilities: &OpenAICapabilities,
+) -> Result<(), OpenAITransformError> {
+    let Some(response_format) = request.response_format.take() else {
+        return Ok(());
+    };
+
+    match response_format.text_type {
+        ResponseFormatType::Text => Ok(()),
+        ResponseFormatType::JsonSchema => {
+            if capabilities.supports_native_structured_output {
+                request.response_format = Some(response_format);
+                return Ok(());
+            }
+
+            // Check if tools are already being used
+            if request
+                .tools
+                .as_ref()
+                .is_some_and(|tools| !tools.is_empty())
+                || request.function_call.is_some()
+                || request.tool_choice.is_some()
+            {
+                return Err(OpenAITransformError::Unsupported {
+                    feature: "tools_with_structured_output".to_string(),
+                });
+            }
+
+            // Convert json_schema to a tool call
+            match response_format.json_schema {
+                Some(schema) => {
+                    request.tools = Some(vec![ToolElement {
+                        function: Some(FunctionObject {
+                            description: Some("Output the result in JSON format".to_string()),
+                            name: "json".to_string(),
+                            parameters: schema.schema.clone(),
+                            strict: schema.strict,
+                        }),
+                        tool_type: ToolType::Function,
+                        custom: None,
+                    }]);
+
+                    request.tool_choice =
+                        Some(ChatCompletionToolChoiceOption::FunctionToolChoiceClass(
+                            FunctionToolChoiceClass {
+                                allowed_tools: None,
+                                allowed_tools_type: FunctionToolChoiceType::Function,
+                                function: Some(AllowedToolsFunction {
+                                    name: "json".to_string(),
+                                }),
+                                custom: None,
+                            },
+                        ));
+
+                    Ok(())
+                }
+                None => Err(OpenAITransformError::InvalidValue {
+                    message: "json_schema response_format is missing schema".to_string(),
+                }),
+            }
+        }
+        ResponseFormatType::JsonObject => {
+            request.response_format = Some(response_format);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_json::json;
+
+    #[test]
+    fn test_openai_detect_request() {
+        let adapter = OpenAIAdapter;
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(adapter.detect_request(&payload));
+    }
+
+    #[test]
+    fn test_openai_passthrough() {
+        let adapter = OpenAIAdapter;
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let universal = adapter.request_to_universal(payload).unwrap();
+        assert_eq!(universal.model, Some("gpt-4".to_string()));
+        assert_eq!(universal.messages.len(), 1);
+
+        let reconstructed = adapter.request_from_universal(&universal).unwrap();
+        assert_eq!(reconstructed.get("model").unwrap(), "gpt-4");
+        assert!(reconstructed.get("messages").is_some());
+    }
+
+    #[test]
+    fn test_openai_preserves_extras() {
+        let adapter = OpenAIAdapter;
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "user": "test-user-123",
+            "custom_field": "should_be_preserved"
+        });
+
+        let universal = adapter.request_to_universal(payload).unwrap();
+        assert!(universal.extras.contains_key("user"));
+        assert!(universal.extras.contains_key("custom_field"));
+
+        let reconstructed = adapter.request_from_universal(&universal).unwrap();
+        assert_eq!(reconstructed.get("user").unwrap(), "test-user-123");
+        assert_eq!(
+            reconstructed.get("custom_field").unwrap(),
+            "should_be_preserved"
+        );
+    }
+
+    #[test]
+    fn test_responses_detect_request() {
+        let adapter = ResponsesAdapter;
+        let payload = json!({
+            "model": "o1",
+            "input": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(adapter.detect_request(&payload));
+    }
+}

--- a/crates/lingua/src/providers/openai/capabilities.rs
+++ b/crates/lingua/src/providers/openai/capabilities.rs
@@ -1,0 +1,127 @@
+/*!
+OpenAI-specific capability detection used by the transformation pipeline.
+*/
+
+use crate::providers::openai::generated::CreateChatCompletionRequestClass;
+
+/// Target provider that will receive a translated OpenAI payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetProvider {
+    OpenAI,
+    Azure,
+    Vertex,
+    Fireworks,
+    Mistral,
+    Databricks,
+    Lepton,
+    Other,
+}
+
+impl std::str::FromStr for TargetProvider {
+    type Err = std::convert::Infallible;
+
+    fn from_str(provider: &str) -> Result<Self, Self::Err> {
+        Ok(match provider {
+            "openai" => Self::OpenAI,
+            "azure" => Self::Azure,
+            "vertex" => Self::Vertex,
+            "fireworks" => Self::Fireworks,
+            "mistral" => Self::Mistral,
+            "databricks" => Self::Databricks,
+            "lepton" => Self::Lepton,
+            _ => Self::Other,
+        })
+    }
+}
+
+/// Capability view derived from a request/model combination.
+#[derive(Debug, Clone)]
+pub struct OpenAICapabilities {
+    pub uses_reasoning_mode: bool,
+    pub is_legacy_o1_model: bool,
+    pub supports_native_structured_output: bool,
+
+    // Provider-specific limitations
+    pub supports_stream_options: bool,
+    pub supports_parallel_tools: bool,
+    pub supports_seed_field: bool,
+    pub requires_model_normalization: bool,
+}
+
+impl OpenAICapabilities {
+    pub fn detect(
+        request: &CreateChatCompletionRequestClass,
+        target: TargetProvider,
+    ) -> OpenAICapabilities {
+        let model = request.model.to_ascii_lowercase();
+        let uses_reasoning_mode =
+            request.reasoning_effort.is_some() || is_reasoning_model_name(&model);
+
+        // Provider-specific capability detection
+        let (
+            supports_stream_options,
+            supports_parallel_tools,
+            supports_seed_field,
+            requires_model_normalization,
+        ) = match target {
+            TargetProvider::Mistral => (false, false, true, false),
+            TargetProvider::Fireworks => (false, true, true, false),
+            TargetProvider::Databricks => (false, false, true, false),
+            TargetProvider::Azure => (true, false, true, false),
+            TargetProvider::Vertex => (true, true, true, true),
+            TargetProvider::OpenAI | TargetProvider::Lepton | TargetProvider::Other => {
+                (true, true, true, false)
+            }
+        };
+
+        OpenAICapabilities {
+            uses_reasoning_mode,
+            is_legacy_o1_model: is_legacy_o1_model(&model),
+            supports_native_structured_output: supports_native_structured_output(&model, target),
+            supports_stream_options,
+            supports_parallel_tools,
+            supports_seed_field,
+            requires_model_normalization,
+        }
+    }
+
+    pub fn requires_reasoning_transforms(&self) -> bool {
+        self.uses_reasoning_mode
+    }
+
+    /// Check if seed field should be removed for Azure with API version
+    pub fn should_remove_seed_for_azure(
+        &self,
+        target: TargetProvider,
+        has_api_version: bool,
+    ) -> bool {
+        matches!(target, TargetProvider::Azure) && has_api_version
+    }
+}
+
+/// Model prefixes that support native structured output.
+const STRUCTURED_OUTPUT_PREFIXES: &[&str] = &["gpt", "o1", "o3"];
+
+/// Model prefixes that indicate reasoning models.
+const REASONING_MODEL_PREFIXES: &[&str] = &["o1", "o2", "o3", "o4", "gpt-5"];
+
+/// Legacy o1 models that need special handling.
+const LEGACY_O1_MODELS: &[&str] = &["o1-preview", "o1-mini", "o1-preview-2024-09-12"];
+
+fn supports_native_structured_output(model: &str, target: TargetProvider) -> bool {
+    STRUCTURED_OUTPUT_PREFIXES
+        .iter()
+        .any(|prefix| model.starts_with(prefix))
+        || matches!(target, TargetProvider::Fireworks)
+}
+
+fn is_reasoning_model_name(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    REASONING_MODEL_PREFIXES
+        .iter()
+        .any(|prefix| lower.starts_with(prefix))
+}
+
+fn is_legacy_o1_model(model: &str) -> bool {
+    LEGACY_O1_MODELS.contains(&model)
+}

--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -615,6 +615,60 @@ impl TryFromLLM<Message> for openai::InputItem {
     }
 }
 
+/// Convert universal messages to OpenAI Responses API InputItem format.
+///
+/// This function handles the 1:N expansion for Tool messages - a single Tool message
+/// can contain multiple tool results, and each result becomes a separate InputItem
+/// (which is required by the Responses API).
+///
+/// This is provided as a standalone function rather than a TryFromLLM impl because
+/// Rust's coherence rules don't allow overriding the blanket Vec implementation.
+pub fn universal_to_responses_input(
+    messages: &[Message],
+) -> Result<Vec<openai::InputItem>, ConvertError> {
+    let mut result = Vec::with_capacity(messages.len());
+
+    for msg in messages {
+        match msg {
+            Message::Tool { content } => {
+                // Expand: one Tool message → multiple InputItems
+                for tool_part in content {
+                    match tool_part {
+                        ToolContentPart::ToolResult(tool_result) => {
+                            let output_string = match &tool_result.output {
+                                serde_json::Value::String(s) => s.clone(),
+                                other => serde_json::to_string(other).map_err(|e| {
+                                    ConvertError::JsonSerializationFailed {
+                                        field: "tool_result_output".to_string(),
+                                        error: e.to_string(),
+                                    }
+                                })?,
+                            };
+
+                            result.push(openai::InputItem {
+                                role: None,
+                                content: None,
+                                input_item_type: Some(openai::InputItemType::FunctionCallOutput),
+                                call_id: Some(tool_result.tool_call_id.clone()),
+                                output: Some(output_string),
+                                ..Default::default()
+                            });
+                        }
+                    }
+                }
+            }
+            other => {
+                // For all other message types, use the standard conversion
+                result.push(<openai::InputItem as TryFromLLM<Message>>::try_from(
+                    other.clone(),
+                )?);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
 /// Convert OutputItem to InputItem for unified processing
 /// OutputItem is used in responses while InputItem is used in requests,
 /// but they have very similar structure for message content

--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -2,6 +2,7 @@ use crate::error::ConvertError;
 use crate::providers::openai::generated as openai;
 use crate::serde_json;
 use crate::universal::convert::TryFromLLM;
+use crate::universal::defaults::{EMPTY_OBJECT_STR, REFUSAL_TEXT};
 use crate::universal::{
     AssistantContent, AssistantContentPart, Message, TextContentPart, ToolContentPart,
     ToolResultContentPart, UserContent, UserContentPart,
@@ -64,7 +65,9 @@ impl TryFromLLM<Vec<openai::InputItem>> for Vec<Message> {
                             .ok_or_else(|| ConvertError::MissingRequiredField {
                                 field: "function call name".to_string(),
                             })?;
-                    let arguments_str = input.arguments.unwrap_or("{}".to_string());
+                    let arguments_str = input
+                        .arguments
+                        .unwrap_or_else(|| EMPTY_OBJECT_STR.to_string());
 
                     let tool_call_part = AssistantContentPart::ToolCall {
                         tool_call_id,
@@ -228,9 +231,7 @@ impl TryFromLLM<openai::InputContent> for UserContentPart {
             openai::InputItemContentListType::Refusal => {
                 // Handle refusal - treat as regular text for now
                 UserContentPart::Text(TextContentPart {
-                    text: value
-                        .text
-                        .unwrap_or_else(|| "Content was refused".to_string()),
+                    text: value.text.unwrap_or_else(|| REFUSAL_TEXT.to_string()),
                     provider_options: None,
                 })
             }

--- a/crates/lingua/src/providers/openai/detect.rs
+++ b/crates/lingua/src/providers/openai/detect.rs
@@ -1,0 +1,323 @@
+/*!
+OpenAI format detection.
+
+This module provides functions to detect if a payload is in
+OpenAI chat completion format by attempting to deserialize into
+the OpenAI struct types.
+*/
+
+use crate::providers::openai::generated::{CreateChatCompletionRequestClass, CreateResponseClass};
+use crate::serde_json::{self, Value};
+use thiserror::Error;
+
+/// Error type for OpenAI payload detection
+#[derive(Debug, Error)]
+pub enum DetectionError {
+    #[error("Deserialization failed: {0}")]
+    DeserializationFailed(String),
+}
+
+/// Attempt to parse a JSON Value as OpenAI CreateChatCompletionRequestClass.
+///
+/// Returns the parsed struct if successful, or an error if the payload
+/// is not valid OpenAI format.
+///
+/// # Examples
+///
+/// ```rust
+/// use lingua::serde_json::json;
+/// use lingua::providers::openai::detect::try_parse_openai;
+///
+/// let openai_payload = json!({
+///     "model": "gpt-4",
+///     "messages": [{"role": "user", "content": "Hello"}]
+/// });
+///
+/// assert!(try_parse_openai(&openai_payload).is_ok());
+/// ```
+pub fn try_parse_openai(
+    payload: &Value,
+) -> Result<CreateChatCompletionRequestClass, DetectionError> {
+    serde_json::from_value(payload.clone())
+        .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))
+}
+
+/// Attempt to parse a JSON Value as OpenAI Responses API CreateResponseClass.
+///
+/// Returns the parsed struct if successful, or an error if the payload
+/// is not valid Responses API format.
+///
+/// The key distinguishing feature is the `input` field (array of InputItem or string)
+/// instead of the `messages` field used by Chat Completions.
+pub fn try_parse_responses(payload: &Value) -> Result<CreateResponseClass, DetectionError> {
+    // First check for Responses-specific indicators
+    // Responses API uses "input" field (not "messages" like Chat Completions)
+    let has_input = payload.get("input").is_some();
+
+    // Also check it doesn't have Chat Completions indicators
+    let has_messages = payload.get("messages").is_some();
+
+    if !has_input || has_messages {
+        return Err(DetectionError::DeserializationFailed(
+            "Not a Responses API payload: missing 'input' field or has 'messages' field"
+                .to_string(),
+        ));
+    }
+
+    serde_json::from_value(payload.clone())
+        .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::openai::generated::{
+        ChatCompletionRequestMessage, ChatCompletionRequestMessageContent,
+        ChatCompletionRequestMessageRole, CreateChatCompletionRequestClass, PurpleFunction,
+        ToolCall, ToolType,
+    };
+    use crate::serde_json::{self, json};
+
+    #[test]
+    fn test_try_parse_openai_basic() {
+        let request = CreateChatCompletionRequestClass {
+            model: "gpt-4".to_string(),
+            messages: vec![ChatCompletionRequestMessage {
+                role: ChatCompletionRequestMessageRole::User,
+                content: Some(ChatCompletionRequestMessageContent::String(
+                    "Hello".to_string(),
+                )),
+                name: None,
+                audio: None,
+                function_call: None,
+                refusal: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            metadata: None,
+            prompt_cache_key: None,
+            safety_identifier: None,
+            service_tier: None,
+            temperature: None,
+            top_logprobs: None,
+            top_p: None,
+            user: None,
+            audio: None,
+            frequency_penalty: None,
+            function_call: None,
+            functions: None,
+            logit_bias: None,
+            logprobs: None,
+            max_completion_tokens: None,
+            max_tokens: None,
+            modalities: None,
+            n: None,
+            parallel_tool_calls: None,
+            prediction: None,
+            presence_penalty: None,
+            reasoning_effort: None,
+            response_format: None,
+            seed: None,
+            stop: None,
+            store: None,
+            stream: None,
+            stream_options: None,
+            tool_choice: None,
+            tools: None,
+            verbosity: None,
+            web_search_options: None,
+        };
+
+        let payload = serde_json::to_value(&request).unwrap();
+        assert!(try_parse_openai(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_openai_with_system() {
+        let request = CreateChatCompletionRequestClass {
+            model: "gpt-4".to_string(),
+            messages: vec![
+                ChatCompletionRequestMessage {
+                    role: ChatCompletionRequestMessageRole::System,
+                    content: Some(ChatCompletionRequestMessageContent::String(
+                        "You are helpful".to_string(),
+                    )),
+                    name: None,
+                    audio: None,
+                    function_call: None,
+                    refusal: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                ChatCompletionRequestMessage {
+                    role: ChatCompletionRequestMessageRole::User,
+                    content: Some(ChatCompletionRequestMessageContent::String(
+                        "Hello".to_string(),
+                    )),
+                    name: None,
+                    audio: None,
+                    function_call: None,
+                    refusal: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+            ],
+            metadata: None,
+            prompt_cache_key: None,
+            safety_identifier: None,
+            service_tier: None,
+            temperature: None,
+            top_logprobs: None,
+            top_p: None,
+            user: None,
+            audio: None,
+            frequency_penalty: None,
+            function_call: None,
+            functions: None,
+            logit_bias: None,
+            logprobs: None,
+            max_completion_tokens: None,
+            max_tokens: None,
+            modalities: None,
+            n: None,
+            parallel_tool_calls: None,
+            prediction: None,
+            presence_penalty: None,
+            reasoning_effort: None,
+            response_format: None,
+            seed: None,
+            stop: None,
+            store: None,
+            stream: None,
+            stream_options: None,
+            tool_choice: None,
+            tools: None,
+            verbosity: None,
+            web_search_options: None,
+        };
+
+        let payload = serde_json::to_value(&request).unwrap();
+        assert!(try_parse_openai(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_openai_with_tool_calls() {
+        let request = CreateChatCompletionRequestClass {
+            model: "gpt-4".to_string(),
+            messages: vec![ChatCompletionRequestMessage {
+                role: ChatCompletionRequestMessageRole::Assistant,
+                content: None,
+                name: None,
+                audio: None,
+                function_call: None,
+                refusal: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_123".to_string(),
+                    tool_call_type: ToolType::Function,
+                    function: Some(PurpleFunction {
+                        name: "get_weather".to_string(),
+                        arguments: "{}".to_string(),
+                    }),
+                    custom: None,
+                }]),
+                tool_call_id: None,
+            }],
+            metadata: None,
+            prompt_cache_key: None,
+            safety_identifier: None,
+            service_tier: None,
+            temperature: None,
+            top_logprobs: None,
+            top_p: None,
+            user: None,
+            audio: None,
+            frequency_penalty: None,
+            function_call: None,
+            functions: None,
+            logit_bias: None,
+            logprobs: None,
+            max_completion_tokens: None,
+            max_tokens: None,
+            modalities: None,
+            n: None,
+            parallel_tool_calls: None,
+            prediction: None,
+            presence_penalty: None,
+            reasoning_effort: None,
+            response_format: None,
+            seed: None,
+            stop: None,
+            store: None,
+            stream: None,
+            stream_options: None,
+            tool_choice: None,
+            tools: None,
+            verbosity: None,
+            web_search_options: None,
+        };
+
+        let payload = serde_json::to_value(&request).unwrap();
+        assert!(try_parse_openai(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_try_parse_openai_fails_no_model() {
+        // Missing model field - should fail struct deserialization
+        let payload = json!({
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(try_parse_openai(&payload).is_err());
+    }
+
+    #[test]
+    fn test_try_parse_openai_empty_messages() {
+        // Empty messages - should fail struct deserialization
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": []
+        });
+        // Note: OpenAI struct allows empty messages array, so this may pass
+        // The actual validation depends on struct definition
+        let result = try_parse_openai(&payload);
+        // Just verify it doesn't panic - behavior depends on struct definition
+        let _ = result;
+    }
+
+    #[test]
+    fn test_try_parse_openai_fails_for_google() {
+        // Google format - should fail OpenAI struct deserialization
+        let payload = json!({
+            "contents": [{"role": "user", "parts": [{"text": "Hello"}]}]
+        });
+        assert!(try_parse_openai(&payload).is_err());
+    }
+
+    #[test]
+    fn test_try_parse_openai_success() {
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = try_parse_openai(&payload);
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.model, "gpt-4");
+    }
+
+    #[test]
+    fn test_try_parse_openai_permissive_for_anthropic() {
+        // Anthropic format with max_tokens but no system role in messages
+        let payload = json!({
+            "model": "claude-3-5-sonnet",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        // This should actually succeed because OpenAI is permissive
+        // OpenAI accepts extra fields and the structure is similar
+        let result = try_parse_openai(&payload);
+        // Note: Due to OpenAI's permissive schema, this may pass
+        let _ = result;
+    }
+}

--- a/crates/lingua/src/providers/openai/mod.rs
+++ b/crates/lingua/src/providers/openai/mod.rs
@@ -6,14 +6,26 @@ that match the TypeScript SDK exactly, now automatically generated from the offi
 OpenAI OpenAPI specification.
 */
 
+pub mod adapter;
+pub mod capabilities;
 pub mod convert;
+pub mod detect;
 pub mod generated;
+
+// Re-export adapters and transformations
+pub use adapter::{apply_target_transforms, OpenAIAdapter, OpenAITransformError, ResponsesAdapter};
 
 #[cfg(test)]
 pub mod test_responses;
 
 #[cfg(test)]
 pub mod test_chat_completions;
+
+// Re-export detection functions
+pub use detect::{try_parse_openai, try_parse_responses, DetectionError};
+
+// Re-export conversion functions
+pub use convert::universal_to_responses_input;
 
 // Re-export generated types (official OpenAI API types from OpenAPI spec)
 pub use generated::{

--- a/crates/lingua/src/universal/defaults.rs
+++ b/crates/lingua/src/universal/defaults.rs
@@ -1,0 +1,20 @@
+//! Default/placeholder values for transformed responses.
+//!
+//! These constants are used when converting between provider formats
+//! where the source format doesn't include certain fields.
+
+/// Placeholder for missing model names.
+pub const PLACEHOLDER_MODEL: &str = "transformed";
+
+/// Placeholder for missing response IDs.
+/// Provider adapters prefix as needed (e.g., "msg_" + PLACEHOLDER_ID).
+pub const PLACEHOLDER_ID: &str = "transformed";
+
+/// Empty JSON object string for missing tool arguments.
+pub const EMPTY_OBJECT_STR: &str = "{}";
+
+/// Default refusal message text.
+pub const REFUSAL_TEXT: &str = "Content was refused";
+
+/// Default image MIME type.
+pub const DEFAULT_MIME_TYPE: &str = "image/jpeg";

--- a/crates/lingua/src/universal/mod.rs
+++ b/crates/lingua/src/universal/mod.rs
@@ -10,6 +10,7 @@ This module provides a 1:1 Rust implementation of the AI SDK ModelMessage format
 */
 
 pub mod convert;
+pub mod defaults;
 pub mod message;
 pub mod request;
 pub mod response;
@@ -17,6 +18,7 @@ pub mod stream;
 pub mod transform;
 
 // Re-export main types for convenience
+pub use defaults::*;
 pub use message::*;
 pub use request::{UniversalParams, UniversalRequest};
 pub use response::{FinishReason, UniversalResponse, UniversalUsage};

--- a/crates/lingua/src/universal/mod.rs
+++ b/crates/lingua/src/universal/mod.rs
@@ -6,10 +6,19 @@ This module provides a 1:1 Rust implementation of the AI SDK ModelMessage format
 * Content parts - Multi-modal content support (text, images, files, reasoning, tool calls)
 * Exact JSON serialization compatibility with the AI SDK
 * Provider options support
+* Universal transformations (message flattening, system extraction)
 */
 
 pub mod convert;
 pub mod message;
+pub mod request;
+pub mod response;
+pub mod stream;
+pub mod transform;
 
 // Re-export main types for convenience
 pub use message::*;
+pub use request::{UniversalParams, UniversalRequest};
+pub use response::{FinishReason, UniversalResponse, UniversalUsage};
+pub use stream::{UniversalStreamChoice, UniversalStreamChunk};
+pub use transform::{extract_system_messages, flatten_consecutive_messages};

--- a/crates/lingua/src/universal/request.rs
+++ b/crates/lingua/src/universal/request.rs
@@ -1,0 +1,81 @@
+/*!
+Universal request types for cross-provider transformation.
+
+This module provides a canonical representation of LLM requests that can be
+converted to/from any provider format.
+
+## Design principles
+
+1. **Round-trip preservation**: Any field not mapped to a canonical field goes
+   into `extras` and is restored when converting back to the source format.
+
+2. **Canonical naming**: Uses consistent field names (e.g., `max_tokens`, `top_p`)
+   regardless of what individual providers call them.
+
+3. **Minimal typing for complex fields**: Fields like `tools`, `tool_choice`, and
+   `response_format` are kept as `Value` since they vary significantly across providers.
+*/
+
+use crate::serde_json::{Map, Value};
+use crate::universal::message::Message;
+
+/// Universal request envelope for LLM API calls.
+///
+/// This type captures the common structure across all provider request formats.
+/// Provider-specific fields that don't map to canonical params go into `extras`.
+#[derive(Debug, Clone)]
+pub struct UniversalRequest {
+    /// Model identifier (may be None for providers that use endpoint-based model selection)
+    pub model: Option<String>,
+
+    /// Conversation messages in universal format
+    pub messages: Vec<Message>,
+
+    /// Common request parameters
+    pub params: UniversalParams,
+
+    /// Provider-specific fields not captured in params
+    pub extras: Map<String, Value>,
+}
+
+/// Common request parameters across providers.
+///
+/// Uses canonical names - adapters handle mapping to provider-specific names.
+#[derive(Debug, Clone, Default)]
+pub struct UniversalParams {
+    /// Sampling temperature (0.0 to 2.0 typically)
+    pub temperature: Option<f64>,
+
+    /// Nucleus sampling probability
+    pub top_p: Option<f64>,
+
+    /// Top-k sampling (not supported by all providers)
+    pub top_k: Option<i64>,
+
+    /// Maximum tokens to generate
+    pub max_tokens: Option<i64>,
+
+    /// Stop sequences (kept as Value due to union type in OpenAI)
+    pub stop: Option<Value>,
+
+    /// Tool definitions (schema varies by provider)
+    pub tools: Option<Value>,
+
+    /// Tool selection strategy (varies by provider)
+    pub tool_choice: Option<Value>,
+
+    /// Output format specification (varies by provider)
+    pub response_format: Option<Value>,
+
+    /// Random seed for deterministic generation
+    pub seed: Option<i64>,
+
+    /// Presence penalty (-2.0 to 2.0)
+    pub presence_penalty: Option<f64>,
+
+    /// Frequency penalty (-2.0 to 2.0)
+    pub frequency_penalty: Option<f64>,
+
+    /// Whether to stream the response
+    pub stream: Option<bool>,
+}

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -5,7 +5,6 @@ This module provides a canonical representation of LLM responses that can be
 converted to/from any provider format.
 */
 
-use crate::serde_json::{Map, Value};
 use crate::universal::message::Message;
 
 /// Universal response envelope for LLM API responses.
@@ -24,9 +23,6 @@ pub struct UniversalResponse {
 
     /// Why the model stopped generating
     pub finish_reason: Option<FinishReason>,
-
-    /// Provider-specific response fields
-    pub extras: Map<String, Value>,
 }
 
 /// Token usage statistics.

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -1,0 +1,84 @@
+/*!
+Universal response types for cross-provider transformation.
+
+This module provides a canonical representation of LLM responses that can be
+converted to/from any provider format.
+*/
+
+use crate::serde_json::{Map, Value};
+use crate::universal::message::Message;
+
+/// Universal response envelope for LLM API responses.
+///
+/// This type captures the common structure across all provider response formats.
+#[derive(Debug, Clone)]
+pub struct UniversalResponse {
+    /// Model that generated the response
+    pub model: Option<String>,
+
+    /// Response messages (may be multiple for multi-choice responses)
+    pub messages: Vec<Message>,
+
+    /// Token usage statistics
+    pub usage: Option<UniversalUsage>,
+
+    /// Why the model stopped generating
+    pub finish_reason: Option<FinishReason>,
+
+    /// Provider-specific response fields
+    pub extras: Map<String, Value>,
+}
+
+/// Token usage statistics.
+#[derive(Debug, Clone, Default)]
+pub struct UniversalUsage {
+    /// Tokens in the prompt/input
+    pub prompt_tokens: Option<i64>,
+
+    /// Tokens in the completion/output
+    pub completion_tokens: Option<i64>,
+
+    /// Cached tokens in the prompt (from prompt caching)
+    pub prompt_cached_tokens: Option<i64>,
+
+    /// Tokens written to cache during this request
+    pub prompt_cache_creation_tokens: Option<i64>,
+
+    /// Tokens used for reasoning in completion (OpenAI: completion_tokens_details.reasoning_tokens, Google: thoughtsTokenCount)
+    pub completion_reasoning_tokens: Option<i64>,
+}
+
+/// Reason why the model stopped generating.
+///
+/// Normalized across provider-specific values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FinishReason {
+    /// Normal completion (OpenAI: "stop", Anthropic: "end_turn", Google: "STOP")
+    Stop,
+
+    /// Hit token limit (OpenAI: "length", Anthropic: "max_tokens")
+    Length,
+
+    /// Model wants to call tools (OpenAI: "tool_calls", Anthropic: "tool_use")
+    ToolCalls,
+
+    /// Content was filtered
+    ContentFilter,
+
+    /// Provider-specific reason not in the canonical set
+    Other(String),
+}
+
+impl std::str::FromStr for FinishReason {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.to_lowercase().as_str() {
+            "stop" | "end_turn" | "completed" => FinishReason::Stop,
+            "length" | "max_tokens" | "max_output_tokens" => FinishReason::Length,
+            "tool_calls" | "tool_use" => FinishReason::ToolCalls,
+            "content_filter" => FinishReason::ContentFilter,
+            _ => FinishReason::Other(s.to_string()),
+        })
+    }
+}

--- a/crates/lingua/src/universal/stream.rs
+++ b/crates/lingua/src/universal/stream.rs
@@ -1,0 +1,257 @@
+/*!
+Universal streaming types for cross-provider stream transformation.
+
+This module provides a canonical representation of LLM streaming chunks that can be
+converted to/from any provider format. The format follows OpenAI's streaming chunk
+structure as the canonical representation.
+*/
+
+use crate::serde_json::{self, Value};
+use crate::universal::response::UniversalUsage;
+use serde::{Deserialize, Serialize};
+
+/// A single choice in a streaming chunk.
+///
+/// Mirrors OpenAI's StreamChoice structure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UniversalStreamChoice {
+    /// Index of this choice in the choices array
+    pub index: u32,
+
+    /// Delta content for this chunk (role, content, tool_calls, etc.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delta: Option<Value>,
+
+    /// Reason why generation stopped (only present on final chunk)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<String>,
+}
+
+/// A normalized streaming chunk following OpenAI's format.
+///
+/// This is the universal representation for streaming events from all providers.
+/// Provider-specific formats are normalized to this structure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UniversalStreamChunk {
+    /// Unique identifier for this completion
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// Model that generated this chunk
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// Array of choices (usually single element for streaming)
+    #[serde(default)]
+    pub choices: Vec<UniversalStreamChoice>,
+
+    /// Unix timestamp when chunk was created
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<u64>,
+
+    /// Token usage (usually only on final chunk)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<UniversalUsage>,
+
+    /// Internal flag for keep-alive events (not serialized)
+    #[serde(skip)]
+    keep_alive: bool,
+}
+
+impl UniversalStreamChunk {
+    /// Create a new streaming chunk with the given fields.
+    pub fn new(
+        id: Option<String>,
+        model: Option<String>,
+        choices: Vec<UniversalStreamChoice>,
+        created: Option<u64>,
+        usage: Option<UniversalUsage>,
+    ) -> Self {
+        Self {
+            id,
+            model,
+            choices,
+            created,
+            usage,
+            keep_alive: false,
+        }
+    }
+
+    /// Create a keep-alive chunk that signals the stream is active but has no content.
+    ///
+    /// Keep-alive chunks are used for:
+    /// - SSE ping events
+    /// - Anthropic metadata events (message_start, content_block_start/stop)
+    /// - Events that don't produce user-visible content
+    pub fn keep_alive() -> Self {
+        Self {
+            id: None,
+            model: None,
+            choices: Vec::new(),
+            created: None,
+            usage: None,
+            keep_alive: true,
+        }
+    }
+
+    /// Check if this is a keep-alive chunk.
+    pub fn is_keep_alive(&self) -> bool {
+        self.keep_alive
+    }
+
+    /// Create a simple text delta chunk.
+    pub fn text_delta(index: u32, content: &str) -> Self {
+        Self::new(
+            None,
+            None,
+            vec![UniversalStreamChoice {
+                index,
+                delta: Some(serde_json::json!({
+                    "role": "assistant",
+                    "content": content
+                })),
+                finish_reason: None,
+            }],
+            None,
+            None,
+        )
+    }
+
+    /// Create a finish chunk with the given reason.
+    pub fn finish(index: u32, reason: &str) -> Self {
+        Self::new(
+            None,
+            None,
+            vec![UniversalStreamChoice {
+                index,
+                delta: Some(serde_json::json!({})),
+                finish_reason: Some(reason.to_string()),
+            }],
+            None,
+            None,
+        )
+    }
+}
+
+impl UniversalStreamChoice {
+    /// Create a new stream choice with a text delta.
+    pub fn text_delta(index: u32, content: &str) -> Self {
+        Self {
+            index,
+            delta: Some(serde_json::json!({
+                "role": "assistant",
+                "content": content
+            })),
+            finish_reason: None,
+        }
+    }
+
+    /// Create a finish choice with the given reason.
+    pub fn finish(index: u32, reason: &str) -> Self {
+        Self {
+            index,
+            delta: Some(serde_json::json!({})),
+            finish_reason: Some(reason.to_string()),
+        }
+    }
+}
+
+// Implement Serialize for UniversalUsage to support streaming chunk serialization
+impl Serialize for UniversalUsage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("UniversalUsage", 5)?;
+        if let Some(prompt) = self.prompt_tokens {
+            state.serialize_field("prompt_tokens", &prompt)?;
+        }
+        if let Some(completion) = self.completion_tokens {
+            state.serialize_field("completion_tokens", &completion)?;
+        }
+        if let Some(cached) = self.prompt_cached_tokens {
+            state.serialize_field("prompt_cached_tokens", &cached)?;
+        }
+        if let Some(cache_creation) = self.prompt_cache_creation_tokens {
+            state.serialize_field("prompt_cache_creation_tokens", &cache_creation)?;
+        }
+        if let Some(reasoning) = self.completion_reasoning_tokens {
+            state.serialize_field("completion_reasoning_tokens", &reasoning)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for UniversalUsage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            prompt_tokens: Option<i64>,
+            completion_tokens: Option<i64>,
+            prompt_cached_tokens: Option<i64>,
+            prompt_cache_creation_tokens: Option<i64>,
+            completion_reasoning_tokens: Option<i64>,
+        }
+        let helper = Helper::deserialize(deserializer)?;
+        Ok(UniversalUsage {
+            prompt_tokens: helper.prompt_tokens,
+            completion_tokens: helper.completion_tokens,
+            prompt_cached_tokens: helper.prompt_cached_tokens,
+            prompt_cache_creation_tokens: helper.prompt_cache_creation_tokens,
+            completion_reasoning_tokens: helper.completion_reasoning_tokens,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keep_alive_chunk() {
+        let chunk = UniversalStreamChunk::keep_alive();
+        assert!(chunk.is_keep_alive());
+        assert!(chunk.choices.is_empty());
+    }
+
+    #[test]
+    fn test_text_delta_chunk() {
+        let chunk = UniversalStreamChunk::text_delta(0, "Hello");
+        assert!(!chunk.is_keep_alive());
+        assert_eq!(chunk.choices.len(), 1);
+        assert_eq!(chunk.choices[0].index, 0);
+
+        let delta = chunk.choices[0].delta.as_ref().unwrap();
+        assert_eq!(delta["content"], "Hello");
+        assert_eq!(delta["role"], "assistant");
+    }
+
+    #[test]
+    fn test_finish_chunk() {
+        let chunk = UniversalStreamChunk::finish(0, "stop");
+        assert!(!chunk.is_keep_alive());
+        assert_eq!(chunk.choices.len(), 1);
+        assert_eq!(chunk.choices[0].finish_reason, Some("stop".to_string()));
+    }
+
+    #[test]
+    fn test_serialization() {
+        let chunk = UniversalStreamChunk::new(
+            Some("test-id".to_string()),
+            Some("gpt-4".to_string()),
+            vec![UniversalStreamChoice::text_delta(0, "Hi")],
+            Some(1234567890),
+            None,
+        );
+
+        let json = serde_json::to_value(&chunk).unwrap();
+        assert_eq!(json["id"], "test-id");
+        assert_eq!(json["model"], "gpt-4");
+        assert_eq!(json["created"], 1234567890);
+        assert!(json.get("keep_alive").is_none()); // Should be skipped
+    }
+}

--- a/crates/lingua/src/universal/transform.rs
+++ b/crates/lingua/src/universal/transform.rs
@@ -1,0 +1,391 @@
+/*!
+Lingua → Lingua transformations that run before converting to a provider format.
+
+This module provides universal transformations that are common across multiple
+providers, mirroring the proxy's behavior:
+
+- **Message flattening**: Merge consecutive messages of the same role
+  (needed for Anthropic, Google, Bedrock)
+- **System message extraction**: Extract system messages to a separate parameter
+  (needed for Anthropic, Google, Bedrock)
+
+# Example
+
+```
+use lingua::universal::{Message, UserContent, extract_system_messages, flatten_consecutive_messages};
+
+let mut messages = vec![
+    Message::System { content: UserContent::String("You are helpful".into()) },
+    Message::User { content: UserContent::String("Hello".into()) },
+    Message::User { content: UserContent::String("World".into()) },
+];
+
+// Extract system messages (for providers that need them separate)
+let system = extract_system_messages(&mut messages);
+assert_eq!(system.len(), 1);
+
+// Flatten consecutive messages of the same role
+flatten_consecutive_messages(&mut messages);
+assert_eq!(messages.len(), 1);
+```
+*/
+
+use crate::universal::{
+    AssistantContent, AssistantContentPart, Message, TextContentPart, ToolContent, UserContent,
+    UserContentPart,
+};
+
+/// Extract system messages from the message list.
+///
+/// Removes all `Message::System` variants and returns their content.
+/// This is needed for providers like Anthropic, Google, and Bedrock
+/// where system messages are passed as a separate parameter.
+///
+/// # Example
+///
+/// ```
+/// use lingua::universal::{Message, UserContent, extract_system_messages};
+///
+/// let mut messages = vec![
+///     Message::System { content: UserContent::String("System prompt".into()) },
+///     Message::User { content: UserContent::String("Hello".into()) },
+/// ];
+///
+/// let system = extract_system_messages(&mut messages);
+/// assert_eq!(system.len(), 1);
+/// assert_eq!(messages.len(), 1); // Only user message remains
+/// ```
+pub fn extract_system_messages(messages: &mut Vec<Message>) -> Vec<UserContent> {
+    let mut system_contents = Vec::new();
+    messages.retain(|msg| {
+        if let Message::System { content } = msg {
+            system_contents.push(content.clone());
+            false
+        } else {
+            true
+        }
+    });
+    system_contents
+}
+
+/// Merge consecutive messages of the same role.
+///
+/// This is needed for providers like Anthropic, Google, and Bedrock
+/// that don't allow consecutive messages of the same role.
+///
+/// For example:
+/// - User("Hello") + User("World") → User(["Hello", "World"])
+/// - Assistant("Hi") + Assistant("there") → Assistant(["Hi", "there"])
+///
+/// # Example
+///
+/// ```
+/// use lingua::universal::{Message, UserContent, flatten_consecutive_messages};
+///
+/// let mut messages = vec![
+///     Message::User { content: UserContent::String("Hello".into()) },
+///     Message::User { content: UserContent::String("World".into()) },
+/// ];
+///
+/// flatten_consecutive_messages(&mut messages);
+/// assert_eq!(messages.len(), 1); // Merged into single user message
+/// ```
+pub fn flatten_consecutive_messages(messages: &mut Vec<Message>) {
+    if messages.is_empty() {
+        return;
+    }
+
+    let mut result: Vec<Message> = Vec::with_capacity(messages.len());
+
+    for msg in messages.drain(..) {
+        if let Some(last) = result.last_mut() {
+            if can_merge(last, &msg) {
+                merge_messages(last, msg);
+                continue;
+            }
+        }
+        result.push(msg);
+    }
+
+    *messages = result;
+}
+
+/// Check if two messages can be merged (same role).
+fn can_merge(a: &Message, b: &Message) -> bool {
+    matches!(
+        (a, b),
+        (Message::User { .. }, Message::User { .. })
+            | (Message::Assistant { .. }, Message::Assistant { .. })
+            | (Message::System { .. }, Message::System { .. })
+            | (Message::Tool { .. }, Message::Tool { .. })
+    )
+}
+
+/// Merge message `b` into message `a`.
+fn merge_messages(a: &mut Message, b: Message) {
+    match (a, b) {
+        (Message::User { content: a_content }, Message::User { content: b_content }) => {
+            merge_user_content(a_content, b_content);
+        }
+        (
+            Message::Assistant {
+                content: a_content, ..
+            },
+            Message::Assistant {
+                content: b_content, ..
+            },
+        ) => {
+            merge_assistant_content(a_content, b_content);
+        }
+        (Message::System { content: a_content }, Message::System { content: b_content }) => {
+            merge_user_content(a_content, b_content);
+        }
+        (Message::Tool { content: a_content }, Message::Tool { content: b_content }) => {
+            merge_tool_content(a_content, b_content);
+        }
+        _ => {} // Can't merge different roles
+    }
+}
+
+/// Merge two UserContent values.
+fn merge_user_content(a: &mut UserContent, b: UserContent) {
+    // Replace `a` with a temporary empty array, get the old value
+    let old_a = std::mem::replace(a, UserContent::Array(vec![]));
+    let a_parts = user_content_to_parts(old_a);
+    let b_parts = user_content_to_parts(b);
+    let mut merged = a_parts;
+    merged.extend(b_parts);
+    *a = UserContent::Array(merged);
+}
+
+/// Merge two AssistantContent values.
+fn merge_assistant_content(a: &mut AssistantContent, b: AssistantContent) {
+    // Replace `a` with a temporary empty array, get the old value
+    let old_a = std::mem::replace(a, AssistantContent::Array(vec![]));
+    let a_parts = assistant_content_to_parts(old_a);
+    let b_parts = assistant_content_to_parts(b);
+    let mut merged = a_parts;
+    merged.extend(b_parts);
+    *a = AssistantContent::Array(merged);
+}
+
+/// Merge two ToolContent values (Vec<ToolContentPart>).
+fn merge_tool_content(a: &mut ToolContent, b: ToolContent) {
+    a.extend(b);
+}
+
+/// Convert UserContent to Vec<UserContentPart>.
+fn user_content_to_parts(content: UserContent) -> Vec<UserContentPart> {
+    match content {
+        UserContent::String(text) => vec![UserContentPart::Text(TextContentPart {
+            text,
+            provider_options: None,
+        })],
+        UserContent::Array(parts) => parts,
+    }
+}
+
+/// Convert AssistantContent to Vec<AssistantContentPart>.
+fn assistant_content_to_parts(content: AssistantContent) -> Vec<AssistantContentPart> {
+    match content {
+        AssistantContent::String(text) => vec![AssistantContentPart::Text(TextContentPart {
+            text,
+            provider_options: None,
+        })],
+        AssistantContent::Array(parts) => parts,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_system_messages() {
+        let mut messages = vec![
+            Message::System {
+                content: UserContent::String("System prompt".into()),
+            },
+            Message::User {
+                content: UserContent::String("Hello".into()),
+            },
+            Message::System {
+                content: UserContent::String("Another system".into()),
+            },
+        ];
+
+        let system = extract_system_messages(&mut messages);
+
+        assert_eq!(system.len(), 2);
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(messages[0], Message::User { .. }));
+    }
+
+    #[test]
+    fn test_flatten_consecutive_user_messages() {
+        let mut messages = vec![
+            Message::User {
+                content: UserContent::String("Hello".into()),
+            },
+            Message::User {
+                content: UserContent::String("World".into()),
+            },
+        ];
+
+        flatten_consecutive_messages(&mut messages);
+
+        assert_eq!(messages.len(), 1);
+        if let Message::User {
+            content: UserContent::Array(parts),
+        } = &messages[0]
+        {
+            assert_eq!(parts.len(), 2);
+        } else {
+            panic!("Expected User message with Array content");
+        }
+    }
+
+    #[test]
+    fn test_flatten_consecutive_assistant_messages() {
+        let mut messages = vec![
+            Message::Assistant {
+                content: AssistantContent::String("Hi".into()),
+                id: None,
+            },
+            Message::Assistant {
+                content: AssistantContent::String("there".into()),
+                id: Some("id2".into()),
+            },
+        ];
+
+        flatten_consecutive_messages(&mut messages);
+
+        assert_eq!(messages.len(), 1);
+        if let Message::Assistant {
+            content: AssistantContent::Array(parts),
+            ..
+        } = &messages[0]
+        {
+            assert_eq!(parts.len(), 2);
+        } else {
+            panic!("Expected Assistant message with Array content");
+        }
+    }
+
+    #[test]
+    fn test_no_modification_when_not_called() {
+        let messages = [
+            Message::User {
+                content: UserContent::String("Hello".into()),
+            },
+            Message::User {
+                content: UserContent::String("World".into()),
+            },
+        ];
+
+        // If we don't call flatten_consecutive_messages, messages stay as-is
+        assert_eq!(messages.len(), 2);
+    }
+
+    #[test]
+    fn test_system_messages_preserved_when_not_extracted() {
+        let messages = [
+            Message::System {
+                content: UserContent::String("System".into()),
+            },
+            Message::User {
+                content: UserContent::String("Hello".into()),
+            },
+        ];
+
+        // If we don't call extract_system_messages, system messages stay in place
+        assert_eq!(messages.len(), 2);
+        assert!(matches!(messages[0], Message::System { .. }));
+    }
+
+    #[test]
+    fn test_mixed_message_sequence() {
+        let mut messages = vec![
+            Message::User {
+                content: UserContent::String("1".into()),
+            },
+            Message::User {
+                content: UserContent::String("2".into()),
+            },
+            Message::Assistant {
+                content: AssistantContent::String("A".into()),
+                id: None,
+            },
+            Message::User {
+                content: UserContent::String("3".into()),
+            },
+        ];
+
+        flatten_consecutive_messages(&mut messages);
+
+        // [User1, User2] -> [User], [Assistant] -> [Assistant], [User3] -> [User]
+        assert_eq!(messages.len(), 3);
+        assert!(matches!(messages[0], Message::User { .. }));
+        assert!(matches!(messages[1], Message::Assistant { .. }));
+        assert!(matches!(messages[2], Message::User { .. }));
+    }
+
+    #[test]
+    fn test_flatten_tool_messages() {
+        use crate::serde_json;
+        use crate::universal::{ToolContentPart, ToolResultContentPart};
+
+        let mut messages = vec![
+            Message::Tool {
+                content: vec![ToolContentPart::ToolResult(ToolResultContentPart {
+                    tool_call_id: "1".into(),
+                    tool_name: "test".into(),
+                    output: serde_json::json!("result1"),
+                    provider_options: None,
+                })],
+            },
+            Message::Tool {
+                content: vec![ToolContentPart::ToolResult(ToolResultContentPart {
+                    tool_call_id: "2".into(),
+                    tool_name: "test".into(),
+                    output: serde_json::json!("result2"),
+                    provider_options: None,
+                })],
+            },
+        ];
+
+        flatten_consecutive_messages(&mut messages);
+
+        assert_eq!(messages.len(), 1);
+        if let Message::Tool { content } = &messages[0] {
+            assert_eq!(content.len(), 2);
+        } else {
+            panic!("Expected Tool message");
+        }
+    }
+
+    #[test]
+    fn test_combined_extract_and_flatten() {
+        // Test the typical flow for providers like Anthropic
+        let mut messages = vec![
+            Message::System {
+                content: UserContent::String("You are helpful".into()),
+            },
+            Message::User {
+                content: UserContent::String("Hello".into()),
+            },
+            Message::User {
+                content: UserContent::String("World".into()),
+            },
+        ];
+
+        // Step 1: Extract system messages
+        let system = extract_system_messages(&mut messages);
+        assert_eq!(system.len(), 1);
+
+        // Step 2: Flatten consecutive messages
+        flatten_consecutive_messages(&mut messages);
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(messages[0], Message::User { .. }));
+    }
+}

--- a/crates/lingua/src/util/media.rs
+++ b/crates/lingua/src/util/media.rs
@@ -1,0 +1,493 @@
+/*!
+Media URL fetching and conversion utilities.
+
+This module provides utilities for fetching media from URLs and converting
+between base64 data URLs and binary data. It mirrors the proxy's behavior
+in `packages/proxy/src/providers/util.ts`.
+*/
+
+use thiserror::Error;
+
+/// A parsed media block containing the MIME type and base64-encoded data.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MediaBlock {
+    /// The MIME type of the media (e.g., "image/png", "application/pdf").
+    pub media_type: String,
+    /// The base64-encoded data (without the data URL prefix).
+    pub data: String,
+}
+
+/// Errors that can occur during media operations.
+#[derive(Debug, Error)]
+pub enum MediaError {
+    /// Failed to fetch media from URL.
+    #[error("failed to fetch media: {0}")]
+    FetchError(String),
+    /// The response did not include a content type.
+    #[error("failed to get content type of the media")]
+    MissingContentType,
+    /// The media type is not in the allowed list.
+    #[error("unsupported media type: {0}")]
+    UnsupportedMediaType(String),
+    /// The media size exceeds the maximum allowed.
+    #[error("media size exceeds the {0} MB limit")]
+    SizeExceeded(usize),
+    /// Failed to decode base64 data.
+    #[error("failed to decode base64: {0}")]
+    Base64Error(String),
+}
+
+/// Parse a base64 data URL into its components.
+///
+/// Returns `None` if the URL is not a valid data URL.
+///
+/// # Example
+///
+/// ```
+/// use lingua::util::media::parse_base64_data_url;
+///
+/// let url = "data:image/png;base64,iVBORw0KGgo=";
+/// let block = parse_base64_data_url(url).unwrap();
+/// assert_eq!(block.media_type, "image/png");
+/// assert_eq!(block.data, "iVBORw0KGgo=");
+/// ```
+pub fn parse_base64_data_url(url: &str) -> Option<MediaBlock> {
+    // Pattern: data:<media_type>;base64,<data>
+    if !url.starts_with("data:") {
+        return None;
+    }
+
+    let without_prefix = &url["data:".len()..];
+    let (meta, data) = without_prefix.split_once(',')?;
+
+    if data.is_empty() {
+        return None;
+    }
+
+    // meta should be like "image/png;base64"
+    let (media_type, encoding) = meta.split_once(';')?;
+    if encoding != "base64" {
+        return None;
+    }
+
+    Some(MediaBlock {
+        media_type: media_type.to_string(),
+        data: data.to_string(),
+    })
+}
+
+/// Convert a MediaBlock back to a data URL.
+///
+/// # Example
+///
+/// ```
+/// use lingua::util::media::{MediaBlock, media_block_to_url};
+///
+/// let block = MediaBlock {
+///     media_type: "image/png".to_string(),
+///     data: "iVBORw0KGgo=".to_string(),
+/// };
+/// let url = media_block_to_url(&block);
+/// assert_eq!(url, "data:image/png;base64,iVBORw0KGgo=");
+/// ```
+pub fn media_block_to_url(block: &MediaBlock) -> String {
+    format!("data:{};base64,{}", block.media_type, block.data)
+}
+
+/// Parse file metadata from a URL.
+///
+/// Returns the filename extracted from the URL path, and optionally the content type
+/// if it can be determined from query parameters (e.g., S3 presigned URLs).
+#[derive(Debug, Clone, PartialEq)]
+pub struct FileMetadata {
+    /// The filename extracted from the URL.
+    pub filename: String,
+    /// The content type, if available.
+    pub content_type: Option<String>,
+}
+
+/// Parse file metadata from a URL.
+///
+/// This handles:
+/// - Regular HTTP(S) URLs: extracts filename from path
+/// - S3 presigned URLs: extracts filename from response-content-disposition
+///
+/// Returns `None` if the URL cannot be parsed or doesn't contain a filename.
+pub fn parse_file_metadata_from_url(url: &str) -> Option<FileMetadata> {
+    // Handle empty string
+    if url.is_empty() || url.trim().is_empty() {
+        return None;
+    }
+
+    // Try to parse as URL
+    let parsed = url::Url::parse(url).ok()?;
+
+    // If the URL is not http(s), file cannot be accessed
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return None;
+    }
+
+    // If pathname is empty or ends with "/", there's no filename to extract
+    let path = parsed.path();
+    if path.is_empty() || path == "/" || path.ends_with('/') {
+        return None;
+    }
+
+    // Get the last segment of the path
+    let mut filename = path.split('/').next_back()?.to_string();
+    if filename.is_empty() {
+        return None;
+    }
+
+    let mut content_type = None;
+
+    // Handle case where this is an S3 pre-signed URL
+    if parsed.query_pairs().any(|(k, _)| k == "X-Amz-Expires") {
+        // Try to extract filename from response-content-disposition
+        if let Some((_, disposition)) = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "response-content-disposition")
+        {
+            // Simple parsing: look for filename="..." or filename*=...
+            if let Some(fname) = parse_content_disposition(&disposition) {
+                filename = fname;
+            }
+        }
+
+        // Try to extract content type
+        if let Some((_, ct)) = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "response-content-type")
+        {
+            content_type = Some(ct.to_string());
+        }
+    }
+
+    // URL decode the filename
+    if let Ok(decoded) = urlencoding::decode(&filename) {
+        filename = decoded.into_owned();
+    }
+
+    Some(FileMetadata {
+        filename,
+        content_type,
+    })
+}
+
+/// Simple content-disposition parser to extract filename.
+fn parse_content_disposition(value: &str) -> Option<String> {
+    // Look for filename="..." pattern
+    if let Some(start) = value.find("filename=\"") {
+        let rest = &value[start + 10..];
+        if let Some(end) = rest.find('"') {
+            let filename = &rest[..end];
+            return Some(
+                urlencoding::decode(filename)
+                    .map(|s| s.into_owned())
+                    .unwrap_or_else(|_| filename.to_string()),
+            );
+        }
+    }
+
+    // Look for filename*=UTF-8''... pattern
+    if let Some(start) = value.find("filename*=") {
+        let rest = &value[start + 10..];
+        // Skip encoding prefix like "UTF-8''"
+        if let Some(quote_pos) = rest.find("''") {
+            let encoded = &rest[quote_pos + 2..];
+            // Take until semicolon or end
+            let encoded = encoded.split(';').next().unwrap_or(encoded);
+            return urlencoding::decode(encoded.trim())
+                .map(|s| s.into_owned())
+                .ok();
+        }
+    }
+
+    None
+}
+
+// ============================================================================
+// Async URL Fetching - WASM implementation
+// ============================================================================
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_fetch {
+    use super::*;
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen_futures::JsFuture;
+    use web_sys::{Request, RequestInit, RequestMode, Response};
+
+    /// Fetch a URL and return its content as a MediaBlock.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL to fetch
+    /// * `allowed_types` - Optional list of allowed MIME types. If `None`, all types are allowed.
+    /// * `max_bytes` - Optional maximum size in bytes. If `None`, no limit is applied.
+    pub async fn fetch_url_to_base64(
+        url: &str,
+        allowed_types: Option<&[&str]>,
+        max_bytes: Option<usize>,
+    ) -> Result<MediaBlock, MediaError> {
+        let window = web_sys::window().ok_or_else(|| MediaError::FetchError("no window".into()))?;
+
+        // Create request
+        let opts = RequestInit::new();
+        opts.set_method("GET");
+        opts.set_mode(RequestMode::Cors);
+
+        let request = Request::new_with_str_and_init(url, &opts)
+            .map_err(|e| MediaError::FetchError(format!("{:?}", e)))?;
+
+        // Fetch
+        let resp_value = JsFuture::from(window.fetch_with_request(&request))
+            .await
+            .map_err(|e| MediaError::FetchError(format!("{:?}", e)))?;
+
+        let resp: Response = resp_value
+            .dyn_into()
+            .map_err(|_| MediaError::FetchError("response is not a Response".into()))?;
+
+        if !resp.ok() {
+            return Err(MediaError::FetchError(format!(
+                "HTTP {}",
+                resp.status_text()
+            )));
+        }
+
+        // Get content type
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .map_err(|e| MediaError::FetchError(format!("{:?}", e)))?
+            .ok_or(MediaError::MissingContentType)?;
+
+        // Extract base content type (before semicolon)
+        let base_content_type = content_type
+            .split(';')
+            .next()
+            .unwrap_or(&content_type)
+            .trim()
+            .to_string();
+
+        // Check allowed types
+        if let Some(allowed) = allowed_types {
+            if !allowed.contains(&base_content_type.as_str()) {
+                return Err(MediaError::UnsupportedMediaType(base_content_type));
+            }
+        }
+
+        // Get array buffer
+        let array_buffer = JsFuture::from(
+            resp.array_buffer()
+                .map_err(|e| MediaError::FetchError(format!("{:?}", e)))?,
+        )
+        .await
+        .map_err(|e| MediaError::FetchError(format!("{:?}", e)))?;
+
+        let uint8_array = js_sys::Uint8Array::new(&array_buffer);
+        let bytes = uint8_array.to_vec();
+
+        // Check size
+        if let Some(max) = max_bytes {
+            if bytes.len() > max {
+                return Err(MediaError::SizeExceeded(max / 1024 / 1024));
+            }
+        }
+
+        // Encode to base64
+        use base64::Engine;
+        let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+
+        Ok(MediaBlock {
+            media_type: base_content_type,
+            data,
+        })
+    }
+}
+
+// ============================================================================
+// Async URL Fetching - Native implementation
+// ============================================================================
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native_fetch {
+    use super::*;
+
+    /// Fetch a URL and return its content as a MediaBlock.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL to fetch
+    /// * `allowed_types` - Optional list of allowed MIME types. If `None`, all types are allowed.
+    /// * `max_bytes` - Optional maximum size in bytes. If `None`, no limit is applied.
+    pub async fn fetch_url_to_base64(
+        url: &str,
+        allowed_types: Option<&[&str]>,
+        max_bytes: Option<usize>,
+    ) -> Result<MediaBlock, MediaError> {
+        let response = reqwest::get(url)
+            .await
+            .map_err(|e| MediaError::FetchError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(MediaError::FetchError(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+
+        // Get content type
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .ok_or(MediaError::MissingContentType)?
+            .to_string();
+
+        // Extract base content type (before semicolon)
+        let base_content_type = content_type
+            .split(';')
+            .next()
+            .unwrap_or(&content_type)
+            .trim()
+            .to_string();
+
+        // Check allowed types
+        if let Some(allowed) = allowed_types {
+            if !allowed.contains(&base_content_type.as_str()) {
+                return Err(MediaError::UnsupportedMediaType(base_content_type));
+            }
+        }
+
+        // Get bytes
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| MediaError::FetchError(e.to_string()))?;
+
+        // Check size
+        if let Some(max) = max_bytes {
+            if bytes.len() > max {
+                return Err(MediaError::SizeExceeded(max / 1024 / 1024));
+            }
+        }
+
+        // Encode to base64
+        use base64::Engine;
+        let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+
+        Ok(MediaBlock {
+            media_type: base_content_type,
+            data,
+        })
+    }
+}
+
+// Re-export the appropriate implementation
+#[cfg(target_arch = "wasm32")]
+pub use wasm_fetch::fetch_url_to_base64;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use native_fetch::fetch_url_to_base64;
+
+/// Convert media (URL or data URL) to a MediaBlock.
+///
+/// If the input is already a base64 data URL, it is parsed directly.
+/// Otherwise, the URL is fetched and the content is converted to base64.
+///
+/// # Arguments
+///
+/// * `media` - A URL or data URL
+/// * `allowed_types` - Optional list of allowed MIME types for fetched URLs
+/// * `max_bytes` - Optional maximum size in bytes for fetched URLs
+pub async fn convert_media_to_base64(
+    media: &str,
+    allowed_types: Option<&[&str]>,
+    max_bytes: Option<usize>,
+) -> Result<MediaBlock, MediaError> {
+    // Try to parse as data URL first
+    if let Some(block) = parse_base64_data_url(media) {
+        return Ok(block);
+    }
+
+    // Otherwise fetch the URL
+    fetch_url_to_base64(media, allowed_types, max_bytes).await
+}
+
+/// Check if a URL is a localhost URL (for special handling).
+pub fn is_localhost_url(url: &str) -> bool {
+    url.starts_with("http://127.0.0.1") || url.starts_with("http://localhost")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_base64_data_url_valid() {
+        let url = "data:image/png;base64,iVBORw0KGgo=";
+        let block = parse_base64_data_url(url).unwrap();
+        assert_eq!(block.media_type, "image/png");
+        assert_eq!(block.data, "iVBORw0KGgo=");
+    }
+
+    #[test]
+    fn test_parse_base64_data_url_pdf() {
+        let url = "data:application/pdf;base64,JVBERi0xLjQ=";
+        let block = parse_base64_data_url(url).unwrap();
+        assert_eq!(block.media_type, "application/pdf");
+        assert_eq!(block.data, "JVBERi0xLjQ=");
+    }
+
+    #[test]
+    fn test_parse_base64_data_url_invalid() {
+        assert!(parse_base64_data_url("not a data url").is_none());
+        assert!(parse_base64_data_url("data:image/png,nobase64").is_none());
+        assert!(parse_base64_data_url("data:image/png;base64,").is_none());
+    }
+
+    #[test]
+    fn test_media_block_to_url() {
+        let block = MediaBlock {
+            media_type: "image/jpeg".to_string(),
+            data: "abcd1234".to_string(),
+        };
+        assert_eq!(
+            media_block_to_url(&block),
+            "data:image/jpeg;base64,abcd1234"
+        );
+    }
+
+    #[test]
+    fn test_is_localhost_url() {
+        assert!(is_localhost_url("http://localhost:3000/image.png"));
+        assert!(is_localhost_url("http://127.0.0.1:8080/file.pdf"));
+        assert!(!is_localhost_url("https://example.com/image.png"));
+        // Note: This matches proxy behavior - starts_with check doesn't prevent this
+        // but in practice this URL pattern is unlikely to be a problem
+        assert!(is_localhost_url("http://localhostfake.com/x"));
+    }
+
+    #[test]
+    fn test_parse_file_metadata_from_url_simple() {
+        let metadata =
+            parse_file_metadata_from_url("https://example.com/path/to/file.pdf").unwrap();
+        assert_eq!(metadata.filename, "file.pdf");
+        assert!(metadata.content_type.is_none());
+    }
+
+    #[test]
+    fn test_parse_file_metadata_from_url_encoded() {
+        let metadata = parse_file_metadata_from_url("https://example.com/my%20file.pdf").unwrap();
+        assert_eq!(metadata.filename, "my file.pdf");
+    }
+
+    #[test]
+    fn test_parse_file_metadata_from_url_invalid() {
+        assert!(parse_file_metadata_from_url("").is_none());
+        assert!(parse_file_metadata_from_url("not a url").is_none());
+        assert!(parse_file_metadata_from_url("ftp://example.com/file").is_none());
+        assert!(parse_file_metadata_from_url("https://example.com/").is_none());
+    }
+}

--- a/crates/lingua/src/util/mod.rs
+++ b/crates/lingua/src/util/mod.rs
@@ -3,5 +3,6 @@ Utility modules for Lingua testing and development.
 */
 
 pub mod error_check;
+pub mod media;
 pub mod test_runner;
 pub mod testutil;

--- a/crates/lingua/src/validation/bedrock.rs
+++ b/crates/lingua/src/validation/bedrock.rs
@@ -22,14 +22,14 @@ mod tests {
 
     #[test]
     fn test_validate_bedrock_request_minimal() {
+        // Uses camelCase keys to match Bedrock API format
         let json = r#"{
-            "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
             "messages": [
                 {
                     "role": "user",
                     "content": [
                         {
-                            "type": "text",
                             "text": "Hello"
                         }
                     ]
@@ -44,7 +44,7 @@ mod tests {
     #[test]
     fn test_validate_bedrock_request_invalid() {
         let json = r#"{
-            "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0"
+            "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0"
         }"#; // missing messages
 
         let result = validate_bedrock_request(json);
@@ -53,26 +53,26 @@ mod tests {
 
     #[test]
     fn test_validate_bedrock_response_minimal() {
+        // Uses camelCase keys to match Bedrock API format
         let json = r#"{
             "output": {
                 "message": {
                     "role": "assistant",
                     "content": [
                         {
-                            "type": "text",
                             "text": "Hello!"
                         }
                     ]
                 }
             },
-            "stop_reason": "end_turn",
+            "stopReason": "end_turn",
             "usage": {
-                "input_tokens": 10,
-                "output_tokens": 20,
-                "total_tokens": 30
+                "inputTokens": 10,
+                "outputTokens": 20,
+                "totalTokens": 30
             },
             "metrics": {
-                "latency_ms": 1000
+                "latencyMs": 1000
             }
         }"#;
 

--- a/crates/lingua/src/validation/cross_provider_tests.rs
+++ b/crates/lingua/src/validation/cross_provider_tests.rs
@@ -78,15 +78,16 @@ mod tests {
         }
     }"#;
 
+    // Bedrock uses camelCase field names (modelId, not model_id)
+    // and untagged content blocks ({"text": "Hello"}, not {"type": "text", "text": "Hello"})
     #[cfg(feature = "bedrock")]
     const BEDROCK_REQUEST: &str = r#"{
-        "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
         "messages": [
             {
                 "role": "user",
                 "content": [
                     {
-                        "type": "text",
                         "text": "Hello"
                     }
                 ]
@@ -101,20 +102,19 @@ mod tests {
                 "role": "assistant",
                 "content": [
                     {
-                        "type": "text",
                         "text": "Hello!"
                     }
                 ]
             }
         },
-        "stop_reason": "end_turn",
+        "stopReason": "end_turn",
         "usage": {
-            "input_tokens": 10,
-            "output_tokens": 20,
-            "total_tokens": 30
+            "inputTokens": 10,
+            "outputTokens": 20,
+            "totalTokens": 30
         },
         "metrics": {
-            "latency_ms": 1000
+            "latencyMs": 1000
         }
     }"#;
 


### PR DESCRIPTION
This PR adds testing matrix + provider adapters for:

- OpenAI (ChatCompletions)
- Anthropic
- Google
- Bedrock (Converse)
- OpenAI (Responses)

and callers use `transform_request` and `transform_response` to translate between providers.



The file below explains how to add a new provider based on the `ProviderAdapter` trait and also a closed testing loop so LLMs can just iterate:  
  
https://github.com/braintrustdata/lingua/blob/a6019a6fc0a082a373d1f55c188df6483772b864/crates/lingua/docs/ADDING_PROVIDER_FORMAT.md



Current coverage status for the testing matrix is here ->:  
  
https://github.com/braintrustdata/lingua/actions/runs/20666751649?pr=50  
