### PR TITLE
add openai responses parameter test cases

### DIFF
--- a/bindings/python/tests/test_roundtrip.py
+++ b/bindings/python/tests/test_roundtrip.py
@@ -58,7 +58,7 @@ def load_test_snapshots(test_case_name: str) -> list[Snapshot]:
     if not snapshots_dir.exists():
         return snapshots
 
-    providers = ["openai-chat-completions", "openai-responses", "anthropic"]
+    providers = ["chat-completions", "responses", "anthropic"]
     turns = ["first_turn", "followup_turn"]
 
     for provider in providers:
@@ -228,7 +228,7 @@ class TestRoundtrip:
 
             for snapshot in snapshots:
                 if (
-                    snapshot.provider != "openai-chat-completions"
+                    snapshot.provider != "chat-completions"
                     or not snapshot.request
                 ):
                     continue

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -1,16 +1,14 @@
 version = 1
-requires-python = ">=3.8"
+revision = 3
+requires-python = ">=3.10"
 
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
@@ -27,9 +25,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/9d/9ad1778b95f15c5b04e7d328c1b5f558f1e893857b7c33cd288c19c0057a/anthropic-0.69.0.tar.gz", hash = "sha256:c604d287f4d73640f40bd2c0f3265a2eb6ce034217ead0608f6b07a8bc5ae5f2", size = 480622 }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/9d/9ad1778b95f15c5b04e7d328c1b5f558f1e893857b7c33cd288c19c0057a/anthropic-0.69.0.tar.gz", hash = "sha256:c604d287f4d73640f40bd2c0f3265a2eb6ce034217ead0608f6b07a8bc5ae5f2", size = 480622, upload-time = "2025-09-29T16:53:45.282Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/38/75129688de5637eb5b383e5f2b1570a5cc3aecafa4de422da8eea4b90a6c/anthropic-0.69.0-py3-none-any.whl", hash = "sha256:1f73193040f33f11e27c2cd6ec25f24fe7c3f193dc1c5cde6b7a08b18a16bcc5", size = 337265 },
+    { url = "https://files.pythonhosted.org/packages/9b/38/75129688de5637eb5b383e5f2b1570a5cc3aecafa4de422da8eea4b90a6c/anthropic-0.69.0-py3-none-any.whl", hash = "sha256:1f73193040f33f11e27c2cd6ec25f24fe7c3f193dc1c5cde6b7a08b18a16bcc5", size = 337265, upload-time = "2025-09-29T16:53:43.686Z" },
 ]
 
 [[package]]
@@ -42,36 +40,36 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f9/9a7ce600ebe7804daf90d4d48b1c0510a4561ddce43a596be46676f82343/anyio-4.5.2.tar.gz", hash = "sha256:23009af4ed04ce05991845451e11ef02fc7c5ed29179ac9a420e5ad0ac7ddc5b", size = 171293 }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f9/9a7ce600ebe7804daf90d4d48b1c0510a4561ddce43a596be46676f82343/anyio-4.5.2.tar.gz", hash = "sha256:23009af4ed04ce05991845451e11ef02fc7c5ed29179ac9a420e5ad0ac7ddc5b", size = 171293, upload-time = "2024-10-13T22:18:03.307Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/b4/f7e396030e3b11394436358ca258a81d6010106582422f23443c16ca1873/anyio-4.5.2-py3-none-any.whl", hash = "sha256:c011ee36bc1e8ba40e5a81cb9df91925c218fe9b778554e0b56a21e1b5d4716f", size = 89766 },
+    { url = "https://files.pythonhosted.org/packages/1b/b4/f7e396030e3b11394436358ca258a81d6010106582422f23443c16ca1873/anyio-4.5.2-py3-none-any.whl", hash = "sha256:c011ee36bc1e8ba40e5a81cb9df91925c218fe9b778554e0b56a21e1b5d4716f", size = 89766, upload-time = "2024-10-13T22:18:01.524Z" },
 ]
 
 [[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170 }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321 },
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
 ]
 
 [[package]]
 name = "asttokens"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978 }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978, upload-time = "2024-11-30T04:30:14.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918 },
+    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918, upload-time = "2024-11-30T04:30:10.946Z" },
 ]
 
 [[package]]
 name = "backcall"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/40/764a663805d84deee23043e1426a9175567db89c8b3287b5c2ad9f71aa93/backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e", size = 18041 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/40/764a663805d84deee23043e1426a9175567db89c8b3287b5c2ad9f71aa93/backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e", size = 18041, upload-time = "2020-06-09T15:11:32.931Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/1c/ff6546b6c12603d8dd1070aa3c3d273ad4c07f5771689a7b69a550e8c951/backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255", size = 11157 },
+    { url = "https://files.pythonhosted.org/packages/4c/1c/ff6546b6c12603d8dd1070aa3c3d273ad4c07f5771689a7b69a550e8c951/backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255", size = 11157, upload-time = "2020-06-09T15:11:30.87Z" },
 ]
 
 [[package]]
@@ -97,6 +95,7 @@ requires-dist = [
     { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.0,<2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
 ]
+provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -109,45 +108,45 @@ dev = [
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386 }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216 },
+    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711 }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190 },
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
 ]
 
 [[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442 }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896 },
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]
@@ -157,27 +156,27 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674 },
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
 ]
 
 [[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488 }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317 },
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -188,9 +187,9 @@ dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
 ]
 
 [[package]]
@@ -203,27 +202,27 @@ dependencies = [
     { name = "httpcore" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -243,11 +242,10 @@ dependencies = [
     { name = "pygments" },
     { name = "stack-data" },
     { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/6a/44ef299b1762f5a73841e87fae8a73a8cc8aee538d6dc8c77a5afe1fd2ce/ipython-8.12.3.tar.gz", hash = "sha256:3910c4b54543c2ad73d06579aa771041b7d5707b033bd488669b4cf544e3b363", size = 5470171 }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/6a/44ef299b1762f5a73841e87fae8a73a8cc8aee538d6dc8c77a5afe1fd2ce/ipython-8.12.3.tar.gz", hash = "sha256:3910c4b54543c2ad73d06579aa771041b7d5707b033bd488669b4cf544e3b363", size = 5470171, upload-time = "2023-09-29T09:14:37.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/97/8fe103906cd81bc42d3b0175b5534a9f67dccae47d6451131cf8d0d70bb2/ipython-8.12.3-py3-none-any.whl", hash = "sha256:b0340d46a933d27c657b211a329d0be23793c36595acf9e6ef4164bc01a1804c", size = 798307 },
+    { url = "https://files.pythonhosted.org/packages/8d/97/8fe103906cd81bc42d3b0175b5534a9f67dccae47d6451131cf8d0d70bb2/ipython-8.12.3-py3-none-any.whl", hash = "sha256:b0340d46a933d27c657b211a329d0be23793c36595acf9e6ef4164bc01a1804c", size = 798307, upload-time = "2023-09-29T09:14:34.431Z" },
 ]
 
 [[package]]
@@ -257,92 +255,68 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "parso" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278 },
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
 ]
 
 [[package]]
 name = "jiter"
 version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/72/c28662416d9807bb5a38625eadedb82d4bd14fd2700c308ece7acdb8e89f/jiter-0.9.1.tar.gz", hash = "sha256:7852990068b6e06102ecdc44c1619855a2af63347bfb5e7e009928dcacf04fdd", size = 162540 }
+sdist = { url = "https://files.pythonhosted.org/packages/84/72/c28662416d9807bb5a38625eadedb82d4bd14fd2700c308ece7acdb8e89f/jiter-0.9.1.tar.gz", hash = "sha256:7852990068b6e06102ecdc44c1619855a2af63347bfb5e7e009928dcacf04fdd", size = 162540, upload-time = "2025-05-18T17:47:14.707Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/5f/7f6aaca7943c644b4fd220650771f39dbfb74f9690efc6fb8c0d4092a399/jiter-0.9.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c0163baa7ee85860fdc14cc39263014500df901eeffdf94c1eab9a2d713b2a9d", size = 312882 },
-    { url = "https://files.pythonhosted.org/packages/86/0d/aac9eafc5d46bdf5c4f127ac1ce85e434d003bb5e3ae886f5e726a988cf6/jiter-0.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:514d4dd845e0af4da15112502e6fcb952f0721f27f17e530454e379472b90c14", size = 311743 },
-    { url = "https://files.pythonhosted.org/packages/b8/54/fab1f4d8634af7bb1ad6dc49bee50ea9f649de0e5309c80192ace739f968/jiter-0.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b879faee1cc1a67fde3f3f370041239fd260ac452bd53e861aa4a94a51e3fd02", size = 1085889 },
-    { url = "https://files.pythonhosted.org/packages/bd/86/bf4ed251d8035d5d72a46c8f9969bd5054fad052371cbea0cb161060e660/jiter-0.9.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20a5ce641f93bfb8d8e336f8c4a045e491652f41eaacc707b15b245ece611e72", size = 1117896 },
-    { url = "https://files.pythonhosted.org/packages/62/40/b04c40deccd5edd5f2a3853f4a80dc0ddbe157d1d523a573fb3d224315fc/jiter-0.9.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8575b1d2b49df04ca82d658882f4a432b7ed315a69126a379df4d10aeb416021", size = 1211956 },
-    { url = "https://files.pythonhosted.org/packages/85/f0/114e9893e4ef5b423718efe9b3da01117539c333f06ef19543c68c8b7ed1/jiter-0.9.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc61831699904e0c58e82943f529713833db87acd13f95a3c0feb791f862d47b", size = 1219691 },
-    { url = "https://files.pythonhosted.org/packages/02/9a/1aeac4541ce1c59c65dc76dbab642232da3d8db0581df3e61b8943033bd7/jiter-0.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fb733faf4d0e730d6663873249c1acb572fc8bd9dae3836ceda69751f27c5be", size = 352604 },
-    { url = "https://files.pythonhosted.org/packages/6b/27/446ec6ca0a25d9d2f45ad546633a2b4a1b6a7f28fb6819c7056b163c5aee/jiter-0.9.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d903b3bb917c0df24f2ef62f587c8f32f6003cb2f97264109ca56c023262557f", size = 1147136 },
-    { url = "https://files.pythonhosted.org/packages/09/9d/c8540bc097b07e106d060c21395c6fa6561223e7366c948a04ef0aa39979/jiter-0.9.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:eac3eb5206845b170142c016ae467eca523a25459dc9c53fcd8e154ea263406c", size = 1255843 },
-    { url = "https://files.pythonhosted.org/packages/d3/61/9b377ecf4e09e325e90f77a7a4859ec933162f58ff5c6b7730aff6352033/jiter-0.9.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7ea0c20cfc61acc5335bb8ee36d639e6a4ded03f34f878b2b3038bb9f3bb553c", size = 1257536 },
-    { url = "https://files.pythonhosted.org/packages/ed/f6/b6754e11ac9d02f05a2d713c0846ce813a69c1f6f7de7f1ae216c4e35ace/jiter-0.9.1-cp310-cp310-win32.whl", hash = "sha256:0f8f812dd6d2b4112db9ab4c1079c4fe73e553a500e936657fdda394fa2517e1", size = 214064 },
-    { url = "https://files.pythonhosted.org/packages/1d/cb/7b9c5d6f73499d1fb5e97e36e8078f3bea00d7541a973117eccf9db1e079/jiter-0.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:f7f0198889170e7af6210509803e6527b402efc6c26f42e2896883597a10426f", size = 209952 },
-    { url = "https://files.pythonhosted.org/packages/ee/3b/9f9deaef471e346354c832b6627e0d1b9ba3d9611d0e0fd394c2acf2a615/jiter-0.9.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6b8564e3198c4c8d835fc95cc54d6bcbd2fd8dc33a047fecc12c208491196995", size = 312737 },
-    { url = "https://files.pythonhosted.org/packages/36/00/76fa6d519f8289aad32ec1caf3716eb700ba48e3212d1dda71e74c385a5c/jiter-0.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:90b92044588d14efe89b394eca735adc4ac096eba82dc75d93c3083b1eebce8d", size = 313357 },
-    { url = "https://files.pythonhosted.org/packages/b3/e9/f864ebe9ddf07761d5bdd3148b45a5d433c6cbce7c7e8be29baf806fa612/jiter-0.9.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3505f7f419b355c7788fcaae0dfc4c6ccbc50c0dc3633a2da797e841c5a423dc", size = 1085946 },
-    { url = "https://files.pythonhosted.org/packages/82/a1/ed02d4c86d620989dcd392366daa67198961eedaf2e66f7a68f0d3846dba/jiter-0.9.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:93af8c3f4a3bf145c690e857a945eb5c655534bf95c67e1447d85c02e5af64d7", size = 1118090 },
-    { url = "https://files.pythonhosted.org/packages/d3/01/d107531d215a57cda3cbc4adfcf3119166dd32adc1c332c1f3f36efd3484/jiter-0.9.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:43b81dd21e260a249780764921b1f9a6379cb31e24e7b61e6bf0799f38ec4b91", size = 1212231 },
-    { url = "https://files.pythonhosted.org/packages/45/1e/6801a81a2ef1f917fe9a7d2139e576dd4f53497c309dab9461136922709c/jiter-0.9.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:db639fad5631b3d1692609f6dd77b64e8578321b7aeec07a026acd2c867c04a5", size = 1219263 },
-    { url = "https://files.pythonhosted.org/packages/a5/d4/40082e8666cfdb24461855e9bb29fe77f063cc65a6c903291f2e5225f780/jiter-0.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15356b943e70ca7ab3b587ffaffadc0158467f6c4e0b491e52a0743c4bdf5ba1", size = 350364 },
-    { url = "https://files.pythonhosted.org/packages/c4/09/09bc72dd143f76acd55e04c3a45b9f9ee3ed28e00b49924e3702ad041812/jiter-0.9.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:53a7033a46141ff815518a6972d657c75d8f5946b9315e1c25b07e9677c1ff6c", size = 1146802 },
-    { url = "https://files.pythonhosted.org/packages/5b/34/9d15a9c04d5760537b432134447bde94b936ec73dc922b4d14a48def2e1f/jiter-0.9.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:68cf519a6f00b8127f9be64a37e97e978094438abced5adebe088a98c64bdcff", size = 1256019 },
-    { url = "https://files.pythonhosted.org/packages/8f/01/1fcd165fb28968a54bb46a209d5919f7649b96608eef7dc4622ea378b95a/jiter-0.9.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9098abdd34cd9ddeb04768cc4f5fc725ebd9a52978c488da74e58a837ce93506", size = 1257610 },
-    { url = "https://files.pythonhosted.org/packages/9f/87/93ac6a57331dd90e4c896ac852bf8ce6b28b40dace4b9698a207dbb99af2/jiter-0.9.1-cp311-cp311-win32.whl", hash = "sha256:7179ce96aecd096af890dd57b84133e47a59fbde32a77734f09bafa6a4da619e", size = 214515 },
-    { url = "https://files.pythonhosted.org/packages/bb/ee/3678b8a3bd5f6471d0a492540e7ff9c63db278d844214458ec5cfb22adb2/jiter-0.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:e6517f5b7b6f60fd77fc1099572f445be19553c6f61b907ab5b413fb7179663f", size = 212258 },
-    { url = "https://files.pythonhosted.org/packages/ba/a7/5b3ce91b5bb83bf47e85ab2efda26a1706fb52498a2abe79df09af7dfa8f/jiter-0.9.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f330c5023ce4153ceb3e8abe76ecab8c5b525824bcec4e781791d044e5b5fc3a", size = 307494 },
-    { url = "https://files.pythonhosted.org/packages/fd/9a/006ebbb5ab55fd9f47c219f9de7fdedd38694c158ddd6760a15f7a6fcdc8/jiter-0.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:77de4d2d529ece2d43fc0dbe90971e9e18f42ed6dd50b40fe232e799efb72c29", size = 312782 },
-    { url = "https://files.pythonhosted.org/packages/17/da/a437705850c8cf6b8c93769ff6fcb3abcbfeb9c12b690c5f1631682d4286/jiter-0.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ed3eec217a70762a01ecfbecea27eda91d7d5792bdef41096d2c672a9e3c1fe", size = 1087076 },
-    { url = "https://files.pythonhosted.org/packages/e6/8b/f463a03de974d437abc312a0ca6212e2b014b7023a880fd6956ebfde15c7/jiter-0.9.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d000bb8b9b3a90fb61ff864869461c56ad2dad5f0fa71127464cb65e69ec864b", size = 1118826 },
-    { url = "https://files.pythonhosted.org/packages/6a/04/4d9289d8610f2b10886b4bd32b0c6e036fdeabc86cc9a902e50434a066bd/jiter-0.9.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3610aed85fad26d5e107ce4e246c236b612e539b382d490761aacc4aa5d7cdbf", size = 1213155 },
-    { url = "https://files.pythonhosted.org/packages/f3/4c/851c0a7c95e333d5213558fc76d217a7760de8b704299c007537af49e1de/jiter-0.9.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae8f1f42f4b0ed244f88bb863d0777292e76e43ee2dc0dac4d63fe29bee183e5", size = 1215024 },
-    { url = "https://files.pythonhosted.org/packages/8f/24/9c62f5775645715ded77a4cf03b9f3c36d4909ee35b07f65bb4ccaad4bfd/jiter-0.9.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2082da43e7b6174c3522a6905a9ee9187c9771e32cad7ab58360f189595a7c3f", size = 350280 },
-    { url = "https://files.pythonhosted.org/packages/d9/79/54a4b1074f1f048ca822a2f4a738fa7b623203540a59ec99d0b0277c38ef/jiter-0.9.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d82b2b8bc089c4ebff99907bdb890730e05c58169d5493473c916518f8d29f5c", size = 1150978 },
-    { url = "https://files.pythonhosted.org/packages/9c/1b/caaa8d274ba82486dfb582e32f431412f2e178344ebf6a231b8606c048fd/jiter-0.9.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:8b7214d4064759ff34846311cabcf49715e8a7286a4431bc7444537ee2f21b1a", size = 1257583 },
-    { url = "https://files.pythonhosted.org/packages/19/f7/a5f991075b16b76b15e4da7939243f373ff4369ce41145be428c7c43d905/jiter-0.9.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:136a635797b27aeb5cacea4d0ffeff5c80081089217c5891bd28968e5df97824", size = 1258268 },
-    { url = "https://files.pythonhosted.org/packages/94/8f/6fabe1aa77637be629e73db2ee3059889b893c4be391f0e038b71948d208/jiter-0.9.1-cp312-cp312-win32.whl", hash = "sha256:5da9a4e2939c4af7617fe01f7e3978fba224d93def72bc748d173f148a8b637f", size = 214250 },
-    { url = "https://files.pythonhosted.org/packages/7d/18/6f118d22acf5930d5a46c4f6853eead883af8c097d83e2a2971308864423/jiter-0.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:d1434a05965d0c1f033061f21553fef5c3a352f3e880a0f503e79e6b639db10c", size = 211070 },
-    { url = "https://files.pythonhosted.org/packages/e2/36/4b5c7c96ce4795376e546bcabd96d8fe8667c9fdeb946523ca382cc30eaa/jiter-0.9.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:cb0629af6a12804ace5f093884c2f14d5075d95951a086054e106cfdb6b8862f", size = 307047 },
-    { url = "https://files.pythonhosted.org/packages/3e/20/7635fb02fe62cd90899dc1c64c972c1470106eede55ce35fc6e3868251af/jiter-0.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d15cc2b5602fb5a16689afb507b27c650167152203394efa429a5139553dd993", size = 311796 },
-    { url = "https://files.pythonhosted.org/packages/e4/43/7e4a38c63b9f1a5795d406a7cf1e8a42af0e51d05d5c5b866708a345d49e/jiter-0.9.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffbf9279273b41fb8c4360ad2590a8eea82b36665728f57b0d7b095a904016d9", size = 1086812 },
-    { url = "https://files.pythonhosted.org/packages/30/17/3d5ad7a1e12bb172040c2e206068ee766a320c6b6327a0a52a9c05bf4cd6/jiter-0.9.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fca2935783d4309eed77ed2acd625f93a07b79693f7d8e58e3c18ac8981e9ea", size = 1118218 },
-    { url = "https://files.pythonhosted.org/packages/a0/f7/9f46d976a91f339898783962043c36b8c9fe103135f264ae25dddad9838e/jiter-0.9.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3f5f14d63924d3b226236c746ceb37f5ac9d3ce1251762819024f84904b4a0f", size = 1211346 },
-    { url = "https://files.pythonhosted.org/packages/93/71/cf594ec8c76188b5e42fc4f00a9cdfb3f675631234f5a1ac5413fe6684cb/jiter-0.9.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0d43dcddb437096ac48e85f6be8355d806ab9246051f95263933fa5e18d026aa", size = 1214466 },
-    { url = "https://files.pythonhosted.org/packages/e2/e5/efd89f27838ea9d8257c9bc8edd58a953e06ca304c7d2b397fdd2a932e51/jiter-0.9.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19773c6f730523effbca88c4a15658b481cf81e4c981fcd1212dd4beaa0cd37a", size = 350245 },
-    { url = "https://files.pythonhosted.org/packages/b3/78/b7960c8a04d593687659007e6b7f911ef3f877eb11cd2503267ad5b2da0b/jiter-0.9.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:01fcc08b6d3e29562d72edfcd6c5b0aab30b964fb0c99ad8287c2dffeb6fd38c", size = 1149223 },
-    { url = "https://files.pythonhosted.org/packages/65/60/4777b5a70febeece230593a82a69d0d19b5b6e36a8b3afcc4b43528c2657/jiter-0.9.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:448afc1a801a518ed438667229f380bb0b8503f379d170ac947575cb7e1e4edf", size = 1257025 },
-    { url = "https://files.pythonhosted.org/packages/e8/c1/8fe3483537d85bc381bdab2a4952707d92944b1ac32074f7b33de188c2d0/jiter-0.9.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f321fb984ed7544e77346714a25ffa5bbefddd1adcc32c8fba49030a119a31c6", size = 1257882 },
-    { url = "https://files.pythonhosted.org/packages/7b/1a/4453114fb7b3722f8d232b3c08114535e455d7d2d4d83b44cede53ed42ae/jiter-0.9.1-cp313-cp313-win32.whl", hash = "sha256:7db7c9a95d72668545606aeaf110549f4f42679eaa3ce5c32f8f26c1838550d8", size = 214946 },
-    { url = "https://files.pythonhosted.org/packages/15/d0/237d7dbaaafb08a6f719c8495663b76d70d6c5880a02c7b092f21292458b/jiter-0.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:a6b750ef1201fe4c431f869705607ece4adaf592e497efb6bc4138efaebb4f59", size = 209888 },
-    { url = "https://files.pythonhosted.org/packages/51/32/e90c89adbea8342b6e470f3be9c213b628ae3842810553df15d5afb386ce/jiter-0.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4096dba935aa2730c7642146b065855a0f5853fd9bbe22de9e3dd39fcacc37fe", size = 311645 },
-    { url = "https://files.pythonhosted.org/packages/29/40/98fee5bab390c27d20ba82c73d12afd1db89aabeef641ae7629a31a7100f/jiter-0.9.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13ad975e0d9d2f7e54b30d9ae8e2e1c97be422e75606bddc67427721ad13cd1c", size = 352754 },
-    { url = "https://files.pythonhosted.org/packages/9b/17/b0fa4ee5bdcb252b2407fc9528f11d8af717b7218455d23018cf314ccf6a/jiter-0.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f11992b20f8a2d336b98b31bff4d8bfcc4bd5aef7840594e32d6cb44fb9b96cf", size = 212573 },
-    { url = "https://files.pythonhosted.org/packages/26/ca/1c7438d66969a13938266492de65daf752754ec59f2a3f3716027c7d708f/jiter-0.9.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:95065923a49ae387bab62b1bf5f798beb12e6fb4469a079fdd0ecad64b40b272", size = 313516 },
-    { url = "https://files.pythonhosted.org/packages/e8/d9/3a6300309e312f8ed529ae57d565f69abdb520e4f12460cefa7996d0716c/jiter-0.9.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a179fbc5c7922844a673be35099a3036a7276dc63753c6c81a77c3cb525f2f8d", size = 308161 },
-    { url = "https://files.pythonhosted.org/packages/b3/91/2aca15be38514daf8f1a1460fd9c4b652ed09148fe109520298858be7928/jiter-0.9.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abd30dc5c0183d31faf30ce8279d723809c54b3fe6d95d922d4a4b31bc462799", size = 1086100 },
-    { url = "https://files.pythonhosted.org/packages/9f/6f/f7ba3dfe7be08bf58939324e0bb4f4aa605eff7f2c2ac140a41221cf50a4/jiter-0.9.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9765512bdeae269843e6615377f48123432da247e18048d05e9c5685377c241c", size = 1118922 },
-    { url = "https://files.pythonhosted.org/packages/b5/4e/b1f4d9bdba81de293e1b8672598300a9195cf3d77b0acc5f331a75695b58/jiter-0.9.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f15cdbdc1e1e89e0d9ea581de63e03975043a4b40ab87d5554fdc440357b771", size = 1212327 },
-    { url = "https://files.pythonhosted.org/packages/3e/ab/e417aaf5a62067bd91c5f7ed4e5ab83bd46f349449adde1159ad8e2d3a21/jiter-0.9.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b1a639b2cfe56b5b687c678ed45d68f46dfb922c2f338fdfb227eb500053929d", size = 1220860 },
-    { url = "https://files.pythonhosted.org/packages/1e/50/c5ba756c641ca8ebc1e4ff07c03ce5c8ef5052b0238f514436f8de3c9fc4/jiter-0.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41955c9d83c8470de9cc64c97b04a3ffd2f32815bb2c4307f44d8e21542b74df", size = 344077 },
-    { url = "https://files.pythonhosted.org/packages/c6/b3/bd7d8d4bad65aa1f4a20562233080054149785c0d7f7b9027e761335d882/jiter-0.9.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f26f6d42c330e26a6ba3471b390364faad96f3ca965a6c579957810b0c078efa", size = 1148785 },
-    { url = "https://files.pythonhosted.org/packages/c0/12/bfd9a167709f96171312d1e0ae2c1be70a167abcc3bff6f3441967e3626a/jiter-0.9.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6a23e01bd7e918f27f02d3df8721b8a395211070a8a65aeb353209b8c72720cf", size = 1255962 },
-    { url = "https://files.pythonhosted.org/packages/5f/3c/3a79020862d2511b854b350bc9229cf228fd38b836e94f274ca940e22e95/jiter-0.9.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8a96ad217989dd9df661711c3fa2e6fb2601c4bbb482e89718110bdafbc16c9e", size = 1257561 },
-    { url = "https://files.pythonhosted.org/packages/93/d3/7f6f8e57613d4947a872980befa6af19de9252e310ea4a512eed0fe1e064/jiter-0.9.1-cp38-cp38-win32.whl", hash = "sha256:4b180e7baa4747b3834c5a9202b1ba30dc64797f45236d9142cdb2a8807763cf", size = 215019 },
-    { url = "https://files.pythonhosted.org/packages/9b/5d/b6f0cd60c8f702936f253644a92dee19e2c82010290e4607af462033351f/jiter-0.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:baf881de1fbc7b3343cce24f75a2ab6350e03fc13d16d00f452929788a6cdc3f", size = 199563 },
-    { url = "https://files.pythonhosted.org/packages/4f/3a/a8a4768af26578c87894bb130bcd6fb6c97f4cb36ed7a20a664412d41935/jiter-0.9.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:ec95aa1b433c50b2b129456b4680b239ec93206ea3f86cfd41b6a70be5beb2f3", size = 313942 },
-    { url = "https://files.pythonhosted.org/packages/63/74/05977891db48000d985a5f573493c43adf0f190eada670e51b92c9ed9139/jiter-0.9.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5d92cb50d135dbdd33b638fa2e0c6af25e1d635d38da13aa9ab05d021fb0c869", size = 308160 },
-    { url = "https://files.pythonhosted.org/packages/21/54/75f529e90442c8ad41acd8cf08323a4f3dcaa105710b2c8a1fda56e3a462/jiter-0.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b146dc2464f1d96007271d08bdf79288a5f1aa4aae5329eb79dcffb1181c703e", size = 1086503 },
-    { url = "https://files.pythonhosted.org/packages/bf/fa/02532a7ce7b712c576125d4f2614e77bc897c95b2b15e21ee25f42b3ff34/jiter-0.9.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fcf20ba858658ecd54b4710172d92009afa66d41d967c86d11607592a3c220fa", size = 1120444 },
-    { url = "https://files.pythonhosted.org/packages/91/c2/ab8cebaea6f2691eddcc5b6c67deb1399adbd85f12ad836f7cd77be78bf8/jiter-0.9.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:147fccc44bebdb672d4c601e9312730488b840d415e201e89c8ea0929a63dacf", size = 1212370 },
-    { url = "https://files.pythonhosted.org/packages/13/e3/90dddb7877b67cc0e1ddb864c2ca74314def26ff6542431a6e3061e0f805/jiter-0.9.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a428061aae26efaa6fb690ef9e7d6224aefe4eef7524165d073beb3cdad75f6f", size = 1221210 },
-    { url = "https://files.pythonhosted.org/packages/81/76/90ee847519a94a4a1a8bad7addce7019f424aea03c55eacf068469226760/jiter-0.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7164d92bb901784bd3c098ac0b0beae4306ea6c741dbd3a375449a8affc5366", size = 353774 },
-    { url = "https://files.pythonhosted.org/packages/59/a6/614a5d672d4b9c6bc9ad34579f0522577a0a78cc265069fca96543a832ca/jiter-0.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:93049a562233808914a2b938b0c745d7049db1667b3f42f0f5cf48e617393ba5", size = 1148581 },
-    { url = "https://files.pythonhosted.org/packages/2d/94/c100147c310361fa83e25c4c6ce17723532147580252962b89e6085795c2/jiter-0.9.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f6dcf2cb16cc15d82a018e20eeaf169e6f6cd8c426f4c312ebe11710c623bed2", size = 1256636 },
-    { url = "https://files.pythonhosted.org/packages/51/9a/dc82e218ba839052899df555e34f16b8ad1d7da9c01be208f65a5bf0083c/jiter-0.9.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2da9d485a7c526817cde9ff8b3394fa50ff5b782b86b6896378a3ba8844550f2", size = 1258099 },
-    { url = "https://files.pythonhosted.org/packages/58/d5/d853e069624038950265ac0e877985b249049b624e925dab6cd11035140c/jiter-0.9.1-cp39-cp39-win32.whl", hash = "sha256:ea58c155d827d24e5ba8d7958ec4738b26be0894c0881a91d88b39ff48bb06c9", size = 214611 },
-    { url = "https://files.pythonhosted.org/packages/cb/8d/7b6b1ee6e3d9d1a06237bbdfe4c6bb21baf323d3f70a0cc8f203de40c6b2/jiter-0.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:be2e911ecdb438951290c2079fe4190e7cc5be9e849df4caeb085b83ed620ff6", size = 211171 },
+    { url = "https://files.pythonhosted.org/packages/2b/5f/7f6aaca7943c644b4fd220650771f39dbfb74f9690efc6fb8c0d4092a399/jiter-0.9.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c0163baa7ee85860fdc14cc39263014500df901eeffdf94c1eab9a2d713b2a9d", size = 312882, upload-time = "2025-05-18T17:45:14.056Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0d/aac9eafc5d46bdf5c4f127ac1ce85e434d003bb5e3ae886f5e726a988cf6/jiter-0.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:514d4dd845e0af4da15112502e6fcb952f0721f27f17e530454e379472b90c14", size = 311743, upload-time = "2025-05-18T17:45:16.196Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/54/fab1f4d8634af7bb1ad6dc49bee50ea9f649de0e5309c80192ace739f968/jiter-0.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b879faee1cc1a67fde3f3f370041239fd260ac452bd53e861aa4a94a51e3fd02", size = 1085889, upload-time = "2025-05-18T17:45:17.883Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/86/bf4ed251d8035d5d72a46c8f9969bd5054fad052371cbea0cb161060e660/jiter-0.9.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20a5ce641f93bfb8d8e336f8c4a045e491652f41eaacc707b15b245ece611e72", size = 1117896, upload-time = "2025-05-18T17:45:19.82Z" },
+    { url = "https://files.pythonhosted.org/packages/62/40/b04c40deccd5edd5f2a3853f4a80dc0ddbe157d1d523a573fb3d224315fc/jiter-0.9.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8575b1d2b49df04ca82d658882f4a432b7ed315a69126a379df4d10aeb416021", size = 1211956, upload-time = "2025-05-18T17:45:21.606Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f0/114e9893e4ef5b423718efe9b3da01117539c333f06ef19543c68c8b7ed1/jiter-0.9.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc61831699904e0c58e82943f529713833db87acd13f95a3c0feb791f862d47b", size = 1219691, upload-time = "2025-05-18T17:45:23.061Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/1aeac4541ce1c59c65dc76dbab642232da3d8db0581df3e61b8943033bd7/jiter-0.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fb733faf4d0e730d6663873249c1acb572fc8bd9dae3836ceda69751f27c5be", size = 352604, upload-time = "2025-05-18T17:45:24.485Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/27/446ec6ca0a25d9d2f45ad546633a2b4a1b6a7f28fb6819c7056b163c5aee/jiter-0.9.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d903b3bb917c0df24f2ef62f587c8f32f6003cb2f97264109ca56c023262557f", size = 1147136, upload-time = "2025-05-18T17:45:25.832Z" },
+    { url = "https://files.pythonhosted.org/packages/09/9d/c8540bc097b07e106d060c21395c6fa6561223e7366c948a04ef0aa39979/jiter-0.9.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:eac3eb5206845b170142c016ae467eca523a25459dc9c53fcd8e154ea263406c", size = 1255843, upload-time = "2025-05-18T17:45:27.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/61/9b377ecf4e09e325e90f77a7a4859ec933162f58ff5c6b7730aff6352033/jiter-0.9.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7ea0c20cfc61acc5335bb8ee36d639e6a4ded03f34f878b2b3038bb9f3bb553c", size = 1257536, upload-time = "2025-05-18T17:45:29.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f6/b6754e11ac9d02f05a2d713c0846ce813a69c1f6f7de7f1ae216c4e35ace/jiter-0.9.1-cp310-cp310-win32.whl", hash = "sha256:0f8f812dd6d2b4112db9ab4c1079c4fe73e553a500e936657fdda394fa2517e1", size = 214064, upload-time = "2025-05-18T17:45:31.037Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/cb/7b9c5d6f73499d1fb5e97e36e8078f3bea00d7541a973117eccf9db1e079/jiter-0.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:f7f0198889170e7af6210509803e6527b402efc6c26f42e2896883597a10426f", size = 209952, upload-time = "2025-05-18T17:45:32.772Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/3b/9f9deaef471e346354c832b6627e0d1b9ba3d9611d0e0fd394c2acf2a615/jiter-0.9.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6b8564e3198c4c8d835fc95cc54d6bcbd2fd8dc33a047fecc12c208491196995", size = 312737, upload-time = "2025-05-18T17:45:34.456Z" },
+    { url = "https://files.pythonhosted.org/packages/36/00/76fa6d519f8289aad32ec1caf3716eb700ba48e3212d1dda71e74c385a5c/jiter-0.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:90b92044588d14efe89b394eca735adc4ac096eba82dc75d93c3083b1eebce8d", size = 313357, upload-time = "2025-05-18T17:45:36.672Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e9/f864ebe9ddf07761d5bdd3148b45a5d433c6cbce7c7e8be29baf806fa612/jiter-0.9.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3505f7f419b355c7788fcaae0dfc4c6ccbc50c0dc3633a2da797e841c5a423dc", size = 1085946, upload-time = "2025-05-18T17:45:37.989Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a1/ed02d4c86d620989dcd392366daa67198961eedaf2e66f7a68f0d3846dba/jiter-0.9.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:93af8c3f4a3bf145c690e857a945eb5c655534bf95c67e1447d85c02e5af64d7", size = 1118090, upload-time = "2025-05-18T17:45:39.322Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/01/d107531d215a57cda3cbc4adfcf3119166dd32adc1c332c1f3f36efd3484/jiter-0.9.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:43b81dd21e260a249780764921b1f9a6379cb31e24e7b61e6bf0799f38ec4b91", size = 1212231, upload-time = "2025-05-18T17:45:40.738Z" },
+    { url = "https://files.pythonhosted.org/packages/45/1e/6801a81a2ef1f917fe9a7d2139e576dd4f53497c309dab9461136922709c/jiter-0.9.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:db639fad5631b3d1692609f6dd77b64e8578321b7aeec07a026acd2c867c04a5", size = 1219263, upload-time = "2025-05-18T17:45:42.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d4/40082e8666cfdb24461855e9bb29fe77f063cc65a6c903291f2e5225f780/jiter-0.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15356b943e70ca7ab3b587ffaffadc0158467f6c4e0b491e52a0743c4bdf5ba1", size = 350364, upload-time = "2025-05-18T17:45:44.257Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/09bc72dd143f76acd55e04c3a45b9f9ee3ed28e00b49924e3702ad041812/jiter-0.9.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:53a7033a46141ff815518a6972d657c75d8f5946b9315e1c25b07e9677c1ff6c", size = 1146802, upload-time = "2025-05-18T17:45:45.945Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/34/9d15a9c04d5760537b432134447bde94b936ec73dc922b4d14a48def2e1f/jiter-0.9.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:68cf519a6f00b8127f9be64a37e97e978094438abced5adebe088a98c64bdcff", size = 1256019, upload-time = "2025-05-18T17:45:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/01/1fcd165fb28968a54bb46a209d5919f7649b96608eef7dc4622ea378b95a/jiter-0.9.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9098abdd34cd9ddeb04768cc4f5fc725ebd9a52978c488da74e58a837ce93506", size = 1257610, upload-time = "2025-05-18T17:45:48.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/87/93ac6a57331dd90e4c896ac852bf8ce6b28b40dace4b9698a207dbb99af2/jiter-0.9.1-cp311-cp311-win32.whl", hash = "sha256:7179ce96aecd096af890dd57b84133e47a59fbde32a77734f09bafa6a4da619e", size = 214515, upload-time = "2025-05-18T17:45:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ee/3678b8a3bd5f6471d0a492540e7ff9c63db278d844214458ec5cfb22adb2/jiter-0.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:e6517f5b7b6f60fd77fc1099572f445be19553c6f61b907ab5b413fb7179663f", size = 212258, upload-time = "2025-05-18T17:45:51.983Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/a7/5b3ce91b5bb83bf47e85ab2efda26a1706fb52498a2abe79df09af7dfa8f/jiter-0.9.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f330c5023ce4153ceb3e8abe76ecab8c5b525824bcec4e781791d044e5b5fc3a", size = 307494, upload-time = "2025-05-18T17:45:53.639Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/9a/006ebbb5ab55fd9f47c219f9de7fdedd38694c158ddd6760a15f7a6fcdc8/jiter-0.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:77de4d2d529ece2d43fc0dbe90971e9e18f42ed6dd50b40fe232e799efb72c29", size = 312782, upload-time = "2025-05-18T17:45:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/17/da/a437705850c8cf6b8c93769ff6fcb3abcbfeb9c12b690c5f1631682d4286/jiter-0.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ed3eec217a70762a01ecfbecea27eda91d7d5792bdef41096d2c672a9e3c1fe", size = 1087076, upload-time = "2025-05-18T17:45:56.866Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/f463a03de974d437abc312a0ca6212e2b014b7023a880fd6956ebfde15c7/jiter-0.9.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d000bb8b9b3a90fb61ff864869461c56ad2dad5f0fa71127464cb65e69ec864b", size = 1118826, upload-time = "2025-05-18T17:45:58.359Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/04/4d9289d8610f2b10886b4bd32b0c6e036fdeabc86cc9a902e50434a066bd/jiter-0.9.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3610aed85fad26d5e107ce4e246c236b612e539b382d490761aacc4aa5d7cdbf", size = 1213155, upload-time = "2025-05-18T17:45:59.719Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/4c/851c0a7c95e333d5213558fc76d217a7760de8b704299c007537af49e1de/jiter-0.9.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae8f1f42f4b0ed244f88bb863d0777292e76e43ee2dc0dac4d63fe29bee183e5", size = 1215024, upload-time = "2025-05-18T17:46:01.083Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/24/9c62f5775645715ded77a4cf03b9f3c36d4909ee35b07f65bb4ccaad4bfd/jiter-0.9.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2082da43e7b6174c3522a6905a9ee9187c9771e32cad7ab58360f189595a7c3f", size = 350280, upload-time = "2025-05-18T17:46:02.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/54a4b1074f1f048ca822a2f4a738fa7b623203540a59ec99d0b0277c38ef/jiter-0.9.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d82b2b8bc089c4ebff99907bdb890730e05c58169d5493473c916518f8d29f5c", size = 1150978, upload-time = "2025-05-18T17:46:04.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/1b/caaa8d274ba82486dfb582e32f431412f2e178344ebf6a231b8606c048fd/jiter-0.9.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:8b7214d4064759ff34846311cabcf49715e8a7286a4431bc7444537ee2f21b1a", size = 1257583, upload-time = "2025-05-18T17:46:06.113Z" },
+    { url = "https://files.pythonhosted.org/packages/19/f7/a5f991075b16b76b15e4da7939243f373ff4369ce41145be428c7c43d905/jiter-0.9.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:136a635797b27aeb5cacea4d0ffeff5c80081089217c5891bd28968e5df97824", size = 1258268, upload-time = "2025-05-18T17:46:08.564Z" },
+    { url = "https://files.pythonhosted.org/packages/94/8f/6fabe1aa77637be629e73db2ee3059889b893c4be391f0e038b71948d208/jiter-0.9.1-cp312-cp312-win32.whl", hash = "sha256:5da9a4e2939c4af7617fe01f7e3978fba224d93def72bc748d173f148a8b637f", size = 214250, upload-time = "2025-05-18T17:46:10.108Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/18/6f118d22acf5930d5a46c4f6853eead883af8c097d83e2a2971308864423/jiter-0.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:d1434a05965d0c1f033061f21553fef5c3a352f3e880a0f503e79e6b639db10c", size = 211070, upload-time = "2025-05-18T17:46:11.39Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/36/4b5c7c96ce4795376e546bcabd96d8fe8667c9fdeb946523ca382cc30eaa/jiter-0.9.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:cb0629af6a12804ace5f093884c2f14d5075d95951a086054e106cfdb6b8862f", size = 307047, upload-time = "2025-05-18T17:46:13.192Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/20/7635fb02fe62cd90899dc1c64c972c1470106eede55ce35fc6e3868251af/jiter-0.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d15cc2b5602fb5a16689afb507b27c650167152203394efa429a5139553dd993", size = 311796, upload-time = "2025-05-18T17:46:14.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/43/7e4a38c63b9f1a5795d406a7cf1e8a42af0e51d05d5c5b866708a345d49e/jiter-0.9.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffbf9279273b41fb8c4360ad2590a8eea82b36665728f57b0d7b095a904016d9", size = 1086812, upload-time = "2025-05-18T17:46:15.765Z" },
+    { url = "https://files.pythonhosted.org/packages/30/17/3d5ad7a1e12bb172040c2e206068ee766a320c6b6327a0a52a9c05bf4cd6/jiter-0.9.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fca2935783d4309eed77ed2acd625f93a07b79693f7d8e58e3c18ac8981e9ea", size = 1118218, upload-time = "2025-05-18T17:46:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f7/9f46d976a91f339898783962043c36b8c9fe103135f264ae25dddad9838e/jiter-0.9.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3f5f14d63924d3b226236c746ceb37f5ac9d3ce1251762819024f84904b4a0f", size = 1211346, upload-time = "2025-05-18T17:46:19.823Z" },
+    { url = "https://files.pythonhosted.org/packages/93/71/cf594ec8c76188b5e42fc4f00a9cdfb3f675631234f5a1ac5413fe6684cb/jiter-0.9.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0d43dcddb437096ac48e85f6be8355d806ab9246051f95263933fa5e18d026aa", size = 1214466, upload-time = "2025-05-18T17:46:21.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e5/efd89f27838ea9d8257c9bc8edd58a953e06ca304c7d2b397fdd2a932e51/jiter-0.9.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19773c6f730523effbca88c4a15658b481cf81e4c981fcd1212dd4beaa0cd37a", size = 350245, upload-time = "2025-05-18T17:46:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/78/b7960c8a04d593687659007e6b7f911ef3f877eb11cd2503267ad5b2da0b/jiter-0.9.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:01fcc08b6d3e29562d72edfcd6c5b0aab30b964fb0c99ad8287c2dffeb6fd38c", size = 1149223, upload-time = "2025-05-18T17:46:25.732Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/4777b5a70febeece230593a82a69d0d19b5b6e36a8b3afcc4b43528c2657/jiter-0.9.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:448afc1a801a518ed438667229f380bb0b8503f379d170ac947575cb7e1e4edf", size = 1257025, upload-time = "2025-05-18T17:46:27.162Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c1/8fe3483537d85bc381bdab2a4952707d92944b1ac32074f7b33de188c2d0/jiter-0.9.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f321fb984ed7544e77346714a25ffa5bbefddd1adcc32c8fba49030a119a31c6", size = 1257882, upload-time = "2025-05-18T17:46:29.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1a/4453114fb7b3722f8d232b3c08114535e455d7d2d4d83b44cede53ed42ae/jiter-0.9.1-cp313-cp313-win32.whl", hash = "sha256:7db7c9a95d72668545606aeaf110549f4f42679eaa3ce5c32f8f26c1838550d8", size = 214946, upload-time = "2025-05-18T17:46:30.607Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d0/237d7dbaaafb08a6f719c8495663b76d70d6c5880a02c7b092f21292458b/jiter-0.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:a6b750ef1201fe4c431f869705607ece4adaf592e497efb6bc4138efaebb4f59", size = 209888, upload-time = "2025-05-18T17:46:31.89Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/e90c89adbea8342b6e470f3be9c213b628ae3842810553df15d5afb386ce/jiter-0.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4096dba935aa2730c7642146b065855a0f5853fd9bbe22de9e3dd39fcacc37fe", size = 311645, upload-time = "2025-05-18T17:46:33.196Z" },
+    { url = "https://files.pythonhosted.org/packages/29/40/98fee5bab390c27d20ba82c73d12afd1db89aabeef641ae7629a31a7100f/jiter-0.9.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13ad975e0d9d2f7e54b30d9ae8e2e1c97be422e75606bddc67427721ad13cd1c", size = 352754, upload-time = "2025-05-18T17:46:34.457Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/17/b0fa4ee5bdcb252b2407fc9528f11d8af717b7218455d23018cf314ccf6a/jiter-0.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f11992b20f8a2d336b98b31bff4d8bfcc4bd5aef7840594e32d6cb44fb9b96cf", size = 212573, upload-time = "2025-05-18T17:46:35.855Z" },
 ]
 
 [[package]]
@@ -352,9 +326,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/5b/a36a337438a14116b16480db471ad061c36c3694df7c2084a0da7ba538b7/matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90", size = 8159 }
+sdist = { url = "https://files.pythonhosted.org/packages/99/5b/a36a337438a14116b16480db471ad061c36c3694df7c2084a0da7ba538b7/matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90", size = 8159, upload-time = "2024-04-15T13:44:44.803Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca", size = 9899 },
+    { url = "https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca", size = 9899, upload-time = "2024-04-15T13:44:43.265Z" },
 ]
 
 [[package]]
@@ -364,21 +338,21 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/7c/b11b870fc4fd84de2099906314ce45488ae17be32ff5493519a6cddc518a/maturin-1.9.4.tar.gz", hash = "sha256:235163a0c99bc6f380fb8786c04fd14dcf6cd622ff295ea3de525015e6ac40cf", size = 213647 }
+sdist = { url = "https://files.pythonhosted.org/packages/13/7c/b11b870fc4fd84de2099906314ce45488ae17be32ff5493519a6cddc518a/maturin-1.9.4.tar.gz", hash = "sha256:235163a0c99bc6f380fb8786c04fd14dcf6cd622ff295ea3de525015e6ac40cf", size = 213647, upload-time = "2025-08-27T11:37:57.079Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/90/0d99389eea1939116fca841cad0763600c8d3183a02a9478d066736c60e8/maturin-1.9.4-py3-none-linux_armv6l.whl", hash = "sha256:6ff37578e3f5fdbe685110d45f60af1f5a7dfce70a1e26dfe3810af66853ecae", size = 8276133 },
-    { url = "https://files.pythonhosted.org/packages/f4/ed/c8ec68b383e50f084bf1fa9605e62a90cd32a3f75d9894ed3a6e5d4cc5b3/maturin-1.9.4-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f3837bb53611b2dafa1c090436c330f2d743ba305ef00d8801a371f4495e7e1b", size = 15994496 },
-    { url = "https://files.pythonhosted.org/packages/84/4e/401ff5f3cfc6b123364d4b94379bf910d7baee32c9c95b72784ff2329357/maturin-1.9.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4227d627d8e3bfe45877a8d65e9d8351a9d01434549f0da75d2c06a1b570de58", size = 8362228 },
-    { url = "https://files.pythonhosted.org/packages/51/8e/c56176dd360da9650c62b8a5ecfb85432cf011e97e46c186901e6996002e/maturin-1.9.4-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:1bb2aa0fa29032e9c5aac03ac400396ddea12cadef242f8967e9c8ef715313a1", size = 8271397 },
-    { url = "https://files.pythonhosted.org/packages/d2/46/001fcc5c6ad509874896418d6169a61acd619df5b724f99766308c44a99f/maturin-1.9.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:a0868d52934c8a5d1411b42367633fdb5cd5515bec47a534192282167448ec30", size = 8775625 },
-    { url = "https://files.pythonhosted.org/packages/b4/2e/26fa7574f01c19b7a74680fd70e5bae2e8c40fed9683d1752e765062cc2b/maturin-1.9.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:68b7b833b25741c0f553b78e8b9e095b31ae7c6611533b3c7b71f84c2cb8fc44", size = 8051117 },
-    { url = "https://files.pythonhosted.org/packages/73/ee/ca7308832d4f5b521c1aa176d9265f6f93e0bd1ad82a90fd9cd799f6b28c/maturin-1.9.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:08dc86312afee55af778af919818632e35d8d0464ccd79cb86700d9ea560ccd7", size = 8132122 },
-    { url = "https://files.pythonhosted.org/packages/45/e8/c623955da75e801a06942edf1fdc4e772a9e8fbc1ceebbdc85d59584dc10/maturin-1.9.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:ef20ffdd943078c4c3699c29fb2ed722bb6b4419efdade6642d1dbf248f94a70", size = 10586762 },
-    { url = "https://files.pythonhosted.org/packages/3c/4b/19ad558fdf54e151b1b4916ed45f1952ada96684ee6db64f9cd91cabec09/maturin-1.9.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:368e958468431dfeec80f75eea9639b4356d8c42428b0128444424b083fecfb0", size = 8926988 },
-    { url = "https://files.pythonhosted.org/packages/7e/27/153ad15eccae26921e8a01812da9f3b7f9013368f8f92c36853f2043b2a3/maturin-1.9.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:273f879214f63f79bfe851cd7d541f8150bdbfae5dfdc3c0c4d125d02d1f41b4", size = 8536758 },
-    { url = "https://files.pythonhosted.org/packages/43/e3/f304c3bdc3fba9adebe5348d4d2dd015f1152c0a9027aaf52cae0bb182c8/maturin-1.9.4-py3-none-win32.whl", hash = "sha256:ed2e54d132ace7e61829bd49709331007dd9a2cc78937f598aa76a4f69b6804d", size = 7265200 },
-    { url = "https://files.pythonhosted.org/packages/14/14/f86d0124bf1816b99005c058a1dbdca7cb5850d9cf4b09dcae07a1bc6201/maturin-1.9.4-py3-none-win_amd64.whl", hash = "sha256:8e450bb2c9afdf38a0059ee2e1ec2b17323f152b59c16f33eb9c74edaf1f9f79", size = 8237391 },
-    { url = "https://files.pythonhosted.org/packages/3f/25/8320fc2591e45b750c3ae71fa596b47aefa802d07d6abaaa719034a85160/maturin-1.9.4-py3-none-win_arm64.whl", hash = "sha256:7a6f980a9b67a5c13c844c268eabd855b54a6a765df4b4bb07d15a990572a4c9", size = 6988277 },
+    { url = "https://files.pythonhosted.org/packages/f2/90/0d99389eea1939116fca841cad0763600c8d3183a02a9478d066736c60e8/maturin-1.9.4-py3-none-linux_armv6l.whl", hash = "sha256:6ff37578e3f5fdbe685110d45f60af1f5a7dfce70a1e26dfe3810af66853ecae", size = 8276133, upload-time = "2025-08-27T11:37:23.325Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ed/c8ec68b383e50f084bf1fa9605e62a90cd32a3f75d9894ed3a6e5d4cc5b3/maturin-1.9.4-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f3837bb53611b2dafa1c090436c330f2d743ba305ef00d8801a371f4495e7e1b", size = 15994496, upload-time = "2025-08-27T11:37:27.092Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4e/401ff5f3cfc6b123364d4b94379bf910d7baee32c9c95b72784ff2329357/maturin-1.9.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4227d627d8e3bfe45877a8d65e9d8351a9d01434549f0da75d2c06a1b570de58", size = 8362228, upload-time = "2025-08-27T11:37:31.181Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8e/c56176dd360da9650c62b8a5ecfb85432cf011e97e46c186901e6996002e/maturin-1.9.4-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:1bb2aa0fa29032e9c5aac03ac400396ddea12cadef242f8967e9c8ef715313a1", size = 8271397, upload-time = "2025-08-27T11:37:33.672Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/46/001fcc5c6ad509874896418d6169a61acd619df5b724f99766308c44a99f/maturin-1.9.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:a0868d52934c8a5d1411b42367633fdb5cd5515bec47a534192282167448ec30", size = 8775625, upload-time = "2025-08-27T11:37:35.86Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/2e/26fa7574f01c19b7a74680fd70e5bae2e8c40fed9683d1752e765062cc2b/maturin-1.9.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:68b7b833b25741c0f553b78e8b9e095b31ae7c6611533b3c7b71f84c2cb8fc44", size = 8051117, upload-time = "2025-08-27T11:37:38.278Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ee/ca7308832d4f5b521c1aa176d9265f6f93e0bd1ad82a90fd9cd799f6b28c/maturin-1.9.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:08dc86312afee55af778af919818632e35d8d0464ccd79cb86700d9ea560ccd7", size = 8132122, upload-time = "2025-08-27T11:37:40.499Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e8/c623955da75e801a06942edf1fdc4e772a9e8fbc1ceebbdc85d59584dc10/maturin-1.9.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:ef20ffdd943078c4c3699c29fb2ed722bb6b4419efdade6642d1dbf248f94a70", size = 10586762, upload-time = "2025-08-27T11:37:42.718Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4b/19ad558fdf54e151b1b4916ed45f1952ada96684ee6db64f9cd91cabec09/maturin-1.9.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:368e958468431dfeec80f75eea9639b4356d8c42428b0128444424b083fecfb0", size = 8926988, upload-time = "2025-08-27T11:37:45.492Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/27/153ad15eccae26921e8a01812da9f3b7f9013368f8f92c36853f2043b2a3/maturin-1.9.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:273f879214f63f79bfe851cd7d541f8150bdbfae5dfdc3c0c4d125d02d1f41b4", size = 8536758, upload-time = "2025-08-27T11:37:48.213Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/f304c3bdc3fba9adebe5348d4d2dd015f1152c0a9027aaf52cae0bb182c8/maturin-1.9.4-py3-none-win32.whl", hash = "sha256:ed2e54d132ace7e61829bd49709331007dd9a2cc78937f598aa76a4f69b6804d", size = 7265200, upload-time = "2025-08-27T11:37:50.881Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f86d0124bf1816b99005c058a1dbdca7cb5850d9cf4b09dcae07a1bc6201/maturin-1.9.4-py3-none-win_amd64.whl", hash = "sha256:8e450bb2c9afdf38a0059ee2e1ec2b17323f152b59c16f33eb9c74edaf1f9f79", size = 8237391, upload-time = "2025-08-27T11:37:53.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/25/8320fc2591e45b750c3ae71fa596b47aefa802d07d6abaaa719034a85160/maturin-1.9.4-py3-none-win_arm64.whl", hash = "sha256:7a6f980a9b67a5c13c844c268eabd855b54a6a765df4b4bb07d15a990572a4c9", size = 6988277, upload-time = "2025-08-27T11:37:55.429Z" },
 ]
 
 [[package]]
@@ -395,27 +369,27 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/dd/4d4d46a06943e37c95b6e388237e1e38d1e9aab264ff070f86345d60b7a4/openai-2.1.0.tar.gz", hash = "sha256:47f3463a5047340a989b4c0cd5378054acfca966ff61a96553b22f098e3270a2", size = 572998 }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/dd/4d4d46a06943e37c95b6e388237e1e38d1e9aab264ff070f86345d60b7a4/openai-2.1.0.tar.gz", hash = "sha256:47f3463a5047340a989b4c0cd5378054acfca966ff61a96553b22f098e3270a2", size = 572998, upload-time = "2025-10-02T20:43:15.385Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/83/88f64fc8f037885efa8a629d1215f5bc1f037453bab4d4f823b5533319eb/openai-2.1.0-py3-none-any.whl", hash = "sha256:33172e8c06a4576144ba4137a493807a9ca427421dcabc54ad3aa656daf757d3", size = 964939 },
+    { url = "https://files.pythonhosted.org/packages/68/83/88f64fc8f037885efa8a629d1215f5bc1f037453bab4d4f823b5533319eb/openai-2.1.0-py3-none-any.whl", hash = "sha256:33172e8c06a4576144ba4137a493807a9ca427421dcabc54ad3aa656daf757d3", size = 964939, upload-time = "2025-10-02T20:43:13.568Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
 name = "parso"
 version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/de/53e0bcf53d13e005bd8c92e7855142494f41171b34c2536b86187474184d/parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a", size = 401205 }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/de/53e0bcf53d13e005bd8c92e7855142494f41171b34c2536b86187474184d/parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a", size = 401205, upload-time = "2025-08-23T15:15:28.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887", size = 106668 },
+    { url = "https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887", size = 106668, upload-time = "2025-08-23T15:15:25.663Z" },
 ]
 
 [[package]]
@@ -425,27 +399,27 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ptyprocess" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450 }
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772 },
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
 ]
 
 [[package]]
 name = "pickleshare"
 version = "0.7.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/b6/df3c1c9b616e9c0edbc4fbab6ddd09df9535849c64ba51fcb6531c32d4d8/pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca", size = 6161 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/b6/df3c1c9b616e9c0edbc4fbab6ddd09df9535849c64ba51fcb6531c32d4d8/pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca", size = 6161, upload-time = "2018-09-25T19:17:37.249Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/41/220f49aaea88bc6fa6cba8d05ecf24676326156c23b991e80b3f2fc24c77/pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56", size = 6877 },
+    { url = "https://files.pythonhosted.org/packages/9a/41/220f49aaea88bc6fa6cba8d05ecf24676326156c23b991e80b3f2fc24c77/pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56", size = 6877, upload-time = "2018-09-25T19:17:35.817Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
 ]
 
 [[package]]
@@ -455,27 +429,27 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431 },
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
 name = "ptyprocess"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762 }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993 },
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
 ]
 
 [[package]]
 name = "pure-eval"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752 }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842 },
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
 ]
 
 [[package]]
@@ -487,9 +461,9 @@ dependencies = [
     { name = "pydantic-core" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/ae/d5220c5c52b158b1de7ca89fc5edb72f304a70a4c540c84c8844bf4008de/pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236", size = 761681 }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/ae/d5220c5c52b158b1de7ca89fc5edb72f304a70a4c540c84c8844bf4008de/pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236", size = 761681, upload-time = "2025-01-24T01:42:12.693Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584", size = 431696 },
+    { url = "https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584", size = 431696, upload-time = "2025-01-24T01:42:10.371Z" },
 ]
 
 [[package]]
@@ -499,116 +473,81 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443 }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443, upload-time = "2024-12-18T11:31:54.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/bc/fed5f74b5d802cf9a03e83f60f18864e90e3aed7223adaca5ffb7a8d8d64/pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa", size = 1895938 },
-    { url = "https://files.pythonhosted.org/packages/71/2a/185aff24ce844e39abb8dd680f4e959f0006944f4a8a0ea372d9f9ae2e53/pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c", size = 1815684 },
-    { url = "https://files.pythonhosted.org/packages/c3/43/fafabd3d94d159d4f1ed62e383e264f146a17dd4d48453319fd782e7979e/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7969e133a6f183be60e9f6f56bfae753585680f3b7307a8e555a948d443cc05a", size = 1829169 },
-    { url = "https://files.pythonhosted.org/packages/a2/d1/f2dfe1a2a637ce6800b799aa086d079998959f6f1215eb4497966efd2274/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3de9961f2a346257caf0aa508a4da705467f53778e9ef6fe744c038119737ef5", size = 1867227 },
-    { url = "https://files.pythonhosted.org/packages/7d/39/e06fcbcc1c785daa3160ccf6c1c38fea31f5754b756e34b65f74e99780b5/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2bb4d3e5873c37bb3dd58714d4cd0b0e6238cebc4177ac8fe878f8b3aa8e74c", size = 2037695 },
-    { url = "https://files.pythonhosted.org/packages/7a/67/61291ee98e07f0650eb756d44998214231f50751ba7e13f4f325d95249ab/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:280d219beebb0752699480fe8f1dc61ab6615c2046d76b7ab7ee38858de0a4e7", size = 2741662 },
-    { url = "https://files.pythonhosted.org/packages/32/90/3b15e31b88ca39e9e626630b4c4a1f5a0dfd09076366f4219429e6786076/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47956ae78b6422cbd46f772f1746799cbb862de838fd8d1fbd34a82e05b0983a", size = 1993370 },
-    { url = "https://files.pythonhosted.org/packages/ff/83/c06d333ee3a67e2e13e07794995c1535565132940715931c1c43bfc85b11/pydantic_core-2.27.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:14d4a5c49d2f009d62a2a7140d3064f686d17a5d1a268bc641954ba181880236", size = 1996813 },
-    { url = "https://files.pythonhosted.org/packages/7c/f7/89be1c8deb6e22618a74f0ca0d933fdcb8baa254753b26b25ad3acff8f74/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:337b443af21d488716f8d0b6164de833e788aa6bd7e3a39c005febc1284f4962", size = 2005287 },
-    { url = "https://files.pythonhosted.org/packages/b7/7d/8eb3e23206c00ef7feee17b83a4ffa0a623eb1a9d382e56e4aa46fd15ff2/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9", size = 2128414 },
-    { url = "https://files.pythonhosted.org/packages/4e/99/fe80f3ff8dd71a3ea15763878d464476e6cb0a2db95ff1c5c554133b6b83/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7041c36f5680c6e0f08d922aed302e98b3745d97fe1589db0a3eebf6624523af", size = 2155301 },
-    { url = "https://files.pythonhosted.org/packages/2b/a3/e50460b9a5789ca1451b70d4f52546fa9e2b420ba3bfa6100105c0559238/pydantic_core-2.27.2-cp310-cp310-win32.whl", hash = "sha256:50a68f3e3819077be2c98110c1f9dcb3817e93f267ba80a2c05bb4f8799e2ff4", size = 1816685 },
-    { url = "https://files.pythonhosted.org/packages/57/4c/a8838731cb0f2c2a39d3535376466de6049034d7b239c0202a64aaa05533/pydantic_core-2.27.2-cp310-cp310-win_amd64.whl", hash = "sha256:e0fd26b16394ead34a424eecf8a31a1f5137094cabe84a1bcb10fa6ba39d3d31", size = 1982876 },
-    { url = "https://files.pythonhosted.org/packages/c2/89/f3450af9d09d44eea1f2c369f49e8f181d742f28220f88cc4dfaae91ea6e/pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc", size = 1893421 },
-    { url = "https://files.pythonhosted.org/packages/9e/e3/71fe85af2021f3f386da42d291412e5baf6ce7716bd7101ea49c810eda90/pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7", size = 1814998 },
-    { url = "https://files.pythonhosted.org/packages/a6/3c/724039e0d848fd69dbf5806894e26479577316c6f0f112bacaf67aa889ac/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15", size = 1826167 },
-    { url = "https://files.pythonhosted.org/packages/2b/5b/1b29e8c1fb5f3199a9a57c1452004ff39f494bbe9bdbe9a81e18172e40d3/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306", size = 1865071 },
-    { url = "https://files.pythonhosted.org/packages/89/6c/3985203863d76bb7d7266e36970d7e3b6385148c18a68cc8915fd8c84d57/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99", size = 2036244 },
-    { url = "https://files.pythonhosted.org/packages/0e/41/f15316858a246b5d723f7d7f599f79e37493b2e84bfc789e58d88c209f8a/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459", size = 2737470 },
-    { url = "https://files.pythonhosted.org/packages/a8/7c/b860618c25678bbd6d1d99dbdfdf0510ccb50790099b963ff78a124b754f/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048", size = 1992291 },
-    { url = "https://files.pythonhosted.org/packages/bf/73/42c3742a391eccbeab39f15213ecda3104ae8682ba3c0c28069fbcb8c10d/pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d", size = 1994613 },
-    { url = "https://files.pythonhosted.org/packages/94/7a/941e89096d1175d56f59340f3a8ebaf20762fef222c298ea96d36a6328c5/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b", size = 2002355 },
-    { url = "https://files.pythonhosted.org/packages/6e/95/2359937a73d49e336a5a19848713555605d4d8d6940c3ec6c6c0ca4dcf25/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474", size = 2126661 },
-    { url = "https://files.pythonhosted.org/packages/2b/4c/ca02b7bdb6012a1adef21a50625b14f43ed4d11f1fc237f9d7490aa5078c/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6", size = 2153261 },
-    { url = "https://files.pythonhosted.org/packages/72/9d/a241db83f973049a1092a079272ffe2e3e82e98561ef6214ab53fe53b1c7/pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c", size = 1812361 },
-    { url = "https://files.pythonhosted.org/packages/e8/ef/013f07248041b74abd48a385e2110aa3a9bbfef0fbd97d4e6d07d2f5b89a/pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc", size = 1982484 },
-    { url = "https://files.pythonhosted.org/packages/10/1c/16b3a3e3398fd29dca77cea0a1d998d6bde3902fa2706985191e2313cc76/pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4", size = 1867102 },
-    { url = "https://files.pythonhosted.org/packages/d6/74/51c8a5482ca447871c93e142d9d4a92ead74de6c8dc5e66733e22c9bba89/pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0", size = 1893127 },
-    { url = "https://files.pythonhosted.org/packages/d3/f3/c97e80721735868313c58b89d2de85fa80fe8dfeeed84dc51598b92a135e/pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef", size = 1811340 },
-    { url = "https://files.pythonhosted.org/packages/9e/91/840ec1375e686dbae1bd80a9e46c26a1e0083e1186abc610efa3d9a36180/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7", size = 1822900 },
-    { url = "https://files.pythonhosted.org/packages/f6/31/4240bc96025035500c18adc149aa6ffdf1a0062a4b525c932065ceb4d868/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934", size = 1869177 },
-    { url = "https://files.pythonhosted.org/packages/fa/20/02fbaadb7808be578317015c462655c317a77a7c8f0ef274bc016a784c54/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6", size = 2038046 },
-    { url = "https://files.pythonhosted.org/packages/06/86/7f306b904e6c9eccf0668248b3f272090e49c275bc488a7b88b0823444a4/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c", size = 2685386 },
-    { url = "https://files.pythonhosted.org/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2", size = 1997060 },
-    { url = "https://files.pythonhosted.org/packages/0d/0f/943b4af7cd416c477fd40b187036c4f89b416a33d3cc0ab7b82708a667aa/pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4", size = 2004870 },
-    { url = "https://files.pythonhosted.org/packages/35/40/aea70b5b1a63911c53a4c8117c0a828d6790483f858041f47bab0b779f44/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3", size = 1999822 },
-    { url = "https://files.pythonhosted.org/packages/f2/b3/807b94fd337d58effc5498fd1a7a4d9d59af4133e83e32ae39a96fddec9d/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4", size = 2130364 },
-    { url = "https://files.pythonhosted.org/packages/fc/df/791c827cd4ee6efd59248dca9369fb35e80a9484462c33c6649a8d02b565/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57", size = 2158303 },
-    { url = "https://files.pythonhosted.org/packages/9b/67/4e197c300976af185b7cef4c02203e175fb127e414125916bf1128b639a9/pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc", size = 1834064 },
-    { url = "https://files.pythonhosted.org/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9", size = 1989046 },
-    { url = "https://files.pythonhosted.org/packages/bc/49/c54baab2f4658c26ac633d798dab66b4c3a9bbf47cff5284e9c182f4137a/pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b", size = 1885092 },
-    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709 },
-    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273 },
-    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027 },
-    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888 },
-    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738 },
-    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138 },
-    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025 },
-    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633 },
-    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404 },
-    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130 },
-    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946 },
-    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387 },
-    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
-    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
-    { url = "https://files.pythonhosted.org/packages/43/53/13e9917fc69c0a4aea06fd63ed6a8d6cda9cf140ca9584d49c1650b0ef5e/pydantic_core-2.27.2-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:d3e8d504bdd3f10835468f29008d72fc8359d95c9c415ce6e767203db6127506", size = 1899595 },
-    { url = "https://files.pythonhosted.org/packages/f4/20/26c549249769ed84877f862f7bb93f89a6ee08b4bee1ed8781616b7fbb5e/pydantic_core-2.27.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:521eb9b7f036c9b6187f0b47318ab0d7ca14bd87f776240b90b21c1f4f149320", size = 1775010 },
-    { url = "https://files.pythonhosted.org/packages/35/eb/8234e05452d92d2b102ffa1b56d801c3567e628fdc63f02080fdfc68fd5e/pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85210c4d99a0114f5a9481b44560d7d1e35e32cc5634c656bc48e590b669b145", size = 1830727 },
-    { url = "https://files.pythonhosted.org/packages/8f/df/59f915c8b929d5f61e5a46accf748a87110ba145156f9326d1a7d28912b2/pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d716e2e30c6f140d7560ef1538953a5cd1a87264c737643d481f2779fc247fe1", size = 1868393 },
-    { url = "https://files.pythonhosted.org/packages/d5/52/81cf4071dca654d485c277c581db368b0c95b2b883f4d7b736ab54f72ddf/pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f66d89ba397d92f840f8654756196d93804278457b5fbede59598a1f9f90b228", size = 2040300 },
-    { url = "https://files.pythonhosted.org/packages/9c/00/05197ce1614f5c08d7a06e1d39d5d8e704dc81971b2719af134b844e2eaf/pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:669e193c1c576a58f132e3158f9dfa9662969edb1a250c54d8fa52590045f046", size = 2738785 },
-    { url = "https://files.pythonhosted.org/packages/f7/a3/5f19bc495793546825ab160e530330c2afcee2281c02b5ffafd0b32ac05e/pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdbe7629b996647b99c01b37f11170a57ae675375b14b8c13b8518b8320ced5", size = 1996493 },
-    { url = "https://files.pythonhosted.org/packages/ed/e8/e0102c2ec153dc3eed88aea03990e1b06cfbca532916b8a48173245afe60/pydantic_core-2.27.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d262606bf386a5ba0b0af3b97f37c83d7011439e3dc1a9298f21efb292e42f1a", size = 1998544 },
-    { url = "https://files.pythonhosted.org/packages/fb/a3/4be70845b555bd80aaee9f9812a7cf3df81550bce6dadb3cfee9c5d8421d/pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:cabb9bcb7e0d97f74df8646f34fc76fbf793b7f6dc2438517d7a9e50eee4f14d", size = 2007449 },
-    { url = "https://files.pythonhosted.org/packages/e3/9f/b779ed2480ba355c054e6d7ea77792467631d674b13d8257085a4bc7dcda/pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_armv7l.whl", hash = "sha256:d2d63f1215638d28221f664596b1ccb3944f6e25dd18cd3b86b0a4c408d5ebb9", size = 2129460 },
-    { url = "https://files.pythonhosted.org/packages/a0/f0/a6ab0681f6e95260c7fbf552874af7302f2ea37b459f9b7f00698f875492/pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bca101c00bff0adb45a833f8451b9105d9df18accb8743b08107d7ada14bd7da", size = 2159609 },
-    { url = "https://files.pythonhosted.org/packages/8a/2b/e1059506795104349712fbca647b18b3f4a7fd541c099e6259717441e1e0/pydantic_core-2.27.2-cp38-cp38-win32.whl", hash = "sha256:f6f8e111843bbb0dee4cb6594cdc73e79b3329b526037ec242a3e49012495b3b", size = 1819886 },
-    { url = "https://files.pythonhosted.org/packages/aa/6d/df49c17f024dfc58db0bacc7b03610058018dd2ea2eaf748ccbada4c3d06/pydantic_core-2.27.2-cp38-cp38-win_amd64.whl", hash = "sha256:fd1aea04935a508f62e0d0ef1f5ae968774a32afc306fb8545e06f5ff5cdf3ad", size = 1980773 },
-    { url = "https://files.pythonhosted.org/packages/27/97/3aef1ddb65c5ccd6eda9050036c956ff6ecbfe66cb7eb40f280f121a5bb0/pydantic_core-2.27.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c10eb4f1659290b523af58fa7cffb452a61ad6ae5613404519aee4bfbf1df993", size = 1896475 },
-    { url = "https://files.pythonhosted.org/packages/ad/d3/5668da70e373c9904ed2f372cb52c0b996426f302e0dee2e65634c92007d/pydantic_core-2.27.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ef592d4bad47296fb11f96cd7dc898b92e795032b4894dfb4076cfccd43a9308", size = 1772279 },
-    { url = "https://files.pythonhosted.org/packages/8a/9e/e44b8cb0edf04a2f0a1f6425a65ee089c1d6f9c4c2dcab0209127b6fdfc2/pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c61709a844acc6bf0b7dce7daae75195a10aac96a596ea1b776996414791ede4", size = 1829112 },
-    { url = "https://files.pythonhosted.org/packages/1c/90/1160d7ac700102effe11616e8119e268770f2a2aa5afb935f3ee6832987d/pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c5f762659e47fdb7b16956c71598292f60a03aa92f8b6351504359dbdba6cf", size = 1866780 },
-    { url = "https://files.pythonhosted.org/packages/ee/33/13983426df09a36d22c15980008f8d9c77674fc319351813b5a2739b70f3/pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c9775e339e42e79ec99c441d9730fccf07414af63eac2f0e48e08fd38a64d76", size = 2037943 },
-    { url = "https://files.pythonhosted.org/packages/01/d7/ced164e376f6747e9158c89988c293cd524ab8d215ae4e185e9929655d5c/pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57762139821c31847cfb2df63c12f725788bd9f04bc2fb392790959b8f70f118", size = 2740492 },
-    { url = "https://files.pythonhosted.org/packages/8b/1f/3dc6e769d5b7461040778816aab2b00422427bcaa4b56cc89e9c653b2605/pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d1e85068e818c73e048fe28cfc769040bb1f475524f4745a5dc621f75ac7630", size = 1995714 },
-    { url = "https://files.pythonhosted.org/packages/07/d7/a0bd09bc39283530b3f7c27033a814ef254ba3bd0b5cfd040b7abf1fe5da/pydantic_core-2.27.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:097830ed52fd9e427942ff3b9bc17fab52913b2f50f2880dc4a5611446606a54", size = 1997163 },
-    { url = "https://files.pythonhosted.org/packages/2d/bb/2db4ad1762e1c5699d9b857eeb41959191980de6feb054e70f93085e1bcd/pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:044a50963a614ecfae59bb1eaf7ea7efc4bc62f49ed594e18fa1e5d953c40e9f", size = 2005217 },
-    { url = "https://files.pythonhosted.org/packages/53/5f/23a5a3e7b8403f8dd8fc8a6f8b49f6b55c7d715b77dcf1f8ae919eeb5628/pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:4e0b4220ba5b40d727c7f879eac379b822eee5d8fff418e9d3381ee45b3b0362", size = 2127899 },
-    { url = "https://files.pythonhosted.org/packages/c2/ae/aa38bb8dd3d89c2f1d8362dd890ee8f3b967330821d03bbe08fa01ce3766/pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e4f4bb20d75e9325cc9696c6802657b58bc1dbbe3022f32cc2b2b632c3fbb96", size = 2155726 },
-    { url = "https://files.pythonhosted.org/packages/98/61/4f784608cc9e98f70839187117ce840480f768fed5d386f924074bf6213c/pydantic_core-2.27.2-cp39-cp39-win32.whl", hash = "sha256:cca63613e90d001b9f2f9a9ceb276c308bfa2a43fafb75c8031c4f66039e8c6e", size = 1817219 },
-    { url = "https://files.pythonhosted.org/packages/57/82/bb16a68e4a1a858bb3768c2c8f1ff8d8978014e16598f001ea29a25bf1d1/pydantic_core-2.27.2-cp39-cp39-win_amd64.whl", hash = "sha256:77d1bca19b0f7021b3a982e6f903dcd5b2b06076def36a652e3907f596e29f67", size = 1985382 },
-    { url = "https://files.pythonhosted.org/packages/46/72/af70981a341500419e67d5cb45abe552a7c74b66326ac8877588488da1ac/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2bf14caea37e91198329b828eae1618c068dfb8ef17bb33287a7ad4b61ac314e", size = 1891159 },
-    { url = "https://files.pythonhosted.org/packages/ad/3d/c5913cccdef93e0a6a95c2d057d2c2cba347815c845cda79ddd3c0f5e17d/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b0cb791f5b45307caae8810c2023a184c74605ec3bcbb67d13846c28ff731ff8", size = 1768331 },
-    { url = "https://files.pythonhosted.org/packages/f6/f0/a3ae8fbee269e4934f14e2e0e00928f9346c5943174f2811193113e58252/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:688d3fd9fcb71f41c4c015c023d12a79d1c4c0732ec9eb35d96e3388a120dcf3", size = 1822467 },
-    { url = "https://files.pythonhosted.org/packages/d7/7a/7bbf241a04e9f9ea24cd5874354a83526d639b02674648af3f350554276c/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d591580c34f4d731592f0e9fe40f9cc1b430d297eecc70b962e93c5c668f15f", size = 1979797 },
-    { url = "https://files.pythonhosted.org/packages/4f/5f/4784c6107731f89e0005a92ecb8a2efeafdb55eb992b8e9d0a2be5199335/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:82f986faf4e644ffc189a7f1aafc86e46ef70372bb153e7001e8afccc6e54133", size = 1987839 },
-    { url = "https://files.pythonhosted.org/packages/6d/a7/61246562b651dff00de86a5f01b6e4befb518df314c54dec187a78d81c84/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:bec317a27290e2537f922639cafd54990551725fc844249e64c523301d0822fc", size = 1998861 },
-    { url = "https://files.pythonhosted.org/packages/86/aa/837821ecf0c022bbb74ca132e117c358321e72e7f9702d1b6a03758545e2/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50", size = 2116582 },
-    { url = "https://files.pythonhosted.org/packages/81/b0/5e74656e95623cbaa0a6278d16cf15e10a51f6002e3ec126541e95c29ea3/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9", size = 2151985 },
-    { url = "https://files.pythonhosted.org/packages/63/37/3e32eeb2a451fddaa3898e2163746b0cffbbdbb4740d38372db0490d67f3/pydantic_core-2.27.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7e17b560be3c98a8e3aa66ce828bdebb9e9ac6ad5466fba92eb74c4c95cb1151", size = 2004715 },
-    { url = "https://files.pythonhosted.org/packages/29/0e/dcaea00c9dbd0348b723cae82b0e0c122e0fa2b43fa933e1622fd237a3ee/pydantic_core-2.27.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c33939a82924da9ed65dab5a65d427205a73181d8098e79b6b426bdf8ad4e656", size = 1891733 },
-    { url = "https://files.pythonhosted.org/packages/86/d3/e797bba8860ce650272bda6383a9d8cad1d1c9a75a640c9d0e848076f85e/pydantic_core-2.27.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:00bad2484fa6bda1e216e7345a798bd37c68fb2d97558edd584942aa41b7d278", size = 1768375 },
-    { url = "https://files.pythonhosted.org/packages/41/f7/f847b15fb14978ca2b30262548f5fc4872b2724e90f116393eb69008299d/pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c817e2b40aba42bac6f457498dacabc568c3b7a986fc9ba7c8d9d260b71485fb", size = 1822307 },
-    { url = "https://files.pythonhosted.org/packages/9c/63/ed80ec8255b587b2f108e514dc03eed1546cd00f0af281e699797f373f38/pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:251136cdad0cb722e93732cb45ca5299fb56e1344a833640bf93b2803f8d1bfd", size = 1979971 },
-    { url = "https://files.pythonhosted.org/packages/a9/6d/6d18308a45454a0de0e975d70171cadaf454bc7a0bf86b9c7688e313f0bb/pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d2088237af596f0a524d3afc39ab3b036e8adb054ee57cbb1dcf8e09da5b29cc", size = 1987616 },
-    { url = "https://files.pythonhosted.org/packages/82/8a/05f8780f2c1081b800a7ca54c1971e291c2d07d1a50fb23c7e4aef4ed403/pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:d4041c0b966a84b4ae7a09832eb691a35aec90910cd2dbe7a208de59be77965b", size = 1998943 },
-    { url = "https://files.pythonhosted.org/packages/5e/3e/fe5b6613d9e4c0038434396b46c5303f5ade871166900b357ada4766c5b7/pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:8083d4e875ebe0b864ffef72a4304827015cff328a1be6e22cc850753bfb122b", size = 2116654 },
-    { url = "https://files.pythonhosted.org/packages/db/ad/28869f58938fad8cc84739c4e592989730bfb69b7c90a8fff138dff18e1e/pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f141ee28a0ad2123b6611b6ceff018039df17f32ada8b534e6aa039545a3efb2", size = 2152292 },
-    { url = "https://files.pythonhosted.org/packages/a1/0c/c5c5cd3689c32ed1fe8c5d234b079c12c281c051759770c05b8bed6412b5/pydantic_core-2.27.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7d0c8399fcc1848491f00e0314bd59fb34a9c008761bcb422a057670c3f65e35", size = 2004961 },
+    { url = "https://files.pythonhosted.org/packages/3a/bc/fed5f74b5d802cf9a03e83f60f18864e90e3aed7223adaca5ffb7a8d8d64/pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa", size = 1895938, upload-time = "2024-12-18T11:27:14.406Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2a/185aff24ce844e39abb8dd680f4e959f0006944f4a8a0ea372d9f9ae2e53/pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c", size = 1815684, upload-time = "2024-12-18T11:27:16.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/43/fafabd3d94d159d4f1ed62e383e264f146a17dd4d48453319fd782e7979e/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7969e133a6f183be60e9f6f56bfae753585680f3b7307a8e555a948d443cc05a", size = 1829169, upload-time = "2024-12-18T11:27:22.16Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d1/f2dfe1a2a637ce6800b799aa086d079998959f6f1215eb4497966efd2274/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3de9961f2a346257caf0aa508a4da705467f53778e9ef6fe744c038119737ef5", size = 1867227, upload-time = "2024-12-18T11:27:25.097Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/39/e06fcbcc1c785daa3160ccf6c1c38fea31f5754b756e34b65f74e99780b5/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2bb4d3e5873c37bb3dd58714d4cd0b0e6238cebc4177ac8fe878f8b3aa8e74c", size = 2037695, upload-time = "2024-12-18T11:27:28.656Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/67/61291ee98e07f0650eb756d44998214231f50751ba7e13f4f325d95249ab/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:280d219beebb0752699480fe8f1dc61ab6615c2046d76b7ab7ee38858de0a4e7", size = 2741662, upload-time = "2024-12-18T11:27:30.798Z" },
+    { url = "https://files.pythonhosted.org/packages/32/90/3b15e31b88ca39e9e626630b4c4a1f5a0dfd09076366f4219429e6786076/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47956ae78b6422cbd46f772f1746799cbb862de838fd8d1fbd34a82e05b0983a", size = 1993370, upload-time = "2024-12-18T11:27:33.692Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/c06d333ee3a67e2e13e07794995c1535565132940715931c1c43bfc85b11/pydantic_core-2.27.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:14d4a5c49d2f009d62a2a7140d3064f686d17a5d1a268bc641954ba181880236", size = 1996813, upload-time = "2024-12-18T11:27:37.111Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f7/89be1c8deb6e22618a74f0ca0d933fdcb8baa254753b26b25ad3acff8f74/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:337b443af21d488716f8d0b6164de833e788aa6bd7e3a39c005febc1284f4962", size = 2005287, upload-time = "2024-12-18T11:27:40.566Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7d/8eb3e23206c00ef7feee17b83a4ffa0a623eb1a9d382e56e4aa46fd15ff2/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9", size = 2128414, upload-time = "2024-12-18T11:27:43.757Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/99/fe80f3ff8dd71a3ea15763878d464476e6cb0a2db95ff1c5c554133b6b83/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7041c36f5680c6e0f08d922aed302e98b3745d97fe1589db0a3eebf6624523af", size = 2155301, upload-time = "2024-12-18T11:27:47.36Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a3/e50460b9a5789ca1451b70d4f52546fa9e2b420ba3bfa6100105c0559238/pydantic_core-2.27.2-cp310-cp310-win32.whl", hash = "sha256:50a68f3e3819077be2c98110c1f9dcb3817e93f267ba80a2c05bb4f8799e2ff4", size = 1816685, upload-time = "2024-12-18T11:27:50.508Z" },
+    { url = "https://files.pythonhosted.org/packages/57/4c/a8838731cb0f2c2a39d3535376466de6049034d7b239c0202a64aaa05533/pydantic_core-2.27.2-cp310-cp310-win_amd64.whl", hash = "sha256:e0fd26b16394ead34a424eecf8a31a1f5137094cabe84a1bcb10fa6ba39d3d31", size = 1982876, upload-time = "2024-12-18T11:27:53.54Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/89/f3450af9d09d44eea1f2c369f49e8f181d742f28220f88cc4dfaae91ea6e/pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc", size = 1893421, upload-time = "2024-12-18T11:27:55.409Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e3/71fe85af2021f3f386da42d291412e5baf6ce7716bd7101ea49c810eda90/pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7", size = 1814998, upload-time = "2024-12-18T11:27:57.252Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3c/724039e0d848fd69dbf5806894e26479577316c6f0f112bacaf67aa889ac/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15", size = 1826167, upload-time = "2024-12-18T11:27:59.146Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/5b/1b29e8c1fb5f3199a9a57c1452004ff39f494bbe9bdbe9a81e18172e40d3/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306", size = 1865071, upload-time = "2024-12-18T11:28:02.625Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6c/3985203863d76bb7d7266e36970d7e3b6385148c18a68cc8915fd8c84d57/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99", size = 2036244, upload-time = "2024-12-18T11:28:04.442Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/41/f15316858a246b5d723f7d7f599f79e37493b2e84bfc789e58d88c209f8a/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459", size = 2737470, upload-time = "2024-12-18T11:28:07.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/7c/b860618c25678bbd6d1d99dbdfdf0510ccb50790099b963ff78a124b754f/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048", size = 1992291, upload-time = "2024-12-18T11:28:10.297Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/73/42c3742a391eccbeab39f15213ecda3104ae8682ba3c0c28069fbcb8c10d/pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d", size = 1994613, upload-time = "2024-12-18T11:28:13.362Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7a/941e89096d1175d56f59340f3a8ebaf20762fef222c298ea96d36a6328c5/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b", size = 2002355, upload-time = "2024-12-18T11:28:16.587Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/95/2359937a73d49e336a5a19848713555605d4d8d6940c3ec6c6c0ca4dcf25/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474", size = 2126661, upload-time = "2024-12-18T11:28:18.407Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/4c/ca02b7bdb6012a1adef21a50625b14f43ed4d11f1fc237f9d7490aa5078c/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6", size = 2153261, upload-time = "2024-12-18T11:28:21.471Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9d/a241db83f973049a1092a079272ffe2e3e82e98561ef6214ab53fe53b1c7/pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c", size = 1812361, upload-time = "2024-12-18T11:28:23.53Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/013f07248041b74abd48a385e2110aa3a9bbfef0fbd97d4e6d07d2f5b89a/pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc", size = 1982484, upload-time = "2024-12-18T11:28:25.391Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1c/16b3a3e3398fd29dca77cea0a1d998d6bde3902fa2706985191e2313cc76/pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4", size = 1867102, upload-time = "2024-12-18T11:28:28.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/74/51c8a5482ca447871c93e142d9d4a92ead74de6c8dc5e66733e22c9bba89/pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0", size = 1893127, upload-time = "2024-12-18T11:28:30.346Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f3/c97e80721735868313c58b89d2de85fa80fe8dfeeed84dc51598b92a135e/pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef", size = 1811340, upload-time = "2024-12-18T11:28:32.521Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/91/840ec1375e686dbae1bd80a9e46c26a1e0083e1186abc610efa3d9a36180/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7", size = 1822900, upload-time = "2024-12-18T11:28:34.507Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/31/4240bc96025035500c18adc149aa6ffdf1a0062a4b525c932065ceb4d868/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934", size = 1869177, upload-time = "2024-12-18T11:28:36.488Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/20/02fbaadb7808be578317015c462655c317a77a7c8f0ef274bc016a784c54/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6", size = 2038046, upload-time = "2024-12-18T11:28:39.409Z" },
+    { url = "https://files.pythonhosted.org/packages/06/86/7f306b904e6c9eccf0668248b3f272090e49c275bc488a7b88b0823444a4/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c", size = 2685386, upload-time = "2024-12-18T11:28:41.221Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2", size = 1997060, upload-time = "2024-12-18T11:28:44.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/0f/943b4af7cd416c477fd40b187036c4f89b416a33d3cc0ab7b82708a667aa/pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4", size = 2004870, upload-time = "2024-12-18T11:28:46.839Z" },
+    { url = "https://files.pythonhosted.org/packages/35/40/aea70b5b1a63911c53a4c8117c0a828d6790483f858041f47bab0b779f44/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3", size = 1999822, upload-time = "2024-12-18T11:28:48.896Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b3/807b94fd337d58effc5498fd1a7a4d9d59af4133e83e32ae39a96fddec9d/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4", size = 2130364, upload-time = "2024-12-18T11:28:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/df/791c827cd4ee6efd59248dca9369fb35e80a9484462c33c6649a8d02b565/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57", size = 2158303, upload-time = "2024-12-18T11:28:54.122Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/4e197c300976af185b7cef4c02203e175fb127e414125916bf1128b639a9/pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc", size = 1834064, upload-time = "2024-12-18T11:28:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9", size = 1989046, upload-time = "2024-12-18T11:28:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/49/c54baab2f4658c26ac633d798dab66b4c3a9bbf47cff5284e9c182f4137a/pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b", size = 1885092, upload-time = "2024-12-18T11:29:01.335Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709, upload-time = "2024-12-18T11:29:03.193Z" },
+    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273, upload-time = "2024-12-18T11:29:05.306Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027, upload-time = "2024-12-18T11:29:07.294Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888, upload-time = "2024-12-18T11:29:09.249Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738, upload-time = "2024-12-18T11:29:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138, upload-time = "2024-12-18T11:29:16.396Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025, upload-time = "2024-12-18T11:29:20.25Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633, upload-time = "2024-12-18T11:29:23.877Z" },
+    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404, upload-time = "2024-12-18T11:29:25.872Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130, upload-time = "2024-12-18T11:29:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946, upload-time = "2024-12-18T11:29:31.338Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387, upload-time = "2024-12-18T11:29:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453, upload-time = "2024-12-18T11:29:35.533Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186, upload-time = "2024-12-18T11:29:37.649Z" },
+    { url = "https://files.pythonhosted.org/packages/46/72/af70981a341500419e67d5cb45abe552a7c74b66326ac8877588488da1ac/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2bf14caea37e91198329b828eae1618c068dfb8ef17bb33287a7ad4b61ac314e", size = 1891159, upload-time = "2024-12-18T11:30:54.382Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3d/c5913cccdef93e0a6a95c2d057d2c2cba347815c845cda79ddd3c0f5e17d/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b0cb791f5b45307caae8810c2023a184c74605ec3bcbb67d13846c28ff731ff8", size = 1768331, upload-time = "2024-12-18T11:30:58.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f0/a3ae8fbee269e4934f14e2e0e00928f9346c5943174f2811193113e58252/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:688d3fd9fcb71f41c4c015c023d12a79d1c4c0732ec9eb35d96e3388a120dcf3", size = 1822467, upload-time = "2024-12-18T11:31:00.6Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/7a/7bbf241a04e9f9ea24cd5874354a83526d639b02674648af3f350554276c/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d591580c34f4d731592f0e9fe40f9cc1b430d297eecc70b962e93c5c668f15f", size = 1979797, upload-time = "2024-12-18T11:31:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5f/4784c6107731f89e0005a92ecb8a2efeafdb55eb992b8e9d0a2be5199335/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:82f986faf4e644ffc189a7f1aafc86e46ef70372bb153e7001e8afccc6e54133", size = 1987839, upload-time = "2024-12-18T11:31:09.775Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a7/61246562b651dff00de86a5f01b6e4befb518df314c54dec187a78d81c84/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:bec317a27290e2537f922639cafd54990551725fc844249e64c523301d0822fc", size = 1998861, upload-time = "2024-12-18T11:31:13.469Z" },
+    { url = "https://files.pythonhosted.org/packages/86/aa/837821ecf0c022bbb74ca132e117c358321e72e7f9702d1b6a03758545e2/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50", size = 2116582, upload-time = "2024-12-18T11:31:17.423Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b0/5e74656e95623cbaa0a6278d16cf15e10a51f6002e3ec126541e95c29ea3/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9", size = 2151985, upload-time = "2024-12-18T11:31:19.901Z" },
+    { url = "https://files.pythonhosted.org/packages/63/37/3e32eeb2a451fddaa3898e2163746b0cffbbdbb4740d38372db0490d67f3/pydantic_core-2.27.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7e17b560be3c98a8e3aa66ce828bdebb9e9ac6ad5466fba92eb74c4c95cb1151", size = 2004715, upload-time = "2024-12-18T11:31:22.821Z" },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
@@ -623,18 +562,18 @@ dependencies = [
     { name = "pluggy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
 ]
 
 [[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -646,48 +585,48 @@ dependencies = [
     { name = "executing" },
     { name = "pure-eval" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
 ]
 
 [[package]]
 name = "tomli"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077 },
-    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429 },
-    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067 },
-    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030 },
-    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898 },
-    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894 },
-    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319 },
-    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
-    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
-    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
-    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
-    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
-    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
-    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
-    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
-    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
-    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
-    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
-    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
-    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
-    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708 },
-    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582 },
-    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543 },
-    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691 },
-    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170 },
-    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530 },
-    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666 },
-    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954 },
-    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
-    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
-    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]
@@ -695,36 +634,36 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540 },
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
 ]
 
 [[package]]
 name = "traitlets"
 version = "5.14.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621 }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359 },
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806 },
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
 ]
 
 [[package]]
 name = "wcwidth"
 version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293 }
+sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286 },
+    { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
 ]

--- a/payloads/cases/index.ts
+++ b/payloads/cases/index.ts
@@ -6,14 +6,20 @@ export * from "./models";
 // Export all case collections
 export { simpleCases } from "./simple";
 export { advancedCases } from "./advanced";
+export { paramsCases } from "./params";
 
 // Import and merge all collections for convenience
 import { simpleCases } from "./simple";
 import { advancedCases } from "./advanced";
+import { paramsCases } from "./params";
 import { mergeCollections } from "./utils";
 
 // Combined collection of all test cases
-export const allTestCases = mergeCollections(simpleCases, advancedCases);
+export const allTestCases = mergeCollections(
+  simpleCases,
+  advancedCases,
+  paramsCases
+);
 
 // Legacy export for backward compatibility (can be removed later)
 export const unifiedTestCases = allTestCases;

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -1,0 +1,246 @@
+import { TestCaseCollection } from "./types";
+import { OPENAI_RESPONSES_MODEL } from "./models";
+
+// OpenAI Responses API parameter test cases
+// Each test case exercises specific parameters from the Responses API
+// Note: temperature, top_p, and logprobs are not supported with reasoning models (gpt-5-nano)
+export const paramsCases: TestCaseCollection = {
+  // === Reasoning Configuration ===
+
+  reasoningSummaryParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "2+2" }],
+      reasoning: {
+        effort: "medium",
+        summary: "detailed",
+      },
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  // === Text Response Configuration ===
+
+  textFormatJsonObjectParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Return JSON with a=1" }],
+      text: {
+        format: {
+          type: "json_object",
+        },
+      },
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  textFormatJsonSchemaParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Name: John, Age: 25" }],
+      text: {
+        format: {
+          type: "json_schema",
+          name: "person_info",
+          schema: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              age: { type: "number" },
+            },
+            required: ["name", "age"],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      },
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  // === Tool Configuration ===
+
+  webSearchToolParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Latest OpenAI news" }],
+      tools: [{ type: "web_search_preview" }],
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  codeInterpreterToolParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [
+        {
+          role: "user",
+          content: "Execute Python code to generate a random number",
+        },
+      ],
+      tools: [{ type: "code_interpreter", container: { type: "auto" } }],
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  toolChoiceRequiredParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Tokyo weather" }],
+      tools: [
+        {
+          type: "function",
+          name: "get_weather",
+          description: "Get weather",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: {
+              location: { type: "string" },
+            },
+            required: ["location"],
+            additionalProperties: false,
+          },
+        },
+      ],
+      tool_choice: { type: "function", name: "get_weather" },
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  parallelToolCallsDisabledParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "NYC and LA weather" }],
+      tools: [
+        {
+          type: "function",
+          name: "get_weather",
+          description: "Get weather",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: {
+              location: { type: "string" },
+            },
+            required: ["location"],
+            additionalProperties: false,
+          },
+        },
+      ],
+      parallel_tool_calls: false,
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  // === Context & State Management ===
+
+  instructionsParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Hi" }],
+      instructions: "Reply with OK",
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  truncationAutoParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Hi" }],
+      truncation: "auto",
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  storeDisabledParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Hi" }],
+      store: false,
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  // === Caching & Performance ===
+
+  serviceTierParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Hi" }],
+      service_tier: "default",
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  promptCacheKeyParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Hi" }],
+      prompt_cache_key: "test-key",
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  // === Metadata & Identification ===
+
+  metadataParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Hi" }],
+      metadata: { key: "value" },
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  safetyIdentifierParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Hi" }],
+      safety_identifier: "test-user",
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+};

--- a/payloads/package.json
+++ b/payloads/package.json
@@ -18,7 +18,7 @@
     "@anthropic-ai/sdk": "^0.63.0",
     "@aws-sdk/client-bedrock-runtime": "^3.700.0",
     "@google/genai": "^1.34.0",
-    "openai": "^5.22.0"
+    "openai": "^6.16.0"
   },
   "devDependencies": {
     "@types/node": "^22.9.0",

--- a/payloads/scripts/providers/openai-responses.ts
+++ b/payloads/scripts/providers/openai-responses.ts
@@ -98,6 +98,12 @@ export async function executeOpenAIResponses(
       }
     }
 
+    // Skip followup if store is disabled (responses aren't persisted)
+    if (payload.store === false) {
+      console.log(`⚠️ Skipping followup for ${caseName} - store is disabled`);
+      return result;
+    }
+
     // Create follow-up conversation if we have a non-streaming response with valid output
     if (
       result.response &&

--- a/payloads/snapshots/codeInterpreterToolParam/responses/followup-request.json
+++ b/payloads/snapshots/codeInterpreterToolParam/responses/followup-request.json
@@ -1,0 +1,53 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Execute Python code to generate a random number"
+    },
+    {
+      "id": "rs_010121ebb5e188bb006967e4607ddc81a18c909c1d7e06c207",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ci_010121ebb5e188bb006967e463fc6c81a1a49c34d9bf2a46ee",
+      "type": "code_interpreter_call",
+      "status": "completed",
+      "code": "import random\nrandom.randint(1,100)",
+      "container_id": "cntr_6967e46040a881918bafe26339ea573d07ea9c1707add848",
+      "outputs": null
+    },
+    {
+      "id": "rs_010121ebb5e188bb006967e46885e481a1bc1bf28e97360474",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_010121ebb5e188bb006967e46aacec81a18809a200d9cfc0c1",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Here's a random number between 1 and 100: 25\n\nWant another one or a different range (e.g., 0-1 float, 1-1000 int)?"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "tools": [
+    {
+      "type": "code_interpreter",
+      "container": {
+        "type": "auto"
+      }
+    }
+  ]
+}

--- a/payloads/snapshots/codeInterpreterToolParam/responses/followup-response.json
+++ b/payloads/snapshots/codeInterpreterToolParam/responses/followup-response.json
@@ -1,0 +1,84 @@
+{
+  "id": "resp_010121ebb5e188bb006967e46cb68c81a18513de8068c05db0",
+  "object": "response",
+  "created_at": 1768416364,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768416382,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_010121ebb5e188bb006967e46d6af481a1ba9f3e4e9c890287",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_010121ebb5e188bb006967e47c7b5081a1a82da65c51c4bef1",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Nice! Want to do something similar or try something a bit different? Here are quick options. Tell me which one you’d like (or give your own parameters), and I’ll run it.\n\n- Generate another random number in the same range (1–100)\n- Random integer in a custom range [a, b] (tell me a and b)\n- Random float between 0 and 1\n- Generate N random integers in a range (e.g., N=5, range 1–100)\n- Pick a random item from a list you provide\n- Generate a random password (length and character set you choose)\n- Seeded run for reproducibility (pass a seed like 42)\n- Save the result to a file (e.g., results.txt)"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "code_interpreter",
+      "container": {
+        "type": "auto"
+      }
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 745,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1891,
+    "output_tokens_details": {
+      "reasoning_tokens": 1728
+    },
+    "total_tokens": 2636
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Nice! Want to do something similar or try something a bit different? Here are quick options. Tell me which one you’d like (or give your own parameters), and I’ll run it.\n\n- Generate another random number in the same range (1–100)\n- Random integer in a custom range [a, b] (tell me a and b)\n- Random float between 0 and 1\n- Generate N random integers in a range (e.g., N=5, range 1–100)\n- Pick a random item from a list you provide\n- Generate a random password (length and character set you choose)\n- Seeded run for reproducibility (pass a seed like 42)\n- Save the result to a file (e.g., results.txt)"
+}

--- a/payloads/snapshots/codeInterpreterToolParam/responses/request.json
+++ b/payloads/snapshots/codeInterpreterToolParam/responses/request.json
@@ -1,0 +1,17 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Execute Python code to generate a random number"
+    }
+  ],
+  "tools": [
+    {
+      "type": "code_interpreter",
+      "container": {
+        "type": "auto"
+      }
+    }
+  ]
+}

--- a/payloads/snapshots/codeInterpreterToolParam/responses/response-streaming.json
+++ b/payloads/snapshots/codeInterpreterToolParam/responses/response-streaming.json
@@ -1,0 +1,776 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0d420c82e16360a5006967e486f50c8197b0231467aa9c0fe4",
+      "object": "response",
+      "created_at": 1768416391,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "code_interpreter",
+          "container": {
+            "type": "auto"
+          }
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0d420c82e16360a5006967e486f50c8197b0231467aa9c0fe4",
+      "object": "response",
+      "created_at": 1768416391,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "code_interpreter",
+          "container": {
+            "type": "auto"
+          }
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0d420c82e16360a5006967e48b6e6c8197bd6139a706385faa",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0d420c82e16360a5006967e48b6e6c8197bd6139a706385faa",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+      "type": "code_interpreter_call",
+      "status": "in_progress",
+      "code": "",
+      "container_id": "cntr_6967e48b1e4c8193912af1b11d99ec3901a863d291c17b9c",
+      "outputs": null
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.code_interpreter_call.in_progress",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "output_index": 1,
+    "sequence_number": 5
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": "import",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "LYZ0yftf2J",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": " random",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "4ldg36ZoR",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": "\n",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "3gSrYaZA8L2x9EI",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": "n",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "uXmH4mykpCewCvh",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": " =",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "q4YMVT4FHTxMbV",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": " random",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "dg0XeCoul",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": ".randint",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "GEcl8kKj",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": "(",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "AAkDv5L6bKQcbsE",
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": "1",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "bPHbibebPbK5Q8W",
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": ",",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "ISwaq3gCIKAPClC",
+    "output_index": 1,
+    "sequence_number": 15
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": " ",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "3DMPnTOuzW639fS",
+    "output_index": 1,
+    "sequence_number": 16
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": "100",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "3Zy8DxQScfHsE",
+    "output_index": 1,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": ")\n",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "3RuGxSwIg2TzaR",
+    "output_index": 1,
+    "sequence_number": 18
+  },
+  {
+    "type": "response.code_interpreter_call_code.delta",
+    "delta": "n",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "obfuscation": "YU7zP6A0DGQ6wmH",
+    "output_index": 1,
+    "sequence_number": 19
+  },
+  {
+    "type": "response.code_interpreter_call_code.done",
+    "code": "import random\nn = random.randint(1, 100)\nn",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "output_index": 1,
+    "sequence_number": 20
+  },
+  {
+    "type": "response.code_interpreter_call.interpreting",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "output_index": 1,
+    "sequence_number": 21
+  },
+  {
+    "type": "response.code_interpreter_call.completed",
+    "item_id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+    "output_index": 1,
+    "sequence_number": 22
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+      "type": "code_interpreter_call",
+      "status": "completed",
+      "code": "import random\nn = random.randint(1, 100)\nn",
+      "container_id": "cntr_6967e48b1e4c8193912af1b11d99ec3901a863d291c17b9c",
+      "outputs": null
+    },
+    "output_index": 1,
+    "sequence_number": 23
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0d420c82e16360a5006967e4962ad481978e4200f20718aebc",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 2,
+    "sequence_number": 24
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0d420c82e16360a5006967e4962ad481978e4200f20718aebc",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 2,
+    "sequence_number": 25
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 3,
+    "sequence_number": 26
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "output_index": 3,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 27
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Here's",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "ly7y31YoRT",
+    "output_index": 3,
+    "sequence_number": 28
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "MhBHliKJcSaVkS",
+    "output_index": 3,
+    "sequence_number": 29
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " random",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "3xtVSfnqH",
+    "output_index": 3,
+    "sequence_number": 30
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " number",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "y5H0uRFhu",
+    "output_index": 3,
+    "sequence_number": 31
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " between",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "t80QtliE",
+    "output_index": 3,
+    "sequence_number": 32
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "5T5s1uYi954y6OH",
+    "output_index": 3,
+    "sequence_number": 33
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "1",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "wFERc4q0xrqWteu",
+    "output_index": 3,
+    "sequence_number": 34
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "hU0MQX7RHKZY",
+    "output_index": 3,
+    "sequence_number": 35
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "oC8HiZ9W96jZouR",
+    "output_index": 3,
+    "sequence_number": 36
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "100",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "VMlVzjgmvvCw3",
+    "output_index": 3,
+    "sequence_number": 37
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "CL8vWY75ydb1QwC",
+    "output_index": 3,
+    "sequence_number": 38
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "AFcnkZuo48EoRXo",
+    "output_index": 3,
+    "sequence_number": 39
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "53",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "N6b38kz9X6tzUj",
+    "output_index": 3,
+    "sequence_number": 40
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n\n",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "aGzQ2v35h0MNZ9",
+    "output_index": 3,
+    "sequence_number": 41
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "If",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "ss5RiZghSK9iR1",
+    "output_index": 3,
+    "sequence_number": 42
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "h0UVfbLSG8xZ",
+    "output_index": 3,
+    "sequence_number": 43
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " want",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "4QNzYiQ2mp6",
+    "output_index": 3,
+    "sequence_number": 44
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "3zbKczBatTqOeS",
+    "output_index": 3,
+    "sequence_number": 45
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " different",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "Jxdjmp",
+    "output_index": 3,
+    "sequence_number": 46
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " range",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "6lLo7rfdGt",
+    "output_index": 3,
+    "sequence_number": 47
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "Lq6emw6HFJXN5",
+    "output_index": 3,
+    "sequence_number": 48
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "HIKdTnPZuMAuq0",
+    "output_index": 3,
+    "sequence_number": 49
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " random",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "NIBUXJfN5",
+    "output_index": 3,
+    "sequence_number": 50
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " float",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "cCvKNIB0WU",
+    "output_index": 3,
+    "sequence_number": 51
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "UO2ot0KHB8pr803",
+    "output_index": 3,
+    "sequence_number": 52
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " tell",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "K4HIVI5jB9p",
+    "output_index": 3,
+    "sequence_number": 53
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " me",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "Lmxgv5zbIlzP6",
+    "output_index": 3,
+    "sequence_number": 54
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " your",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "xrOX7fzYpSJ",
+    "output_index": 3,
+    "sequence_number": 55
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " preferences",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "PhR4",
+    "output_index": 3,
+    "sequence_number": 56
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "obfuscation": "qRKmOUkcApdnMi7",
+    "output_index": 3,
+    "sequence_number": 57
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "logprobs": [],
+    "output_index": 3,
+    "sequence_number": 58,
+    "text": "Here's a random number between 1 and 100: 53\n\nIf you want a different range or a random float, tell me your preferences."
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+    "output_index": 3,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "Here's a random number between 1 and 100: 53\n\nIf you want a different range or a random float, tell me your preferences."
+    },
+    "sequence_number": 59
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Here's a random number between 1 and 100: 53\n\nIf you want a different range or a random float, tell me your preferences."
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 3,
+    "sequence_number": 60
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0d420c82e16360a5006967e486f50c8197b0231467aa9c0fe4",
+      "object": "response",
+      "created_at": 1768416391,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768416409,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_0d420c82e16360a5006967e48b6e6c8197bd6139a706385faa",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ci_0d420c82e16360a5006967e48fef8881979dd32c8445fe7a63",
+          "type": "code_interpreter_call",
+          "status": "completed",
+          "code": "import random\nn = random.randint(1, 100)\nn",
+          "container_id": "cntr_6967e48b1e4c8193912af1b11d99ec3901a863d291c17b9c",
+          "outputs": null
+        },
+        {
+          "id": "rs_0d420c82e16360a5006967e4962ad481978e4200f20718aebc",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_0d420c82e16360a5006967e4977a1c8197b5ad0f3abd6ef5d4",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "Here's a random number between 1 and 100: 53\n\nIf you want a different range or a random float, tell me your preferences."
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "code_interpreter",
+          "container": {
+            "type": "auto"
+          }
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 1246,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 676,
+        "output_tokens_details": {
+          "reasoning_tokens": 640
+        },
+        "total_tokens": 1922
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 61
+  }
+]

--- a/payloads/snapshots/codeInterpreterToolParam/responses/response.json
+++ b/payloads/snapshots/codeInterpreterToolParam/responses/response.json
@@ -1,0 +1,97 @@
+{
+  "id": "resp_010121ebb5e188bb006967e457cd3081a18576dd1906e07d88",
+  "object": "response",
+  "created_at": 1768416343,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768416364,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_010121ebb5e188bb006967e4607ddc81a18c909c1d7e06c207",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ci_010121ebb5e188bb006967e463fc6c81a1a49c34d9bf2a46ee",
+      "type": "code_interpreter_call",
+      "status": "completed",
+      "code": "import random\nrandom.randint(1,100)",
+      "container_id": "cntr_6967e46040a881918bafe26339ea573d07ea9c1707add848",
+      "outputs": null
+    },
+    {
+      "id": "rs_010121ebb5e188bb006967e46885e481a1bc1bf28e97360474",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_010121ebb5e188bb006967e46aacec81a18809a200d9cfc0c1",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Here's a random number between 1 and 100: 25\n\nWant another one or a different range (e.g., 0-1 float, 1-1000 int)?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "code_interpreter",
+      "container": {
+        "type": "auto"
+      }
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 1104,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 684,
+    "output_tokens_details": {
+      "reasoning_tokens": 640
+    },
+    "total_tokens": 1788
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Here's a random number between 1 and 100: 25\n\nWant another one or a different range (e.g., 0-1 float, 1-1000 int)?"
+}

--- a/payloads/snapshots/instructionsParam/responses/followup-request.json
+++ b/payloads/snapshots/instructionsParam/responses/followup-request.json
@@ -1,0 +1,33 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    },
+    {
+      "id": "rs_0ab144e1c69938ee006967e27277b4819e88de016ef3ff3b31",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0ab144e1c69938ee006967e273c358819e850d14f1808c55a6",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "OK"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "instructions": "Reply with OK"
+}

--- a/payloads/snapshots/instructionsParam/responses/followup-response.json
+++ b/payloads/snapshots/instructionsParam/responses/followup-response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_0ab144e1c69938ee006967e2741e64819e93c26e619ceb8bcb",
+  "object": "response",
+  "created_at": 1768415860,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415875,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": "Reply with OK",
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0ab144e1c69938ee006967e2748888819eb4731a13bbec7bd1",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0ab144e1c69938ee006967e2810e14819eaf28936fb433a39e",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Happy to help. What would you like to work on? A task, a project, learning something new, or making a decision? If you're not sure, here are quick ways to get moving:\n\n- Define a goal: Write one sentence for what you want to achieve and a clear deadline.\n- Brainstorm options: List 3–5 ways to reach that goal, then pick the best one.\n- Plan in small steps: Break the chosen option into 3 concrete actions and start a 25-minute focus session (a short sprint).\n- Check in: After you try, note what went well and what blocked you, then adjust.\n\nIf you share your goal or area (coding, writing, study, health, career, etc.), I’ll tailor a simple, step-by-step plan with your timeline."
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 31,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1129,
+    "output_tokens_details": {
+      "reasoning_tokens": 960
+    },
+    "total_tokens": 1160
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Happy to help. What would you like to work on? A task, a project, learning something new, or making a decision? If you're not sure, here are quick ways to get moving:\n\n- Define a goal: Write one sentence for what you want to achieve and a clear deadline.\n- Brainstorm options: List 3–5 ways to reach that goal, then pick the best one.\n- Plan in small steps: Break the chosen option into 3 concrete actions and start a 25-minute focus session (a short sprint).\n- Check in: After you try, note what went well and what blocked you, then adjust.\n\nIf you share your goal or area (coding, writing, study, health, career, etc.), I’ll tailor a simple, step-by-step plan with your timeline."
+}

--- a/payloads/snapshots/instructionsParam/responses/request.json
+++ b/payloads/snapshots/instructionsParam/responses/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    }
+  ],
+  "instructions": "Reply with OK"
+}

--- a/payloads/snapshots/instructionsParam/responses/response-streaming.json
+++ b/payloads/snapshots/instructionsParam/responses/response-streaming.json
@@ -1,0 +1,269 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0cc244cc140cf9ff006967e2a60ef481a1aa8a57f19532f756",
+      "object": "response",
+      "created_at": 1768415910,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": "Reply with OK",
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0cc244cc140cf9ff006967e2a60ef481a1aa8a57f19532f756",
+      "object": "response",
+      "created_at": 1768415910,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": "Reply with OK",
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0cc244cc140cf9ff006967e2a64cec81a1b9a38fc3f3b54697",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0cc244cc140cf9ff006967e2a64cec81a1b9a38fc3f3b54697",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_0cc244cc140cf9ff006967e2a7732081a1ba28834dec7ad063",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_0cc244cc140cf9ff006967e2a7732081a1ba28834dec7ad063",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "OK",
+    "item_id": "msg_0cc244cc140cf9ff006967e2a7732081a1ba28834dec7ad063",
+    "logprobs": [],
+    "obfuscation": "XkSCXPnfLuITLa",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_0cc244cc140cf9ff006967e2a7732081a1ba28834dec7ad063",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 7,
+    "text": "OK"
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_0cc244cc140cf9ff006967e2a7732081a1ba28834dec7ad063",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "OK"
+    },
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_0cc244cc140cf9ff006967e2a7732081a1ba28834dec7ad063",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "OK"
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0cc244cc140cf9ff006967e2a60ef481a1aa8a57f19532f756",
+      "object": "response",
+      "created_at": 1768415910,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415911,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": "Reply with OK",
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_0cc244cc140cf9ff006967e2a64cec81a1b9a38fc3f3b54697",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_0cc244cc140cf9ff006967e2a7732081a1ba28834dec7ad063",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "OK"
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 14,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 71,
+        "output_tokens_details": {
+          "reasoning_tokens": 64
+        },
+        "total_tokens": 85
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 10
+  }
+]

--- a/payloads/snapshots/instructionsParam/responses/response.json
+++ b/payloads/snapshots/instructionsParam/responses/response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_0ab144e1c69938ee006967e2707c8c819ead46839fd3ba3f32",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415859,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": "Reply with OK",
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0ab144e1c69938ee006967e27277b4819e88de016ef3ff3b31",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0ab144e1c69938ee006967e273c358819e850d14f1808c55a6",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "OK"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 14,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 71,
+    "output_tokens_details": {
+      "reasoning_tokens": 64
+    },
+    "total_tokens": 85
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "OK"
+}

--- a/payloads/snapshots/metadataParam/responses/followup-request.json
+++ b/payloads/snapshots/metadataParam/responses/followup-request.json
@@ -1,0 +1,35 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    },
+    {
+      "id": "rs_058c0bd4ea1763f3006967e27263a0819293bf740ecddd6469",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_058c0bd4ea1763f3006967e277ad488192a5e2704e5759d9c8",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi there! How can I help today? I can explain ideas, help with writing or editing, brainstorm, plan something, or assist with coding and tech questions. \n\nTell me what you’re working on or drop a topic, and I’ll jump in. If you’re not sure, here are a few quick ideas:\n- Explain a concept in simple terms\n- Draft an email or document\n- Brainstorm ideas for a project\n- Debug a snippet of code\n- Plan a trip or itinerary\n\nWhat would you like to do?"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "metadata": {
+    "key": "value"
+  }
+}

--- a/payloads/snapshots/metadataParam/responses/followup-response.json
+++ b/payloads/snapshots/metadataParam/responses/followup-response.json
@@ -1,0 +1,79 @@
+{
+  "id": "resp_058c0bd4ea1763f3006967e2794e48819297f424b18c8a08c3",
+  "object": "response",
+  "created_at": 1768415865,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415879,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_058c0bd4ea1763f3006967e279b1308192912488b72344ba14",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_058c0bd4ea1763f3006967e28455b08192833ec12dff483f6c",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "I can help you pick a concrete next step. Quick options:\n\n- Momentum boost (2 minutes): do a tiny task you’ve been avoiding (reply to one email, tidy a file, etc.). Start now.\n- Quick learning: tell me a topic and I’ll give a simple explain-and-exercise plan.\n- Productivity sprint: pick one task, set a 25-minute Pomodoro, then a 5-minute break.\n- Writing: draft a short email, note, or outline (even 1 paragraph).\n- Coding: choose a tiny feature or bug to fix, with a minimal, testable patch.\n- Planning: outline a 1-page plan for a project/trip/event with 3 milestones.\n- Reflection: 5-minute journal: what’s going well, what to improve, and one small change.\n\nIf you share what you’re working on (work, study, a personal project) I’ll tailor a concrete next action for you. What would you like to focus on?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 132,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1167,
+    "output_tokens_details": {
+      "reasoning_tokens": 960
+    },
+    "total_tokens": 1299
+  },
+  "user": null,
+  "metadata": {
+    "key": "value"
+  },
+  "output_text": "I can help you pick a concrete next step. Quick options:\n\n- Momentum boost (2 minutes): do a tiny task you’ve been avoiding (reply to one email, tidy a file, etc.). Start now.\n- Quick learning: tell me a topic and I’ll give a simple explain-and-exercise plan.\n- Productivity sprint: pick one task, set a 25-minute Pomodoro, then a 5-minute break.\n- Writing: draft a short email, note, or outline (even 1 paragraph).\n- Coding: choose a tiny feature or bug to fix, with a minimal, testable patch.\n- Planning: outline a 1-page plan for a project/trip/event with 3 milestones.\n- Reflection: 5-minute journal: what’s going well, what to improve, and one small change.\n\nIf you share what you’re working on (work, study, a personal project) I’ll tailor a concrete next action for you. What would you like to focus on?"
+}

--- a/payloads/snapshots/metadataParam/responses/request.json
+++ b/payloads/snapshots/metadataParam/responses/request.json
@@ -1,0 +1,12 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    }
+  ],
+  "metadata": {
+    "key": "value"
+  }
+}

--- a/payloads/snapshots/metadataParam/responses/response-streaming.json
+++ b/payloads/snapshots/metadataParam/responses/response-streaming.json
@@ -1,0 +1,1295 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0037234f925e23d2006967e2a5aedc819c90b68ef35f361cbc",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {
+        "key": "value"
+      }
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0037234f925e23d2006967e2a5aedc819c90b68ef35f361cbc",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {
+        "key": "value"
+      }
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0037234f925e23d2006967e2a5e9ac819c8423598e04081f85",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0037234f925e23d2006967e2a5e9ac819c8423598e04081f85",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Hi",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "Z2XChZsWGwL11x",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "!",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "K63PK0Omp8oNare",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " How",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "IOxQ845hApHU",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "5l2R9Y5yEGPN",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "lTXS5Qc1luzRoI",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " help",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "O9yFRgwpIIk",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " today",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "AaZ9sQdhLP",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "?\n\n",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "MhbvKz50wIGpx",
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "A",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "Qfn8fBCG970ws5a",
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " few",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "uR71hI8E4yOF",
+    "output_index": 1,
+    "sequence_number": 15
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " things",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "2ntj9VHam",
+    "output_index": 1,
+    "sequence_number": 16
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "9DVnICOBEAIoTQ",
+    "output_index": 1,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "mHcXHcXmnW15",
+    "output_index": 1,
+    "sequence_number": 18
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " do",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "rmROIMvq9wcGE",
+    "output_index": 1,
+    "sequence_number": 19
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":\n",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "N88rPeQOtkW1h4",
+    "output_index": 1,
+    "sequence_number": 20
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "dxVh33fWlref9uv",
+    "output_index": 1,
+    "sequence_number": 21
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Answer",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "L8D4C1t4W",
+    "output_index": 1,
+    "sequence_number": 22
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " questions",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "6rhFK3",
+    "output_index": 1,
+    "sequence_number": 23
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "9F45dWZSmWAh8",
+    "output_index": 1,
+    "sequence_number": 24
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " explain",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "TTmMdABX",
+    "output_index": 1,
+    "sequence_number": 25
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " concepts",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "G9O0Mi7",
+    "output_index": 1,
+    "sequence_number": 26
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "ZCQAbFMTObOctR4",
+    "output_index": 1,
+    "sequence_number": 27
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "2uh9LSCdClDVEAa",
+    "output_index": 1,
+    "sequence_number": 28
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Help",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "pVmLZtn6414",
+    "output_index": 1,
+    "sequence_number": 29
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " write",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "pECGINRwIr",
+    "output_index": 1,
+    "sequence_number": 30
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "DChrP8MVTxbX4",
+    "output_index": 1,
+    "sequence_number": 31
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " edit",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "WPT3QLgcOHH",
+    "output_index": 1,
+    "sequence_number": 32
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "kR1aa4imnvjrDg",
+    "output_index": 1,
+    "sequence_number": 33
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "emails",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "svdAQUyz12",
+    "output_index": 1,
+    "sequence_number": 34
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "F5UP5FYJbql0eq1",
+    "output_index": 1,
+    "sequence_number": 35
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " essays",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "bNFDcyxuP",
+    "output_index": 1,
+    "sequence_number": 36
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "Zzh8Bowdp9AILwo",
+    "output_index": 1,
+    "sequence_number": 37
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " resumes",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "7ChQJinF",
+    "output_index": 1,
+    "sequence_number": 38
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "6qrb2xS8l0he1al",
+    "output_index": 1,
+    "sequence_number": 39
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " reports",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "0HpsxULf",
+    "output_index": 1,
+    "sequence_number": 40
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ")\n",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "I4EH3YJ2feT109",
+    "output_index": 1,
+    "sequence_number": 41
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "wMJ9xz7Ks9vAJ4O",
+    "output_index": 1,
+    "sequence_number": 42
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Assist",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "5yS0hgMMy",
+    "output_index": 1,
+    "sequence_number": 43
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " with",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "FPamHv2MoMz",
+    "output_index": 1,
+    "sequence_number": 44
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " coding",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "VCwGzk5yE",
+    "output_index": 1,
+    "sequence_number": 45
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "f0oqM4zH20WNAEZ",
+    "output_index": 1,
+    "sequence_number": 46
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " debugging",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "PxpzTP",
+    "output_index": 1,
+    "sequence_number": 47
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "dLUEKTkZGEFQwkw",
+    "output_index": 1,
+    "sequence_number": 48
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "ozyBK9AJuaOXP",
+    "output_index": 1,
+    "sequence_number": 49
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " math",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "sV7IgkKeplX",
+    "output_index": 1,
+    "sequence_number": 50
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " problems",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "cz7Swzi",
+    "output_index": 1,
+    "sequence_number": 51
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "NAZ9CHX1IWtp5A8",
+    "output_index": 1,
+    "sequence_number": 52
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "ztJ7f1VX9xns1zH",
+    "output_index": 1,
+    "sequence_number": 53
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Plan",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "CPe1JAMZDAJ",
+    "output_index": 1,
+    "sequence_number": 54
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "yjB5vS9ctA5Ex",
+    "output_index": 1,
+    "sequence_number": 55
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " brainstorm",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "J9lu6",
+    "output_index": 1,
+    "sequence_number": 56
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "1xRyKmDI39QudX",
+    "output_index": 1,
+    "sequence_number": 57
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "projects",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "KKOmee8i",
+    "output_index": 1,
+    "sequence_number": 58
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "Q0qDkEMTlWZo6Bj",
+    "output_index": 1,
+    "sequence_number": 59
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " trips",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "dULxVZCZsg",
+    "output_index": 1,
+    "sequence_number": 60
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "f0fWiwv3ToJdSoM",
+    "output_index": 1,
+    "sequence_number": 61
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " events",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "HXL6BIoMq",
+    "output_index": 1,
+    "sequence_number": 62
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ")\n",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "wFNnvDrEyG4AnA",
+    "output_index": 1,
+    "sequence_number": 63
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "RSjByDt7Owd4M8s",
+    "output_index": 1,
+    "sequence_number": 64
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Summ",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "3ySCfo41aDr",
+    "output_index": 1,
+    "sequence_number": 65
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "ar",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "uMmsTmtroFwFrF",
+    "output_index": 1,
+    "sequence_number": 66
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "ize",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "oHVU5l7QjlFrA",
+    "output_index": 1,
+    "sequence_number": 67
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " long",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "GvxuU5cNcAB",
+    "output_index": 1,
+    "sequence_number": 68
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " articles",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "CshPoC4",
+    "output_index": 1,
+    "sequence_number": 69
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "4wXRYPIOxgSrLJt",
+    "output_index": 1,
+    "sequence_number": 70
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " compare",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "SIiYjX5z",
+    "output_index": 1,
+    "sequence_number": 71
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " options",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "rFiPkhoK",
+    "output_index": 1,
+    "sequence_number": 72
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "PesrVuVDsIRNPgH",
+    "output_index": 1,
+    "sequence_number": 73
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "LRWqZNc3NP6wB",
+    "output_index": 1,
+    "sequence_number": 74
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " translate",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "vAjJjL",
+    "output_index": 1,
+    "sequence_number": 75
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " text",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "nSk2ZC0H2g3",
+    "output_index": 1,
+    "sequence_number": 76
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "KqUiTJPCB6AYYxz",
+    "output_index": 1,
+    "sequence_number": 77
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "KZlKGEmVO6YqSl1",
+    "output_index": 1,
+    "sequence_number": 78
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Generate",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "i4DFgez",
+    "output_index": 1,
+    "sequence_number": 79
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ideas",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "cwi0m3g0lL",
+    "output_index": 1,
+    "sequence_number": 80
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " for",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "ymOvr3jVrF8A",
+    "output_index": 1,
+    "sequence_number": 81
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " creative",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "MW7T9u2",
+    "output_index": 1,
+    "sequence_number": 82
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " writing",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "4h942qPf",
+    "output_index": 1,
+    "sequence_number": 83
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "vtoir6AFLUuRq",
+    "output_index": 1,
+    "sequence_number": 84
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " other",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "00Tg4DP4sI",
+    "output_index": 1,
+    "sequence_number": 85
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " tasks",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "AcDUkCPnzV",
+    "output_index": 1,
+    "sequence_number": 86
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n\n",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "hoQ8Jdz6k613DL",
+    "output_index": 1,
+    "sequence_number": 87
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Tell",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "HjBdBZcap5bd",
+    "output_index": 1,
+    "sequence_number": 88
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " me",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "igPyhjb2H7Uig",
+    "output_index": 1,
+    "sequence_number": 89
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " what",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "NgwMtQKqoeV",
+    "output_index": 1,
+    "sequence_number": 90
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "GE82G0tEIZYs",
+    "output_index": 1,
+    "sequence_number": 91
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’re",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "D5mZDRtfCylNA",
+    "output_index": 1,
+    "sequence_number": 92
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " working",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "zT6nruWk",
+    "output_index": 1,
+    "sequence_number": 93
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " on",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "P2q4dQoTqVILI",
+    "output_index": 1,
+    "sequence_number": 94
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "lhwHSi4whACXH",
+    "output_index": 1,
+    "sequence_number": 95
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " what",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "PUa18j0UGah",
+    "output_index": 1,
+    "sequence_number": 96
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "LRyJ8kjG7dVa",
+    "output_index": 1,
+    "sequence_number": 97
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’d",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "PI8A9uiv6D0gYu",
+    "output_index": 1,
+    "sequence_number": 98
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " like",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "05wN7ifGldk",
+    "output_index": 1,
+    "sequence_number": 99
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " to",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "xvxzrxWlNtS3N",
+    "output_index": 1,
+    "sequence_number": 100
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " achieve",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "DejAauea",
+    "output_index": 1,
+    "sequence_number": 101
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "aVVdMq4HcAm3boQ",
+    "output_index": 1,
+    "sequence_number": 102
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "ymPXuYZo8D1T",
+    "output_index": 1,
+    "sequence_number": 103
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " any",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "EyaIbhMrmNY2",
+    "output_index": 1,
+    "sequence_number": 104
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " details",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "EMGm2DOF",
+    "output_index": 1,
+    "sequence_number": 105
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "lpo9lD8QMDT04",
+    "output_index": 1,
+    "sequence_number": 106
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " preferences",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "emXJ",
+    "output_index": 1,
+    "sequence_number": 107
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "obfuscation": "xhkWQKVKG3z0ARt",
+    "output_index": 1,
+    "sequence_number": 108
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 109,
+    "text": "Hi! How can I help today?\n\nA few things I can do:\n- Answer questions or explain concepts\n- Help write or edit (emails, essays, resumes, reports)\n- Assist with coding, debugging, or math problems\n- Plan or brainstorm (projects, trips, events)\n- Summarize long articles, compare options, or translate text\n- Generate ideas for creative writing or other tasks\n\nTell me what you’re working on or what you’d like to achieve, and any details or preferences."
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "Hi! How can I help today?\n\nA few things I can do:\n- Answer questions or explain concepts\n- Help write or edit (emails, essays, resumes, reports)\n- Assist with coding, debugging, or math problems\n- Plan or brainstorm (projects, trips, events)\n- Summarize long articles, compare options, or translate text\n- Generate ideas for creative writing or other tasks\n\nTell me what you’re working on or what you’d like to achieve, and any details or preferences."
+    },
+    "sequence_number": 110
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi! How can I help today?\n\nA few things I can do:\n- Answer questions or explain concepts\n- Help write or edit (emails, essays, resumes, reports)\n- Assist with coding, debugging, or math problems\n- Plan or brainstorm (projects, trips, events)\n- Summarize long articles, compare options, or translate text\n- Generate ideas for creative writing or other tasks\n\nTell me what you’re working on or what you’d like to achieve, and any details or preferences."
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 111
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0037234f925e23d2006967e2a5aedc819c90b68ef35f361cbc",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415915,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_0037234f925e23d2006967e2a5e9ac819c8423598e04081f85",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_0037234f925e23d2006967e2aacf8c819c956c611e80168b5e",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "Hi! How can I help today?\n\nA few things I can do:\n- Answer questions or explain concepts\n- Help write or edit (emails, essays, resumes, reports)\n- Assist with coding, debugging, or math problems\n- Plan or brainstorm (projects, trips, events)\n- Summarize long articles, compare options, or translate text\n- Generate ideas for creative writing or other tasks\n\nTell me what you’re working on or what you’d like to achieve, and any details or preferences."
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 7,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 621,
+        "output_tokens_details": {
+          "reasoning_tokens": 512
+        },
+        "total_tokens": 628
+      },
+      "user": null,
+      "metadata": {
+        "key": "value"
+      }
+    },
+    "sequence_number": 112
+  }
+]

--- a/payloads/snapshots/metadataParam/responses/response.json
+++ b/payloads/snapshots/metadataParam/responses/response.json
@@ -1,0 +1,79 @@
+{
+  "id": "resp_058c0bd4ea1763f3006967e27046988192a91531a09b4c2709",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415865,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_058c0bd4ea1763f3006967e27263a0819293bf740ecddd6469",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_058c0bd4ea1763f3006967e277ad488192a5e2704e5759d9c8",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi there! How can I help today? I can explain ideas, help with writing or editing, brainstorm, plan something, or assist with coding and tech questions. \n\nTell me what you’re working on or drop a topic, and I’ll jump in. If you’re not sure, here are a few quick ideas:\n- Explain a concept in simple terms\n- Draft an email or document\n- Brainstorm ideas for a project\n- Debug a snippet of code\n- Plan a trip or itinerary\n\nWhat would you like to do?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 7,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 435,
+    "output_tokens_details": {
+      "reasoning_tokens": 320
+    },
+    "total_tokens": 442
+  },
+  "user": null,
+  "metadata": {
+    "key": "value"
+  },
+  "output_text": "Hi there! How can I help today? I can explain ideas, help with writing or editing, brainstorm, plan something, or assist with coding and tech questions. \n\nTell me what you’re working on or drop a topic, and I’ll jump in. If you’re not sure, here are a few quick ideas:\n- Explain a concept in simple terms\n- Draft an email or document\n- Brainstorm ideas for a project\n- Debug a snippet of code\n- Plan a trip or itinerary\n\nWhat would you like to do?"
+}

--- a/payloads/snapshots/parallelToolCallsDisabledParam/responses/followup-request.json
+++ b/payloads/snapshots/parallelToolCallsDisabledParam/responses/followup-request.json
@@ -1,0 +1,48 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "NYC and LA weather"
+    },
+    {
+      "id": "rs_03615faf8d09f158006967e27286ec8197b119539d5c94e307",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "fc_03615faf8d09f158006967e275a8908197b141e9d9cb52583c",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"location\":\"New York City\"}",
+      "call_id": "call_A8tDE6SdX81Xa2MZgnT75oFC",
+      "name": "get_weather"
+    },
+    {
+      "type": "function_call_output",
+      "call_id": "call_A8tDE6SdX81Xa2MZgnT75oFC",
+      "output": "71 degrees"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "name": "get_weather",
+      "description": "Get weather",
+      "strict": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "location"
+        ],
+        "additionalProperties": false
+      }
+    }
+  ],
+  "parallel_tool_calls": false
+}

--- a/payloads/snapshots/parallelToolCallsDisabledParam/responses/followup-response.json
+++ b/payloads/snapshots/parallelToolCallsDisabledParam/responses/followup-response.json
@@ -1,0 +1,90 @@
+{
+  "id": "resp_03615faf8d09f158006967e27611f08197921380f582c65e90",
+  "object": "response",
+  "created_at": 1768415862,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415862,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_03615faf8d09f158006967e27656508197956e997ceb6e49b1",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "fc_03615faf8d09f158006967e276b3508197a5daa580e708afea",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"location\":\"Los Angeles\"}",
+      "call_id": "call_5k61U7AJ4FYqey6A7hloPOdI",
+      "name": "get_weather"
+    }
+  ],
+  "parallel_tool_calls": false,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "function",
+      "description": "Get weather",
+      "name": "get_weather",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "location"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 308,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 21,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 329
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": ""
+}

--- a/payloads/snapshots/parallelToolCallsDisabledParam/responses/request.json
+++ b/payloads/snapshots/parallelToolCallsDisabledParam/responses/request.json
@@ -1,0 +1,30 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "NYC and LA weather"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "name": "get_weather",
+      "description": "Get weather",
+      "strict": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "location"
+        ],
+        "additionalProperties": false
+      }
+    }
+  ],
+  "parallel_tool_calls": false
+}

--- a/payloads/snapshots/parallelToolCallsDisabledParam/responses/response-streaming.json
+++ b/payloads/snapshots/parallelToolCallsDisabledParam/responses/response-streaming.json
@@ -1,0 +1,333 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0aab5826c3db2e45006967e2a5b7a481949df5116f0bbf0295",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": false,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "function",
+          "description": "Get weather",
+          "name": "get_weather",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "location"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0aab5826c3db2e45006967e2a5b7a481949df5116f0bbf0295",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": false,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "function",
+          "description": "Get weather",
+          "name": "get_weather",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "location"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0aab5826c3db2e45006967e2a604388194ada5a6130c256da3",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0aab5826c3db2e45006967e2a604388194ada5a6130c256da3",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+      "type": "function_call",
+      "status": "in_progress",
+      "arguments": "",
+      "call_id": "call_HDAZXOgVseWCLrm06flg55Pg",
+      "name": "get_weather"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": "{\"",
+    "item_id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+    "obfuscation": "bkpnmePO0RHOSI",
+    "output_index": 1,
+    "sequence_number": 5
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": "location",
+    "item_id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+    "obfuscation": "w4t4uygX",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": "\":\"",
+    "item_id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+    "obfuscation": "n7NkKSK2cSnNr",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": "New",
+    "item_id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+    "obfuscation": "cPAMRLycfyMYQ",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": " York",
+    "item_id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+    "obfuscation": "P46LuXechi9",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": " City",
+    "item_id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+    "obfuscation": "UT8z5Vn5EL6",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": "\"}",
+    "item_id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+    "obfuscation": "U1OsJ7fLubR2R1",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.function_call_arguments.done",
+    "arguments": "{\"location\":\"New York City\"}",
+    "item_id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"location\":\"New York City\"}",
+      "call_id": "call_HDAZXOgVseWCLrm06flg55Pg",
+      "name": "get_weather"
+    },
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0aab5826c3db2e45006967e2a5b7a481949df5116f0bbf0295",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415912,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_0aab5826c3db2e45006967e2a604388194ada5a6130c256da3",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "fc_0aab5826c3db2e45006967e2a88c1081948c6063241d81a271",
+          "type": "function_call",
+          "status": "completed",
+          "arguments": "{\"location\":\"New York City\"}",
+          "call_id": "call_HDAZXOgVseWCLrm06flg55Pg",
+          "name": "get_weather"
+        }
+      ],
+      "parallel_tool_calls": false,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "function",
+          "description": "Get weather",
+          "name": "get_weather",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "location"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 122,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 214,
+        "output_tokens_details": {
+          "reasoning_tokens": 192
+        },
+        "total_tokens": 336
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 14
+  }
+]

--- a/payloads/snapshots/parallelToolCallsDisabledParam/responses/response.json
+++ b/payloads/snapshots/parallelToolCallsDisabledParam/responses/response.json
@@ -1,0 +1,90 @@
+{
+  "id": "resp_03615faf8d09f158006967e2704fcc819791df08f2cfeaf1b4",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415861,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_03615faf8d09f158006967e27286ec8197b119539d5c94e307",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "fc_03615faf8d09f158006967e275a8908197b141e9d9cb52583c",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"location\":\"New York City\"}",
+      "call_id": "call_A8tDE6SdX81Xa2MZgnT75oFC",
+      "name": "get_weather"
+    }
+  ],
+  "parallel_tool_calls": false,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "function",
+      "description": "Get weather",
+      "name": "get_weather",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "location"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 122,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 150,
+    "output_tokens_details": {
+      "reasoning_tokens": 128
+    },
+    "total_tokens": 272
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": ""
+}

--- a/payloads/snapshots/promptCacheKeyParam/responses/followup-request.json
+++ b/payloads/snapshots/promptCacheKeyParam/responses/followup-request.json
@@ -1,0 +1,33 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    },
+    {
+      "id": "rs_0e19df7168186fd3006967e270e93481a3918d4e3669b9044a",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0e19df7168186fd3006967e274421c81a3abfb1238d8f9ca7a",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi! How can I help today? I can answer questions, explain concepts, assist with writing or editing, help with math or coding, brainstorm ideas, plan things, and more.\n\nIf you’d like, tell me what you’re working on or ask a question. Quick examples:\n- Explain photosynthesis in simple terms\n- Draft an email to a coworker\n- Help debug a Python function\n- Brainstorm ideas for a short story\n- Plan a trip itinerary\n\nIf you have an image, you can upload it and I can describe or analyze it. What would you like to do?"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "prompt_cache_key": "test-key"
+}

--- a/payloads/snapshots/promptCacheKeyParam/responses/followup-response.json
+++ b/payloads/snapshots/promptCacheKeyParam/responses/followup-response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_0e19df7168186fd3006967e27583d481a39f4bb05f8b350c9a",
+  "object": "response",
+  "created_at": 1768415861,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415876,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0e19df7168186fd3006967e275c91881a38cff7a7b558fa07f",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0e19df7168186fd3006967e2817de881a38c84a673c274b08a",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Happy to help. To tailor the next step, tell me a bit about what you’re trying to achieve (goal, deadline, and any constraints). If you’d prefer quick options right now, here are three practical paths you can start with:\n\n- Path 1: Quick micro-action (best for momentum)\n  - Pick one concrete thing you can do in the next 15 minutes that moves you toward your goal.\n  - Do it now, then tell me what you accomplished.\n\n- Path 2: Planning sprint (best for moving from idea to plan)\n  - Write down your goal in one sentence.\n  - List 3 small next steps that would each take 30–60 minutes.\n  - Block time for one of those steps soon and plan a quick check-in to review progress.\n\n- Path 3: Decision-making (best for choosing among options)\n  - List your options and 3 criteria that matter (e.g., impact, effort, risk).\n  - Give each option a simple score for each criterion, total them, and pick the top choice.\n\nIf you want, tell me your goal and any deadline, and I’ll propose a concrete, step-by-step plan. I can also help draft/edit, debug code, brainstorm ideas, or analyze an image if you have one."
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": "test-key",
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 144,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1549,
+    "output_tokens_details": {
+      "reasoning_tokens": 1280
+    },
+    "total_tokens": 1693
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Happy to help. To tailor the next step, tell me a bit about what you’re trying to achieve (goal, deadline, and any constraints). If you’d prefer quick options right now, here are three practical paths you can start with:\n\n- Path 1: Quick micro-action (best for momentum)\n  - Pick one concrete thing you can do in the next 15 minutes that moves you toward your goal.\n  - Do it now, then tell me what you accomplished.\n\n- Path 2: Planning sprint (best for moving from idea to plan)\n  - Write down your goal in one sentence.\n  - List 3 small next steps that would each take 30–60 minutes.\n  - Block time for one of those steps soon and plan a quick check-in to review progress.\n\n- Path 3: Decision-making (best for choosing among options)\n  - List your options and 3 criteria that matter (e.g., impact, effort, risk).\n  - Give each option a simple score for each criterion, total them, and pick the top choice.\n\nIf you want, tell me your goal and any deadline, and I’ll propose a concrete, step-by-step plan. I can also help draft/edit, debug code, brainstorm ideas, or analyze an image if you have one."
+}

--- a/payloads/snapshots/promptCacheKeyParam/responses/request.json
+++ b/payloads/snapshots/promptCacheKeyParam/responses/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    }
+  ],
+  "prompt_cache_key": "test-key"
+}

--- a/payloads/snapshots/promptCacheKeyParam/responses/response-streaming.json
+++ b/payloads/snapshots/promptCacheKeyParam/responses/response-streaming.json
@@ -1,0 +1,739 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0aa87d5ace8108ed006967e2a63d788191865c1df4f9d44189",
+      "object": "response",
+      "created_at": 1768415910,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": "test-key",
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0aa87d5ace8108ed006967e2a63d788191865c1df4f9d44189",
+      "object": "response",
+      "created_at": 1768415910,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": "test-key",
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0aa87d5ace8108ed006967e2a6887c8191a6e1b3c256be8e85",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0aa87d5ace8108ed006967e2a6887c8191a6e1b3c256be8e85",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Hi",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "j6u5Np4wvn1eIY",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " there",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "FT9v9WEyK6",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "!",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "YcEsKHmYGjyNRRx",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " How",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "FxR6YslH1aPH",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "8AZB6IWKZyRx",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "zZslZW82TM7Ofh",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " help",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "NkHtruDV7Jo",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " today",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "VyMz1cKcpp",
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "?",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "seqc4RXfA8kq8AI",
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "n34bFJOiLiZpBB",
+    "output_index": 1,
+    "sequence_number": 15
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "z3FbPmSFi5rt",
+    "output_index": 1,
+    "sequence_number": 16
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " explain",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "kZWlw3Fq",
+    "output_index": 1,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " concepts",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "h3j0rHO",
+    "output_index": 1,
+    "sequence_number": 18
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "Fl9MELv7YqgsqsP",
+    "output_index": 1,
+    "sequence_number": 19
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " help",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "cPzcSIJt84t",
+    "output_index": 1,
+    "sequence_number": 20
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " with",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "djC2cczR032",
+    "output_index": 1,
+    "sequence_number": 21
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " writing",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "mz00sJZA",
+    "output_index": 1,
+    "sequence_number": 22
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "PCUmQVGTghi6i",
+    "output_index": 1,
+    "sequence_number": 23
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " editing",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "sfgShHN6",
+    "output_index": 1,
+    "sequence_number": 24
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "4EnQ03638xUWaiJ",
+    "output_index": 1,
+    "sequence_number": 25
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " brainstorm",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "zk790",
+    "output_index": 1,
+    "sequence_number": 26
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ideas",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "HqrqIQOBXc",
+    "output_index": 1,
+    "sequence_number": 27
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "VmVMii1IZv3yxLi",
+    "output_index": 1,
+    "sequence_number": 28
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " solve",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "LOjRPGoqYG",
+    "output_index": 1,
+    "sequence_number": 29
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " problems",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "THBOf5a",
+    "output_index": 1,
+    "sequence_number": 30
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "YcM1FdV5wm9Fl9U",
+    "output_index": 1,
+    "sequence_number": 31
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "FH4HdsUQIQ72D",
+    "output_index": 1,
+    "sequence_number": 32
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " analyze",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "KciQVtUE",
+    "output_index": 1,
+    "sequence_number": 33
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " images",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "Ozbp4H8NV",
+    "output_index": 1,
+    "sequence_number": 34
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "vvHL9OSwSK2UugY",
+    "output_index": 1,
+    "sequence_number": 35
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Tell",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "YAesDjQTHFh",
+    "output_index": 1,
+    "sequence_number": 36
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " me",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "DJySMgxsBEDeR",
+    "output_index": 1,
+    "sequence_number": 37
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " what",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "k3PDvF2mwf0",
+    "output_index": 1,
+    "sequence_number": 38
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "URFw3MFcAkAA",
+    "output_index": 1,
+    "sequence_number": 39
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’re",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "NOXNgfqoYsuKu",
+    "output_index": 1,
+    "sequence_number": 40
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " working",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "xheXiOre",
+    "output_index": 1,
+    "sequence_number": 41
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " on",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "qRYATvHlFm2Nw",
+    "output_index": 1,
+    "sequence_number": 42
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "BHTDbk9JQHola",
+    "output_index": 1,
+    "sequence_number": 43
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ask",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "B7ggz4S32qXD",
+    "output_index": 1,
+    "sequence_number": 44
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "LVWbvtBW515QA5",
+    "output_index": 1,
+    "sequence_number": 45
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " question",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "AGOIypk",
+    "output_index": 1,
+    "sequence_number": 46
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "Jg3bomQ6F042enX",
+    "output_index": 1,
+    "sequence_number": 47
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "We4FVSSCWsgE",
+    "output_index": 1,
+    "sequence_number": 48
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "GpJkg5JSduHtSN",
+    "output_index": 1,
+    "sequence_number": 49
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’ll",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "oTnuJzEyj1xZ7",
+    "output_index": 1,
+    "sequence_number": 50
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " dive",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "FfSyspp6Nuz",
+    "output_index": 1,
+    "sequence_number": 51
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " in",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "IeNWkYZ5UzKtl",
+    "output_index": 1,
+    "sequence_number": 52
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "obfuscation": "vkUAVjfC38ium3j",
+    "output_index": 1,
+    "sequence_number": 53
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 54,
+    "text": "Hi there! How can I help today? I can explain concepts, help with writing or editing, brainstorm ideas, solve problems, or analyze images. Tell me what you’re working on or ask a question, and I’ll dive in."
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "Hi there! How can I help today? I can explain concepts, help with writing or editing, brainstorm ideas, solve problems, or analyze images. Tell me what you’re working on or ask a question, and I’ll dive in."
+    },
+    "sequence_number": 55
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi there! How can I help today? I can explain concepts, help with writing or editing, brainstorm ideas, solve problems, or analyze images. Tell me what you’re working on or ask a question, and I’ll dive in."
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 56
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0aa87d5ace8108ed006967e2a63d788191865c1df4f9d44189",
+      "object": "response",
+      "created_at": 1768415910,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415914,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_0aa87d5ace8108ed006967e2a6887c8191a6e1b3c256be8e85",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_0aa87d5ace8108ed006967e2aa05388191b3baf747ef2026a2",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "Hi there! How can I help today? I can explain concepts, help with writing or editing, brainstorm ideas, solve problems, or analyze images. Tell me what you’re working on or ask a question, and I’ll dive in."
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": "test-key",
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 7,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 374,
+        "output_tokens_details": {
+          "reasoning_tokens": 320
+        },
+        "total_tokens": 381
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 57
+  }
+]

--- a/payloads/snapshots/promptCacheKeyParam/responses/response.json
+++ b/payloads/snapshots/promptCacheKeyParam/responses/response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_0e19df7168186fd3006967e270710c81a3a83a6933c2788d19",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415861,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0e19df7168186fd3006967e270e93481a3918d4e3669b9044a",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0e19df7168186fd3006967e274421c81a3abfb1238d8f9ca7a",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi! How can I help today? I can answer questions, explain concepts, assist with writing or editing, help with math or coding, brainstorm ideas, plan things, and more.\n\nIf you’d like, tell me what you’re working on or ask a question. Quick examples:\n- Explain photosynthesis in simple terms\n- Draft an email to a coworker\n- Help debug a Python function\n- Brainstorm ideas for a short story\n- Plan a trip itinerary\n\nIf you have an image, you can upload it and I can describe or analyze it. What would you like to do?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": "test-key",
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 7,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 511,
+    "output_tokens_details": {
+      "reasoning_tokens": 384
+    },
+    "total_tokens": 518
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Hi! How can I help today? I can answer questions, explain concepts, assist with writing or editing, help with math or coding, brainstorm ideas, plan things, and more.\n\nIf you’d like, tell me what you’re working on or ask a question. Quick examples:\n- Explain photosynthesis in simple terms\n- Draft an email to a coworker\n- Help debug a Python function\n- Brainstorm ideas for a short story\n- Plan a trip itinerary\n\nIf you have an image, you can upload it and I can describe or analyze it. What would you like to do?"
+}

--- a/payloads/snapshots/reasoningSummaryParam/responses/followup-request.json
+++ b/payloads/snapshots/reasoningSummaryParam/responses/followup-request.json
@@ -1,0 +1,36 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "2+2"
+    },
+    {
+      "id": "rs_00b90c1886cbcba7006967e272d2cc819085ea07d7b4800005",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_00b90c1886cbcba7006967e2746e8c819080d22a72d9cab2cb",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "4"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "reasoning": {
+    "effort": "medium",
+    "summary": "detailed"
+  }
+}

--- a/payloads/snapshots/reasoningSummaryParam/responses/followup-response.json
+++ b/payloads/snapshots/reasoningSummaryParam/responses/followup-response.json
@@ -1,0 +1,98 @@
+{
+  "id": "resp_00b90c1886cbcba7006967e2750a2c8190aacafa3feede1dcf",
+  "object": "response",
+  "created_at": 1768415861,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415887,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_00b90c1886cbcba7006967e27555988190a773742994989e98",
+      "type": "reasoning",
+      "summary": [
+        {
+          "type": "summary_text",
+          "text": "**Proposing next steps in learning**\n\nI’m thinking about how to help the user progress in their learning. Options could include solving more arithmetic problems, tackling word problems, or exploring concepts. If they want to stick to arithmetic, I could suggest a few simple problems like 7+5, 9-4, or 12*3. However, I realize it might be better to structure their learning, starting with addition and moving to multiplication or fractions.\n\nSince the initial question about 2+2 was straightforward, I wonder if they’re just testing my ability to suggest next steps. I'll ask them, \"What would you like to do next?\""
+        },
+        {
+          "type": "summary_text",
+          "text": "**Suggesting learning options**\n\nI've come up with several options to help the user progress in their math practice. For more math practice, I could suggest quick arithmetic problems or introduce increasing difficulties like fractions, decimals, or percentages. \n\nI could offer a mini-plan with various options: \n\nOption A for quick math warm-up, like 7+6 or 9×3; \n\nOption B for concept learning, such as order of operations; \n\nOption C for brain teasers or riddles; \n\nOption D for any other study topics they might have; \n\nOption E for Python code snippets; \n\nand Option F for engaging in conversation or creative writing. I just need to keep it concise and helpful!"
+        },
+        {
+          "type": "summary_text",
+          "text": "**Providing next steps and a challenge**\n\nI'm thinking about how to help the user decide what to do next, so I’ll start by asking a clarifying question like, \"Do you want more math practice or something else?\" Then, I could propose a few options. \n\nI could even offer a mini-challenge like a 5-question rapid-fire arithmetic test and set a time limit if they’d like. For instance, I could provide quick problems:\n\n1) 7 + 5 \n2) 14 - 9 \n3) 6 × 7 \n4) 144 ÷ 12 \n5) 3/4 + 1/6 \n\nBut I’ll avoid solving them; they can answer them at their own pace!"
+        },
+        {
+          "type": "summary_text",
+          "text": "**Creating a learning plan**\n\nI’m considering a structured approach to guide the user on what to do next. First, I’ll confirm their goal. If they're looking for math practice, I could give direct suggestions. \n\nFor example, I’d ask, \"Would you like a quick puzzle, a small math quiz, or to learn a concept?\" Then, I could present choices like:\n\n- Quick mental math warm-up (5 problems, no calculator)\n- Learn a math concept, such as order of operations\n- Solve a word problem\n- Play a game or riddle\n- Code something simple, like a script to compute numbers\n\nI'll round it off with, \"Nice job with 4. What would you like to do next?\""
+        },
+        {
+          "type": "summary_text",
+          "text": "**Offering choices for next steps**\n\nI'm excited to help the user decide what to do next! I'll start with a friendly tone and offer a few clear options:\n\n1) Quick math practice: I'll provide 5 mental math problems, and I can check their answers.\n2) Learn a concept: We could cover the order of operations (PEMDAS) with examples.\n3) Solve a word problem or brain teaser: This can be a fun challenge too!\n\nI’ll say, \"Great question. What would you like next? Here are some options.\" Then, I can invite them to pick one or tell me a topic they want to focus on!"
+        }
+      ]
+    },
+    {
+      "id": "msg_00b90c1886cbcba7006967e28facd481908f538be7d77151ab",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Nice work getting to 4. What would you like to do next? Here are a few easy options:\n\n- Quick math practice (5 problems): I’ll give you problems and check your answers.\n- Learn a concept: quick mini-lesson (e.g., order of operations PEMDAS, fractions, decimals).\n- Short brain teaser or riddle.\n- Start a tiny coding/math task (e.g., write a small script to add numbers).\n- Tell me a topic or goal and I tailor a mini plan.\n\nIf you want, I can start with a 5-question arithmetic quiz right away. Which option do you prefer?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": "detailed"
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 26,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1542,
+    "output_tokens_details": {
+      "reasoning_tokens": 1408
+    },
+    "total_tokens": 1568
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Nice work getting to 4. What would you like to do next? Here are a few easy options:\n\n- Quick math practice (5 problems): I’ll give you problems and check your answers.\n- Learn a concept: quick mini-lesson (e.g., order of operations PEMDAS, fractions, decimals).\n- Short brain teaser or riddle.\n- Start a tiny coding/math task (e.g., write a small script to add numbers).\n- Tell me a topic or goal and I tailor a mini plan.\n\nIf you want, I can start with a 5-question arithmetic quiz right away. Which option do you prefer?"
+}

--- a/payloads/snapshots/reasoningSummaryParam/responses/request.json
+++ b/payloads/snapshots/reasoningSummaryParam/responses/request.json
@@ -1,0 +1,13 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "2+2"
+    }
+  ],
+  "reasoning": {
+    "effort": "medium",
+    "summary": "detailed"
+  }
+}

--- a/payloads/snapshots/reasoningSummaryParam/responses/response-streaming.json
+++ b/payloads/snapshots/reasoningSummaryParam/responses/response-streaming.json
@@ -1,0 +1,1155 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_03d097e4e669f33b006967e2a5b220819484132cf2a5fe8241",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": "detailed"
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_03d097e4e669f33b006967e2a5b220819484132cf2a5fe8241",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": "detailed"
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.reasoning_summary_part.added",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "output_index": 0,
+    "part": {
+      "type": "summary_text",
+      "text": ""
+    },
+    "sequence_number": 3,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "**Calcul",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "YFvpIeUs",
+    "output_index": 0,
+    "sequence_number": 4,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "ating",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "05sg5ExiKfN",
+    "output_index": 0,
+    "sequence_number": 5,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " simple",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "wjptGxT4M",
+    "output_index": 0,
+    "sequence_number": 6,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " arithmetic",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "eZ6RI",
+    "output_index": 0,
+    "sequence_number": 7,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "**\n\nI",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "MufMfPjmFaQ",
+    "output_index": 0,
+    "sequence_number": 8,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " need",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "MzJUOOJ1l7u",
+    "output_index": 0,
+    "sequence_number": 9,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " to",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "T2rd58rYP88Hu",
+    "output_index": 0,
+    "sequence_number": 10,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " respond",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "o3jfZNeK",
+    "output_index": 0,
+    "sequence_number": 11,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " to",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "mripu1VvRE334",
+    "output_index": 0,
+    "sequence_number": 12,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " the",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "KQjuoH8b7XFC",
+    "output_index": 0,
+    "sequence_number": 13,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " user's",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "4sdTGE2Xf",
+    "output_index": 0,
+    "sequence_number": 14,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " query",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "3AjGUA5X6p",
+    "output_index": 0,
+    "sequence_number": 15,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ",",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "mRZ8gt30yNJCQMJ",
+    "output_index": 0,
+    "sequence_number": 16,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " \"",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "ZmxteX7dwRlc5w",
+    "output_index": 0,
+    "sequence_number": 17,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "2",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "e03wbF8zvNWjB9W",
+    "output_index": 0,
+    "sequence_number": 18,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "+",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "m5oPckOCxZvdiIu",
+    "output_index": 0,
+    "sequence_number": 19,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "2",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "gLafbYTuhVG80Hx",
+    "output_index": 0,
+    "sequence_number": 20,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ",\"",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "8ftc0p5Bx4sUFQ",
+    "output_index": 0,
+    "sequence_number": 21,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " which",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "zDXYJsQ3ws",
+    "output_index": 0,
+    "sequence_number": 22,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " is",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "LOZoarJAIncFf",
+    "output_index": 0,
+    "sequence_number": 23,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " straightforward",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "",
+    "output_index": 0,
+    "sequence_number": 24,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " arithmetic",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "UDzTD",
+    "output_index": 0,
+    "sequence_number": 25,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ".",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "7qCm5lhipV1y8Dv",
+    "output_index": 0,
+    "sequence_number": 26,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " The",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "b2Mmu7tuKSf8",
+    "output_index": 0,
+    "sequence_number": 27,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " answer",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "K3jOAVGFk",
+    "output_index": 0,
+    "sequence_number": 28,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " is",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "kzYCs6395YMSF",
+    "output_index": 0,
+    "sequence_number": 29,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " 4",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "4gsG9XqNihUG7H",
+    "output_index": 0,
+    "sequence_number": 30,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ",",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "9skDikXwTWlma9n",
+    "output_index": 0,
+    "sequence_number": 31,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " and",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "4nXH5ZQhqCR1",
+    "output_index": 0,
+    "sequence_number": 32,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " I",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "TmU6IWt29fAJSf",
+    "output_index": 0,
+    "sequence_number": 33,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " should",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "CiOMBXlvu",
+    "output_index": 0,
+    "sequence_number": 34,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " confirm",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "k6FcwteR",
+    "output_index": 0,
+    "sequence_number": 35,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " that",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "oewXr2LN4a0",
+    "output_index": 0,
+    "sequence_number": 36,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " conc",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "P9viOWLfRdv",
+    "output_index": 0,
+    "sequence_number": 37,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "is",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "FU9PcQfGYhrIxw",
+    "output_index": 0,
+    "sequence_number": 38,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "ely",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "KCh0OFOA5Vdty",
+    "output_index": 0,
+    "sequence_number": 39,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ".",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "piDVzW41JO4p6uE",
+    "output_index": 0,
+    "sequence_number": 40,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " I",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "mBlhgh8JFalVDW",
+    "output_index": 0,
+    "sequence_number": 41,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " could",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "v8ss82shxl",
+    "output_index": 0,
+    "sequence_number": 42,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " show",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "u3WcXRkE1lD",
+    "output_index": 0,
+    "sequence_number": 43,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " a",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "YSETA8w3bgz5vq",
+    "output_index": 0,
+    "sequence_number": 44,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " brief",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "Xc3usKc9du",
+    "output_index": 0,
+    "sequence_number": 45,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " calculation",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "wH2a",
+    "output_index": 0,
+    "sequence_number": 46,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " like",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "0rBSXm1uaGc",
+    "output_index": 0,
+    "sequence_number": 47,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " \"",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "eMvsRcijZkykUz",
+    "output_index": 0,
+    "sequence_number": 48,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "2",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "zrthnIl2pv9wz6t",
+    "output_index": 0,
+    "sequence_number": 49,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " +",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "b8s1piL7WJrUNF",
+    "output_index": 0,
+    "sequence_number": 50,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " 2",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "k5nktbA97hGYPY",
+    "output_index": 0,
+    "sequence_number": 51,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " =",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "ouYtL9V8aPfxn2",
+    "output_index": 0,
+    "sequence_number": 52,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " 4",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "Ebi07K0epNZ8lq",
+    "output_index": 0,
+    "sequence_number": 53,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ",\"",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "2ViM5Nzh9TaYxi",
+    "output_index": 0,
+    "sequence_number": 54,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " but",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "En5g6C1fesKJ",
+    "output_index": 0,
+    "sequence_number": 55,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " since",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "as3eHGQzd6",
+    "output_index": 0,
+    "sequence_number": 56,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " the",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "fXSslQfI8MLF",
+    "output_index": 0,
+    "sequence_number": 57,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " user",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "5zos1CKV3Px",
+    "output_index": 0,
+    "sequence_number": 58,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " just",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "lNinYQOk4zv",
+    "output_index": 0,
+    "sequence_number": 59,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " asked",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "WnAcyOZxBt",
+    "output_index": 0,
+    "sequence_number": 60,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " for",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "YIzwXmg0Zt63",
+    "output_index": 0,
+    "sequence_number": 61,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " the",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "SWL0XBrXssPk",
+    "output_index": 0,
+    "sequence_number": 62,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " answer",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "MEaYXlW0a",
+    "output_index": 0,
+    "sequence_number": 63,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ",",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "yo27dPZuuU0ewp1",
+    "output_index": 0,
+    "sequence_number": 64,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " a",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "rxZYmoM2Kmlbeu",
+    "output_index": 0,
+    "sequence_number": 65,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " simple",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "BFMnvlaWY",
+    "output_index": 0,
+    "sequence_number": 66,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " \"",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "nhKNRpsVBk2zQp",
+    "output_index": 0,
+    "sequence_number": 67,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "4",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "NyHApQ6Sr11Hzen",
+    "output_index": 0,
+    "sequence_number": 68,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "\"",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "cSgXu13AXBRCgA0",
+    "output_index": 0,
+    "sequence_number": 69,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " will",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "Z037iKmNKsz",
+    "output_index": 0,
+    "sequence_number": 70,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " suffice",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "TzksVSz3",
+    "output_index": 0,
+    "sequence_number": 71,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ".",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "yeCeoZ8LcMQuzn6",
+    "output_index": 0,
+    "sequence_number": 72,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " I",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "FzePDcr8NSHC6H",
+    "output_index": 0,
+    "sequence_number": 73,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " must",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "wSUdlcPts2U",
+    "output_index": 0,
+    "sequence_number": 74,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " keep",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "lbNHk19AyRK",
+    "output_index": 0,
+    "sequence_number": 75,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " it",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "lkW0h9eLZxFbS",
+    "output_index": 0,
+    "sequence_number": 76,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " minimal",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "cd0BMIyy",
+    "output_index": 0,
+    "sequence_number": 77,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " and",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "5eMEbSGker3B",
+    "output_index": 0,
+    "sequence_number": 78,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " clear",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "6yOuooATkG",
+    "output_index": 0,
+    "sequence_number": 79,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ",",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "NhU5mjjFPT3Xcbt",
+    "output_index": 0,
+    "sequence_number": 80,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " avoiding",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "BXFQnR2",
+    "output_index": 0,
+    "sequence_number": 81,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " unnecessary",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "WVMl",
+    "output_index": 0,
+    "sequence_number": 82,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " details",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "7900eYUi",
+    "output_index": 0,
+    "sequence_number": 83,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ".",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "sAIBqbKRNNdAzpd",
+    "output_index": 0,
+    "sequence_number": 84,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " So",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "eHJQRkwHtKslU",
+    "output_index": 0,
+    "sequence_number": 85,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ",",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "87TQxSiPJX09ND5",
+    "output_index": 0,
+    "sequence_number": 86,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " I'll",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "YEZR3rt0c1o",
+    "output_index": 0,
+    "sequence_number": 87,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " go",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "tTlGiDkj8zo9R",
+    "output_index": 0,
+    "sequence_number": 88,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " with",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "o7YbWF59y0J",
+    "output_index": 0,
+    "sequence_number": 89,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " \"",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "DE8siNR2h8lZFF",
+    "output_index": 0,
+    "sequence_number": 90,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "4",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "ToNFHWQkMI99eVm",
+    "output_index": 0,
+    "sequence_number": 91,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": "\"",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "N8gCzMNK76YskN5",
+    "output_index": 0,
+    "sequence_number": 92,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " for",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "rQBFrra4HRw8",
+    "output_index": 0,
+    "sequence_number": 93,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " my",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "UosFETUAgcM7L",
+    "output_index": 0,
+    "sequence_number": 94,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " final",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "ieSvTqUifL",
+    "output_index": 0,
+    "sequence_number": 95,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": " response",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "GhraxIH",
+    "output_index": 0,
+    "sequence_number": 96,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.delta",
+    "delta": ".",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "obfuscation": "qMlvvQGML9F6YVC",
+    "output_index": 0,
+    "sequence_number": 97,
+    "summary_index": 0
+  },
+  {
+    "type": "response.reasoning_summary_text.done",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "output_index": 0,
+    "sequence_number": 98,
+    "summary_index": 0,
+    "text": "**Calculating simple arithmetic**\n\nI need to respond to the user's query, \"2+2,\" which is straightforward arithmetic. The answer is 4, and I should confirm that concisely. I could show a brief calculation like \"2 + 2 = 4,\" but since the user just asked for the answer, a simple \"4\" will suffice. I must keep it minimal and clear, avoiding unnecessary details. So, I'll go with \"4\" for my final response."
+  },
+  {
+    "type": "response.reasoning_summary_part.done",
+    "item_id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+    "output_index": 0,
+    "part": {
+      "type": "summary_text",
+      "text": "**Calculating simple arithmetic**\n\nI need to respond to the user's query, \"2+2,\" which is straightforward arithmetic. The answer is 4, and I should confirm that concisely. I could show a brief calculation like \"2 + 2 = 4,\" but since the user just asked for the answer, a simple \"4\" will suffice. I must keep it minimal and clear, avoiding unnecessary details. So, I'll go with \"4\" for my final response."
+    },
+    "sequence_number": 99,
+    "summary_index": 0
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+      "type": "reasoning",
+      "summary": [
+        {
+          "type": "summary_text",
+          "text": "**Calculating simple arithmetic**\n\nI need to respond to the user's query, \"2+2,\" which is straightforward arithmetic. The answer is 4, and I should confirm that concisely. I could show a brief calculation like \"2 + 2 = 4,\" but since the user just asked for the answer, a simple \"4\" will suffice. I must keep it minimal and clear, avoiding unnecessary details. So, I'll go with \"4\" for my final response."
+        }
+      ]
+    },
+    "output_index": 0,
+    "sequence_number": 100
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_03d097e4e669f33b006967e2ab051c81948ba3d480520ffbfb",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 101
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_03d097e4e669f33b006967e2ab051c81948ba3d480520ffbfb",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 102
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "4",
+    "item_id": "msg_03d097e4e669f33b006967e2ab051c81948ba3d480520ffbfb",
+    "logprobs": [],
+    "obfuscation": "OB5lDmPShOed6z4",
+    "output_index": 1,
+    "sequence_number": 103
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_03d097e4e669f33b006967e2ab051c81948ba3d480520ffbfb",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 104,
+    "text": "4"
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_03d097e4e669f33b006967e2ab051c81948ba3d480520ffbfb",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "4"
+    },
+    "sequence_number": 105
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_03d097e4e669f33b006967e2ab051c81948ba3d480520ffbfb",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "4"
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 106
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_03d097e4e669f33b006967e2a5b220819484132cf2a5fe8241",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415915,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_03d097e4e669f33b006967e2a603a48194b24b792fba121e54",
+          "type": "reasoning",
+          "summary": [
+            {
+              "type": "summary_text",
+              "text": "**Calculating simple arithmetic**\n\nI need to respond to the user's query, \"2+2,\" which is straightforward arithmetic. The answer is 4, and I should confirm that concisely. I could show a brief calculation like \"2 + 2 = 4,\" but since the user just asked for the answer, a simple \"4\" will suffice. I must keep it minimal and clear, avoiding unnecessary details. So, I'll go with \"4\" for my final response."
+            }
+          ]
+        },
+        {
+          "id": "msg_03d097e4e669f33b006967e2ab051c81948ba3d480520ffbfb",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "4"
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": "detailed"
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 9,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 199,
+        "output_tokens_details": {
+          "reasoning_tokens": 192
+        },
+        "total_tokens": 208
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 107
+  }
+]

--- a/payloads/snapshots/reasoningSummaryParam/responses/response.json
+++ b/payloads/snapshots/reasoningSummaryParam/responses/response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_00b90c1886cbcba7006967e2706c8881908ad43d147a836d38",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415860,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_00b90c1886cbcba7006967e272d2cc819085ea07d7b4800005",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_00b90c1886cbcba7006967e2746e8c819080d22a72d9cab2cb",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "4"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": "detailed"
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 9,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 71,
+    "output_tokens_details": {
+      "reasoning_tokens": 64
+    },
+    "total_tokens": 80
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "4"
+}

--- a/payloads/snapshots/safetyIdentifierParam/responses/followup-request.json
+++ b/payloads/snapshots/safetyIdentifierParam/responses/followup-request.json
@@ -1,0 +1,33 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    },
+    {
+      "id": "rs_0ed226998f748acc006967e272539881a1828ec73bf40fe48d",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0ed226998f748acc006967e279616881a1a563255f26b92361",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi! How can I help today? I can assist with:\n\n- Answering questions or explaining topics\n- Writing, editing, or brainstorming\n- Coding help and debugging\n- Math and problem solving\n- Planning, study tips, summaries\n- Translating or explaining texts\n- Generating ideas for projects, stories, resumes\n\nIf you have a specific task, tell me the details or paste the text, and I’ll jump in. What would you like to do?"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "safety_identifier": "test-user"
+}

--- a/payloads/snapshots/safetyIdentifierParam/responses/followup-response.json
+++ b/payloads/snapshots/safetyIdentifierParam/responses/followup-response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_0ed226998f748acc006967e27b254c81a1bce84273c2038439",
+  "object": "response",
+  "created_at": 1768415867,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415884,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0ed226998f748acc006967e27b715881a19d41381a2677bb81",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0ed226998f748acc006967e28a2c4881a18f68d39533255799",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Sure—happy to help. What are you aiming to do today? If you’re not sure, here are a few quick options you can pick from, and I’ll tailor the next steps:\n\n1) Quick productivity sprint (about 25 minutes)\n- We pick 1–3 tasks, estimate time, set a timer, and I’ll help you review progress after.\n\n2) 15-minute learning bite\n- Choose a topic, I’ll give a concise mini-lesson with practical takeaways and a short exercise.\n\n3) Short writing task\n- Give me a topic or a draft, and I’ll help outline or rewrite to be clearer and stronger.\n\n4) Project planning\n- Describe a project you’re working on (goal, constraints, deadline), and I’ll draft a milestone plan and a ready-to-do list.\n\n5) Code help\n- Paste a snippet and describe the bug or feature you’re working on, and I’ll help debug or implement it.\n\nIf you want, tell me your goal and a rough timeframe, and I’ll propose a concrete next step. What would you like to do?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": "test-user",
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 119,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1447,
+    "output_tokens_details": {
+      "reasoning_tokens": 1216
+    },
+    "total_tokens": 1566
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Sure—happy to help. What are you aiming to do today? If you’re not sure, here are a few quick options you can pick from, and I’ll tailor the next steps:\n\n1) Quick productivity sprint (about 25 minutes)\n- We pick 1–3 tasks, estimate time, set a timer, and I’ll help you review progress after.\n\n2) 15-minute learning bite\n- Choose a topic, I’ll give a concise mini-lesson with practical takeaways and a short exercise.\n\n3) Short writing task\n- Give me a topic or a draft, and I’ll help outline or rewrite to be clearer and stronger.\n\n4) Project planning\n- Describe a project you’re working on (goal, constraints, deadline), and I’ll draft a milestone plan and a ready-to-do list.\n\n5) Code help\n- Paste a snippet and describe the bug or feature you’re working on, and I’ll help debug or implement it.\n\nIf you want, tell me your goal and a rough timeframe, and I’ll propose a concrete next step. What would you like to do?"
+}

--- a/payloads/snapshots/safetyIdentifierParam/responses/request.json
+++ b/payloads/snapshots/safetyIdentifierParam/responses/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    }
+  ],
+  "safety_identifier": "test-user"
+}

--- a/payloads/snapshots/safetyIdentifierParam/responses/response-streaming.json
+++ b/payloads/snapshots/safetyIdentifierParam/responses/response-streaming.json
@@ -1,0 +1,759 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0ee7281976ff21fb006967e2a5b5fc8197aebdb2c2ed0b2995",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": "test-user",
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0ee7281976ff21fb006967e2a5b5fc8197aebdb2c2ed0b2995",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": "test-user",
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0ee7281976ff21fb006967e2a6168c819796ba0288343c6c75",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0ee7281976ff21fb006967e2a6168c819796ba0288343c6c75",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Hi",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "mryWCd0fVJK3Pt",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "!",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "Hp9ICBhe83J1WXa",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " How",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "RTQ0ZzBHwGQQ",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "AMCcTtL2CmHj",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "1JgZhPlEqVj1rA",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " help",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "KOc2KYq8Fbs",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " today",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "urDj6aWTPS",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "?",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "yXZzjzpWk5vaUEt",
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Tell",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "3HYVPF3jQao",
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " me",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "YQPvOoU50uUGo",
+    "output_index": 1,
+    "sequence_number": 15
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " your",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "5EBSRQ0lclX",
+    "output_index": 1,
+    "sequence_number": 16
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " goal",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "lZTbvezpc2v",
+    "output_index": 1,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "fHIf5DCapYkIb",
+    "output_index": 1,
+    "sequence_number": 18
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " the",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "su7DLAFltSno",
+    "output_index": 1,
+    "sequence_number": 19
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " task",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "nuFXxMAJaHq",
+    "output_index": 1,
+    "sequence_number": 20
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "aq1S4nPwOX7m",
+    "output_index": 1,
+    "sequence_number": 21
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " have",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "lLBwPkmRSHh",
+    "output_index": 1,
+    "sequence_number": 22
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " in",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "0Oxr82kyHOFkG",
+    "output_index": 1,
+    "sequence_number": 23
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " mind",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "d4dpjWa4nOU",
+    "output_index": 1,
+    "sequence_number": 24
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "nG8POg1HL5BP3tH",
+    "output_index": 1,
+    "sequence_number": 25
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "2SwxTjL2K27r",
+    "output_index": 1,
+    "sequence_number": 26
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "gEPIBcNTYKbtx4",
+    "output_index": 1,
+    "sequence_number": 27
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’ll",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "yV0Rj5qwcPUvL",
+    "output_index": 1,
+    "sequence_number": 28
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " jump",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "gyxq6POOqsZ",
+    "output_index": 1,
+    "sequence_number": 29
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " in",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "Q3SmBNVcchma7",
+    "output_index": 1,
+    "sequence_number": 30
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "WWlRRVcpt7S9FPM",
+    "output_index": 1,
+    "sequence_number": 31
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "0cV2wsKcPQLemx",
+    "output_index": 1,
+    "sequence_number": 32
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "u4FmlK0hQNIG",
+    "output_index": 1,
+    "sequence_number": 33
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " answer",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "5kOts2r7z",
+    "output_index": 1,
+    "sequence_number": 34
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " questions",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "Z7xRiV",
+    "output_index": 1,
+    "sequence_number": 35
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "UgZzhRfpU4OAdX9",
+    "output_index": 1,
+    "sequence_number": 36
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " help",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "nKydaGm10z0",
+    "output_index": 1,
+    "sequence_number": 37
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " with",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "LoXHKIwJZtU",
+    "output_index": 1,
+    "sequence_number": 38
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " writing",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "pFx00hxY",
+    "output_index": 1,
+    "sequence_number": 39
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "BFfhhxoRgtdbW",
+    "output_index": 1,
+    "sequence_number": 40
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " editing",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "VyFeCFGr",
+    "output_index": 1,
+    "sequence_number": 41
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "GiF0L0XSRboiSPZ",
+    "output_index": 1,
+    "sequence_number": 42
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " assist",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "dokhf60nA",
+    "output_index": 1,
+    "sequence_number": 43
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " with",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "mxdrmevHcv9",
+    "output_index": 1,
+    "sequence_number": 44
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " coding",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "27zZXHEan",
+    "output_index": 1,
+    "sequence_number": 45
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "T0ZqNfNEqxeleT2",
+    "output_index": 1,
+    "sequence_number": 46
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " brainstorm",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "KHcdV",
+    "output_index": 1,
+    "sequence_number": 47
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ideas",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "0UcXqi15aB",
+    "output_index": 1,
+    "sequence_number": 48
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "PC6YmASnStZC0kF",
+    "output_index": 1,
+    "sequence_number": 49
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " plan",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "zQMjZPd4LpF",
+    "output_index": 1,
+    "sequence_number": 50
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " things",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "0TXe1PgsV",
+    "output_index": 1,
+    "sequence_number": 51
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "2MUPWOZElOa6fU9",
+    "output_index": 1,
+    "sequence_number": 52
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "8JQbqhDkE2Vh",
+    "output_index": 1,
+    "sequence_number": 53
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " more",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "qfzkKkO3NPY",
+    "output_index": 1,
+    "sequence_number": 54
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "obfuscation": "zqcYAAyUK7fwkja",
+    "output_index": 1,
+    "sequence_number": 55
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 56,
+    "text": "Hi! How can I help today? Tell me your goal or the task you have in mind, and I’ll jump in. I can answer questions, help with writing or editing, assist with coding, brainstorm ideas, plan things, and more."
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "Hi! How can I help today? Tell me your goal or the task you have in mind, and I’ll jump in. I can answer questions, help with writing or editing, assist with coding, brainstorm ideas, plan things, and more."
+    },
+    "sequence_number": 57
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi! How can I help today? Tell me your goal or the task you have in mind, and I’ll jump in. I can answer questions, help with writing or editing, assist with coding, brainstorm ideas, plan things, and more."
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 58
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0ee7281976ff21fb006967e2a5b5fc8197aebdb2c2ed0b2995",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415914,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_0ee7281976ff21fb006967e2a6168c819796ba0288343c6c75",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_0ee7281976ff21fb006967e2a9a1c881979ac349c16aebea03",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "Hi! How can I help today? Tell me your goal or the task you have in mind, and I’ll jump in. I can answer questions, help with writing or editing, assist with coding, brainstorm ideas, plan things, and more."
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": "test-user",
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 7,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 376,
+        "output_tokens_details": {
+          "reasoning_tokens": 320
+        },
+        "total_tokens": 383
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 59
+  }
+]

--- a/payloads/snapshots/safetyIdentifierParam/responses/response.json
+++ b/payloads/snapshots/safetyIdentifierParam/responses/response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_0ed226998f748acc006967e2704e7481a183fe9871b8c89767",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415866,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0ed226998f748acc006967e272539881a1828ec73bf40fe48d",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0ed226998f748acc006967e279616881a1a563255f26b92361",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi! How can I help today? I can assist with:\n\n- Answering questions or explaining topics\n- Writing, editing, or brainstorming\n- Coding help and debugging\n- Math and problem solving\n- Planning, study tips, summaries\n- Translating or explaining texts\n- Generating ideas for projects, stories, resumes\n\nIf you have a specific task, tell me the details or paste the text, and I’ll jump in. What would you like to do?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": "test-user",
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 7,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 550,
+    "output_tokens_details": {
+      "reasoning_tokens": 448
+    },
+    "total_tokens": 557
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Hi! How can I help today? I can assist with:\n\n- Answering questions or explaining topics\n- Writing, editing, or brainstorming\n- Coding help and debugging\n- Math and problem solving\n- Planning, study tips, summaries\n- Translating or explaining texts\n- Generating ideas for projects, stories, resumes\n\nIf you have a specific task, tell me the details or paste the text, and I’ll jump in. What would you like to do?"
+}

--- a/payloads/snapshots/serviceTierParam/responses/followup-request.json
+++ b/payloads/snapshots/serviceTierParam/responses/followup-request.json
@@ -1,0 +1,33 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    },
+    {
+      "id": "rs_046d311d0d184f00006967e272604c81a386ecbc9a1f9d64e7",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_046d311d0d184f00006967e2760abc81a3be7dac2dad0dc957",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi! How can I help today? I can explain concepts, answer questions, help with writing or code, brainstorm ideas, plan stuff, and more. Tell me what you’d like to do, or share a topic you’re curious about. If you have an image, you can upload it and I can describe or analyze it."
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "service_tier": "default"
+}

--- a/payloads/snapshots/serviceTierParam/responses/followup-response.json
+++ b/payloads/snapshots/serviceTierParam/responses/followup-response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_046d311d0d184f00006967e27750dc81a3b1e7a9d599d8ff44",
+  "object": "response",
+  "created_at": 1768415863,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415882,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_046d311d0d184f00006967e277a10c81a381ca7938ba8d9bae",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_046d311d0d184f00006967e288153881a3b64e71dcab03df80",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Nice question. Here are quick, practical options you can pick from. Tell me which one you want, or share a goal and I’ll tailor it.\n\n- Learn something fast: I give you a 5-minute micro-lesson on any topic and a take-away you can apply immediately.\n- Solve a problem: describe the challenge you’re facing, and I’ll outline concrete steps and a simple solution.\n- Write or edit: draft a paragraph, email, resume bullet, or a short snippet; I’ll revise for clarity and impact.\n- Plan something: create a short plan for a day, week, project, or trip—tasks, priorities, and deadlines.\n- Brainstorm: generate ideas for a project, story prompt, product concept, or marketing angle.\n- Code help: write or debug a small function, explain an error, or review a snippet.\n- Quick self-care or focus routine: a 5-minute breathing, stretch, or focus session to reset.\n- Quick momentum boost: do a 2-minute brain dump (list 3 goals for today) or a 15-minute sprint plan.\n\nIf you want, tell me your goal or topic and I’ll propose a specific next step right away. What area would you like to focus on?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 90,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1604,
+    "output_tokens_details": {
+      "reasoning_tokens": 1344
+    },
+    "total_tokens": 1694
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Nice question. Here are quick, practical options you can pick from. Tell me which one you want, or share a goal and I’ll tailor it.\n\n- Learn something fast: I give you a 5-minute micro-lesson on any topic and a take-away you can apply immediately.\n- Solve a problem: describe the challenge you’re facing, and I’ll outline concrete steps and a simple solution.\n- Write or edit: draft a paragraph, email, resume bullet, or a short snippet; I’ll revise for clarity and impact.\n- Plan something: create a short plan for a day, week, project, or trip—tasks, priorities, and deadlines.\n- Brainstorm: generate ideas for a project, story prompt, product concept, or marketing angle.\n- Code help: write or debug a small function, explain an error, or review a snippet.\n- Quick self-care or focus routine: a 5-minute breathing, stretch, or focus session to reset.\n- Quick momentum boost: do a 2-minute brain dump (list 3 goals for today) or a 15-minute sprint plan.\n\nIf you want, tell me your goal or topic and I’ll propose a specific next step right away. What area would you like to focus on?"
+}

--- a/payloads/snapshots/serviceTierParam/responses/request.json
+++ b/payloads/snapshots/serviceTierParam/responses/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    }
+  ],
+  "service_tier": "default"
+}

--- a/payloads/snapshots/serviceTierParam/responses/response-streaming.json
+++ b/payloads/snapshots/serviceTierParam/responses/response-streaming.json
@@ -1,0 +1,1249 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0c67abd1f33ae923006967e2a5b2288196925b063b1f5d7150",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0c67abd1f33ae923006967e2a5b2288196925b063b1f5d7150",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0c67abd1f33ae923006967e2a5f91481969ce58cd4a56eb3e1",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0c67abd1f33ae923006967e2a5f91481969ce58cd4a56eb3e1",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Hi",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "dw12Dd3julbiBe",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "!",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "BeVvOekJ6pG2IvB",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " How",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "ShEsoDChW885",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "YoaGE50vaN83",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "tZnAhFsBitnZ8x",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " help",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "H1Y0qrKE4Ml",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " today",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "PDcV1PjLJn",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "?\n\n",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "2CgCiBTZRRj7t",
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "I",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "E13ajf4Vcehxi6K",
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "WLLfEDG3ap87",
+    "output_index": 1,
+    "sequence_number": 15
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":\n",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "kEtJM9Mgb1vl74",
+    "output_index": 1,
+    "sequence_number": 16
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "zBVne8h9AkfNsvR",
+    "output_index": 1,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Explain",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "UXTqE3o8",
+    "output_index": 1,
+    "sequence_number": 18
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " topics",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "nY3S0BWug",
+    "output_index": 1,
+    "sequence_number": 19
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " in",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "lT575HDGiG71Q",
+    "output_index": 1,
+    "sequence_number": 20
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " plain",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "RZqrAHO0Po",
+    "output_index": 1,
+    "sequence_number": 21
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " language",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "y9cxfn9",
+    "output_index": 1,
+    "sequence_number": 22
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "rfgHqLDXZPfD7T0",
+    "output_index": 1,
+    "sequence_number": 23
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "GCxkecmFxinykr4",
+    "output_index": 1,
+    "sequence_number": 24
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Help",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "8djFv3f9aRo",
+    "output_index": 1,
+    "sequence_number": 25
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " with",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "YlsyWNte4F1",
+    "output_index": 1,
+    "sequence_number": 26
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " writing",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "qixbti18",
+    "output_index": 1,
+    "sequence_number": 27
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "ZelfGvzaVgXLRbN",
+    "output_index": 1,
+    "sequence_number": 28
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " editing",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "5OqLVwi0",
+    "output_index": 1,
+    "sequence_number": 29
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "ZJyNw4PrOPtXzRY",
+    "output_index": 1,
+    "sequence_number": 30
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "5jN819MoAeYoD",
+    "output_index": 1,
+    "sequence_number": 31
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " brainstorming",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "XA",
+    "output_index": 1,
+    "sequence_number": 32
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "BPoBnnJS8BZCnv2",
+    "output_index": 1,
+    "sequence_number": 33
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "CezxyHDSwlNNL4B",
+    "output_index": 1,
+    "sequence_number": 34
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Answer",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "vsWujRIQw",
+    "output_index": 1,
+    "sequence_number": 35
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " questions",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "ju7MUe",
+    "output_index": 1,
+    "sequence_number": 36
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "f3tUOlN4qOqJD6",
+    "output_index": 1,
+    "sequence_number": 37
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "math",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "fNydKDRh0BVJ",
+    "output_index": 1,
+    "sequence_number": 38
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "4dLXPRvT3XP28be",
+    "output_index": 1,
+    "sequence_number": 39
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " science",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "tP6r03Cr",
+    "output_index": 1,
+    "sequence_number": 40
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "BzIm2ZIP248olgd",
+    "output_index": 1,
+    "sequence_number": 41
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " history",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "ngzqXlKv",
+    "output_index": 1,
+    "sequence_number": 42
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "yA3y4UnSrZc9Xgd",
+    "output_index": 1,
+    "sequence_number": 43
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " etc",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "OaTeqBqK1uqS",
+    "output_index": 1,
+    "sequence_number": 44
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".)\n",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "PCUXHPqwK5wAC",
+    "output_index": 1,
+    "sequence_number": 45
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "Im92HRFgRpHupJj",
+    "output_index": 1,
+    "sequence_number": 46
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Debug",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "PwGxrl34U6",
+    "output_index": 1,
+    "sequence_number": 47
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "neDRpzzE3nUVm",
+    "output_index": 1,
+    "sequence_number": 48
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " review",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "I7tOY7mCY",
+    "output_index": 1,
+    "sequence_number": 49
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " code",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "6SaJWpgD9TA",
+    "output_index": 1,
+    "sequence_number": 50
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "srrZDk7PKVjKmwa",
+    "output_index": 1,
+    "sequence_number": 51
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "GdEzrZqzQPVmD8F",
+    "output_index": 1,
+    "sequence_number": 52
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Translate",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "P1Fj7b",
+    "output_index": 1,
+    "sequence_number": 53
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "HG8wTKRwP2F8V",
+    "output_index": 1,
+    "sequence_number": 54
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " summarize",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "mwyDYX",
+    "output_index": 1,
+    "sequence_number": 55
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " text",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "X4BY5H034NR",
+    "output_index": 1,
+    "sequence_number": 56
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "MrOdBVKujWsGqKS",
+    "output_index": 1,
+    "sequence_number": 57
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "Ss3KJVAHTSiULMN",
+    "output_index": 1,
+    "sequence_number": 58
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Plan",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "5OGNVfKCRnn",
+    "output_index": 1,
+    "sequence_number": 59
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "bezuEOnB0lDaX",
+    "output_index": 1,
+    "sequence_number": 60
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " brainstorm",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "LZeu7",
+    "output_index": 1,
+    "sequence_number": 61
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " projects",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "udO8AKq",
+    "output_index": 1,
+    "sequence_number": 62
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "tDlv7BRoszUcJkn",
+    "output_index": 1,
+    "sequence_number": 63
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " trips",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "67EFVOiHAb",
+    "output_index": 1,
+    "sequence_number": 64
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "aTKxgTTBhXrwNvD",
+    "output_index": 1,
+    "sequence_number": 65
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " study",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "4DT4iJ6U8I",
+    "output_index": 1,
+    "sequence_number": 66
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " guides",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "rQYfNoKN1",
+    "output_index": 1,
+    "sequence_number": 67
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "WWaU51pmrqWD8QH",
+    "output_index": 1,
+    "sequence_number": 68
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "PoPVbpzbHHzRQdL",
+    "output_index": 1,
+    "sequence_number": 69
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Analyze",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "XM3l6l52",
+    "output_index": 1,
+    "sequence_number": 70
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " images",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "HMdZZekyr",
+    "output_index": 1,
+    "sequence_number": 71
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "xJhYm6uXzsiTX7",
+    "output_index": 1,
+    "sequence_number": 72
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "if",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "ZiodBRoLSdlI6k",
+    "output_index": 1,
+    "sequence_number": 73
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "4Wdbx8QHOMKX",
+    "output_index": 1,
+    "sequence_number": 74
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " want",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "Ot2vTnIvE1w",
+    "output_index": 1,
+    "sequence_number": 75
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "ZZ9GsV36h54FA3l",
+    "output_index": 1,
+    "sequence_number": 76
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "4ouqqgTxTHKw",
+    "output_index": 1,
+    "sequence_number": 77
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "kxqBXvyEY92x",
+    "output_index": 1,
+    "sequence_number": 78
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " share",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "f07I8Ki3n4",
+    "output_index": 1,
+    "sequence_number": 79
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " one",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "If78HuergwmH",
+    "output_index": 1,
+    "sequence_number": 80
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ")\n\n",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "NgMHRxFh8lXJm",
+    "output_index": 1,
+    "sequence_number": 81
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "What",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "lagvxCimQNyx",
+    "output_index": 1,
+    "sequence_number": 82
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " would",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "q2GYAGxotK",
+    "output_index": 1,
+    "sequence_number": 83
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "0KYBFcc8k5Di",
+    "output_index": 1,
+    "sequence_number": 84
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " like",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "GcNMjtb33fe",
+    "output_index": 1,
+    "sequence_number": 85
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " to",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "syXNrR8AJDfqG",
+    "output_index": 1,
+    "sequence_number": 86
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " do",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "c6UINisiBmXs1",
+    "output_index": 1,
+    "sequence_number": 87
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "?",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "FgZoGXeOztt5qmd",
+    "output_index": 1,
+    "sequence_number": 88
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " If",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "MlDKbKqZH8Zlv",
+    "output_index": 1,
+    "sequence_number": 89
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "qZvVoATuk1kb",
+    "output_index": 1,
+    "sequence_number": 90
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’re",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "msBRJys3uCB2a",
+    "output_index": 1,
+    "sequence_number": 91
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " unsure",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "NvEEDudOs",
+    "output_index": 1,
+    "sequence_number": 92
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "e9IY0WaGcSf7bQx",
+    "output_index": 1,
+    "sequence_number": 93
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " tell",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "YJkej8dNm5k",
+    "output_index": 1,
+    "sequence_number": 94
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " me",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "VSBmonCZRZA6J",
+    "output_index": 1,
+    "sequence_number": 95
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " your",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "blBJHA3PaoM",
+    "output_index": 1,
+    "sequence_number": 96
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " goal",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "iVHxiY0bjgu",
+    "output_index": 1,
+    "sequence_number": 97
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "AmDvQdrL35Xe",
+    "output_index": 1,
+    "sequence_number": 98
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "EdL1FWnLSLpWP7",
+    "output_index": 1,
+    "sequence_number": 99
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’ll",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "DvtaBFU4Zh84c",
+    "output_index": 1,
+    "sequence_number": 100
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " suggest",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "iEeTHLCv",
+    "output_index": 1,
+    "sequence_number": 101
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "Jp4430vzXPy0Ql",
+    "output_index": 1,
+    "sequence_number": 102
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " plan",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "5YA6E5CFnq0",
+    "output_index": 1,
+    "sequence_number": 103
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "obfuscation": "9JqxegcarIqa64b",
+    "output_index": 1,
+    "sequence_number": 104
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 105,
+    "text": "Hi! How can I help today?\n\nI can:\n- Explain topics in plain language\n- Help with writing, editing, or brainstorming\n- Answer questions (math, science, history, etc.)\n- Debug or review code\n- Translate or summarize text\n- Plan or brainstorm projects, trips, study guides\n- Analyze images (if you want, you can share one)\n\nWhat would you like to do? If you’re unsure, tell me your goal and I’ll suggest a plan."
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "Hi! How can I help today?\n\nI can:\n- Explain topics in plain language\n- Help with writing, editing, or brainstorming\n- Answer questions (math, science, history, etc.)\n- Debug or review code\n- Translate or summarize text\n- Plan or brainstorm projects, trips, study guides\n- Analyze images (if you want, you can share one)\n\nWhat would you like to do? If you’re unsure, tell me your goal and I’ll suggest a plan."
+    },
+    "sequence_number": 106
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi! How can I help today?\n\nI can:\n- Explain topics in plain language\n- Help with writing, editing, or brainstorming\n- Answer questions (math, science, history, etc.)\n- Debug or review code\n- Translate or summarize text\n- Plan or brainstorm projects, trips, study guides\n- Analyze images (if you want, you can share one)\n\nWhat would you like to do? If you’re unsure, tell me your goal and I’ll suggest a plan."
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 107
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0c67abd1f33ae923006967e2a5b2288196925b063b1f5d7150",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415913,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_0c67abd1f33ae923006967e2a5f91481969ce58cd4a56eb3e1",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_0c67abd1f33ae923006967e2a8f66081968cbd63b5fc9f1c3a",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "Hi! How can I help today?\n\nI can:\n- Explain topics in plain language\n- Help with writing, editing, or brainstorming\n- Answer questions (math, science, history, etc.)\n- Debug or review code\n- Translate or summarize text\n- Plan or brainstorm projects, trips, study guides\n- Analyze images (if you want, you can share one)\n\nWhat would you like to do? If you’re unsure, tell me your goal and I’ll suggest a plan."
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 7,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 361,
+        "output_tokens_details": {
+          "reasoning_tokens": 256
+        },
+        "total_tokens": 368
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 108
+  }
+]

--- a/payloads/snapshots/serviceTierParam/responses/response.json
+++ b/payloads/snapshots/serviceTierParam/responses/response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_046d311d0d184f00006967e270792881a3bf6aaadde78de23d",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415863,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_046d311d0d184f00006967e272604c81a386ecbc9a1f9d64e7",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_046d311d0d184f00006967e2760abc81a3be7dac2dad0dc957",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi! How can I help today? I can explain concepts, answer questions, help with writing or code, brainstorm ideas, plan stuff, and more. Tell me what you’d like to do, or share a topic you’re curious about. If you have an image, you can upload it and I can describe or analyze it."
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 7,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 329,
+    "output_tokens_details": {
+      "reasoning_tokens": 256
+    },
+    "total_tokens": 336
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Hi! How can I help today? I can explain concepts, answer questions, help with writing or code, brainstorm ideas, plan stuff, and more. Tell me what you’d like to do, or share a topic you’re curious about. If you have an image, you can upload it and I can describe or analyze it."
+}

--- a/payloads/snapshots/storeDisabledParam/responses/request.json
+++ b/payloads/snapshots/storeDisabledParam/responses/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    }
+  ],
+  "store": false
+}

--- a/payloads/snapshots/storeDisabledParam/responses/response-streaming.json
+++ b/payloads/snapshots/storeDisabledParam/responses/response-streaming.json
@@ -1,0 +1,1079 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_07b6fd91faab6206016967e2a5acf0819cb4fdc6faf0166f9d",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": false,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_07b6fd91faab6206016967e2a5acf0819cb4fdc6faf0166f9d",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": false,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_07b6fd91faab6206016967e2a5e6a8819c8019fd16fd4ec624",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_07b6fd91faab6206016967e2a5e6a8819c8019fd16fd4ec624",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Hi",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "u3vPz4gbhO91gy",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " there",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "NKByi36rH2",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "!",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "NfRHpmtLvkilyTZ",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " How",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "4Ki3xZF8gPEy",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "5YpeQztLw2vv",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "EllbeaUTPVArxv",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " help",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "h3MgJyljiUr",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " today",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "W2u6LiedFo",
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "?",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "6uClgs9gm1w5KMa",
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " If",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "Kfm94hLeGy2GC",
+    "output_index": 1,
+    "sequence_number": 15
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "2GYgyznxmxQ0",
+    "output_index": 1,
+    "sequence_number": 16
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’re",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "WErf0OB8yGJfo",
+    "output_index": 1,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " not",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "atMbV0rAtmEr",
+    "output_index": 1,
+    "sequence_number": 18
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " sure",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "lQcwaP9jAnB",
+    "output_index": 1,
+    "sequence_number": 19
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "O4k6KRrDzFC50Cz",
+    "output_index": 1,
+    "sequence_number": 20
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " here",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "Ds6TYw8KuRE",
+    "output_index": 1,
+    "sequence_number": 21
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " are",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "9pbGOqBN54cg",
+    "output_index": 1,
+    "sequence_number": 22
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "H5tgUoolhRKG9G",
+    "output_index": 1,
+    "sequence_number": 23
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " few",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "McPWoSsHhWfh",
+    "output_index": 1,
+    "sequence_number": 24
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ideas",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "0Bpcjo5X2I",
+    "output_index": 1,
+    "sequence_number": 25
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":\n",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "ZtPh7izTxoP6Zg",
+    "output_index": 1,
+    "sequence_number": 26
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "WHGkoAzD6Mr6zrl",
+    "output_index": 1,
+    "sequence_number": 27
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Explain",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "74WyjCwX",
+    "output_index": 1,
+    "sequence_number": 28
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "75SfGmrVhuORNw",
+    "output_index": 1,
+    "sequence_number": 29
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " topic",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "5VU6Z736vh",
+    "output_index": 1,
+    "sequence_number": 30
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "FiN2MUwZBo4lz",
+    "output_index": 1,
+    "sequence_number": 31
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " answer",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "BBa8ESU4l",
+    "output_index": 1,
+    "sequence_number": 32
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "0iMj63F1BFotow",
+    "output_index": 1,
+    "sequence_number": 33
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " question",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "BB7aa6r",
+    "output_index": 1,
+    "sequence_number": 34
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "cJYJpZaQ6Xywvbp",
+    "output_index": 1,
+    "sequence_number": 35
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "XCLAmhcuoL6mVw1",
+    "output_index": 1,
+    "sequence_number": 36
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Help",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "xY5unlH0p1O",
+    "output_index": 1,
+    "sequence_number": 37
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " draft",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "OBS3JExizO",
+    "output_index": 1,
+    "sequence_number": 38
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "dwI1VUxiyCmsI",
+    "output_index": 1,
+    "sequence_number": 39
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " edit",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "uk4XGRaDRCD",
+    "output_index": 1,
+    "sequence_number": 40
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " something",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "5654t6",
+    "output_index": 1,
+    "sequence_number": 41
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "CR58ToOwdnSDti",
+    "output_index": 1,
+    "sequence_number": 42
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "email",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "Pin7bHwpOBS",
+    "output_index": 1,
+    "sequence_number": 43
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "6FXnorxAVHwsI1n",
+    "output_index": 1,
+    "sequence_number": 44
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " resume",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "UmZ4VoP3f",
+    "output_index": 1,
+    "sequence_number": 45
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "VNGx3G8JZY9q44E",
+    "output_index": 1,
+    "sequence_number": 46
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " essay",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "HcvxVg0eqi",
+    "output_index": 1,
+    "sequence_number": 47
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ")\n",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "uhupP6pTvjY7nZ",
+    "output_index": 1,
+    "sequence_number": 48
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "Kb0nr9kn7XKNVCD",
+    "output_index": 1,
+    "sequence_number": 49
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Solve",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "e7r6HnPiFm",
+    "output_index": 1,
+    "sequence_number": 50
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "0BmpTB0nWMdTFG",
+    "output_index": 1,
+    "sequence_number": 51
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " math",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "vs5XTly3sZi",
+    "output_index": 1,
+    "sequence_number": 52
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " problem",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "JI77g9D9",
+    "output_index": 1,
+    "sequence_number": 53
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "pwbdO4yDGOJTE",
+    "output_index": 1,
+    "sequence_number": 54
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " code",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "AvZaz3plIm9",
+    "output_index": 1,
+    "sequence_number": 55
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " issue",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "61hQuVtExo",
+    "output_index": 1,
+    "sequence_number": 56
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "zO5HOdgKsp1KUto",
+    "output_index": 1,
+    "sequence_number": 57
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "COHd4bqW2szuhcT",
+    "output_index": 1,
+    "sequence_number": 58
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Plan",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "FYnAxQKbih6",
+    "output_index": 1,
+    "sequence_number": 59
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "Rw9aYqRLXe1NS",
+    "output_index": 1,
+    "sequence_number": 60
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " brainstorm",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "v7zPK",
+    "output_index": 1,
+    "sequence_number": 61
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "AIe0EY4EMsDkNh",
+    "output_index": 1,
+    "sequence_number": 62
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "projects",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "akfYiPIU",
+    "output_index": 1,
+    "sequence_number": 63
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "mO5ShkJBM8aV4ez",
+    "output_index": 1,
+    "sequence_number": 64
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " trips",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "d36UqzFBrE",
+    "output_index": 1,
+    "sequence_number": 65
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "w5lfytTmp2j748q",
+    "output_index": 1,
+    "sequence_number": 66
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " writing",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "zIvD0JgL",
+    "output_index": 1,
+    "sequence_number": 67
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ")\n",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "QOiIQQSxx3ltG9",
+    "output_index": 1,
+    "sequence_number": 68
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "l4Qw0E9bsnJEVT5",
+    "output_index": 1,
+    "sequence_number": 69
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Quick",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "F0MErY5roL",
+    "output_index": 1,
+    "sequence_number": 70
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " lesson",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "geMHC7rmj",
+    "output_index": 1,
+    "sequence_number": 71
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "h3GxJl2jcbv74",
+    "output_index": 1,
+    "sequence_number": 72
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " overview",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "vglV3X3",
+    "output_index": 1,
+    "sequence_number": 73
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " on",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "if9aAPxCEjoc1",
+    "output_index": 1,
+    "sequence_number": 74
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " something",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "ZnIx8E",
+    "output_index": 1,
+    "sequence_number": 75
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " new",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "FMBSkV2quIen",
+    "output_index": 1,
+    "sequence_number": 76
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n\n",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "GEA0f7NLAHm6D1",
+    "output_index": 1,
+    "sequence_number": 77
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "What",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "ipB6FT4bhVcD",
+    "output_index": 1,
+    "sequence_number": 78
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " would",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "5eoYswppsc",
+    "output_index": 1,
+    "sequence_number": 79
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "4gTJT3GPoXYK",
+    "output_index": 1,
+    "sequence_number": 80
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " like",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "RkMHaJvcwnU",
+    "output_index": 1,
+    "sequence_number": 81
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " to",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "dL83rceYAarXS",
+    "output_index": 1,
+    "sequence_number": 82
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " do",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "S2gr0y2t5lWHq",
+    "output_index": 1,
+    "sequence_number": 83
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "fVjoKWYAq75wH",
+    "output_index": 1,
+    "sequence_number": 84
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " chat",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "GNGcWXXilML",
+    "output_index": 1,
+    "sequence_number": 85
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " about",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "rHrODFYWyE",
+    "output_index": 1,
+    "sequence_number": 86
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "?",
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "obfuscation": "JQPKCei0AlCFYje",
+    "output_index": 1,
+    "sequence_number": 87
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 88,
+    "text": "Hi there! How can I help today? If you’re not sure, here are a few ideas:\n- Explain a topic or answer a question\n- Help draft or edit something (email, resume, essay)\n- Solve a math problem or code issue\n- Plan or brainstorm (projects, trips, writing)\n- Quick lesson or overview on something new\n\nWhat would you like to do or chat about?"
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "Hi there! How can I help today? If you’re not sure, here are a few ideas:\n- Explain a topic or answer a question\n- Help draft or edit something (email, resume, essay)\n- Solve a math problem or code issue\n- Plan or brainstorm (projects, trips, writing)\n- Quick lesson or overview on something new\n\nWhat would you like to do or chat about?"
+    },
+    "sequence_number": 89
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi there! How can I help today? If you’re not sure, here are a few ideas:\n- Explain a topic or answer a question\n- Help draft or edit something (email, resume, essay)\n- Solve a math problem or code issue\n- Plan or brainstorm (projects, trips, writing)\n- Quick lesson or overview on something new\n\nWhat would you like to do or chat about?"
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 90
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_07b6fd91faab6206016967e2a5acf0819cb4fdc6faf0166f9d",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415915,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_07b6fd91faab6206016967e2a5e6a8819c8019fd16fd4ec624",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_07b6fd91faab6206016967e2aaffb4819c99df1a2d47ad1e81",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "Hi there! How can I help today? If you’re not sure, here are a few ideas:\n- Explain a topic or answer a question\n- Help draft or edit something (email, resume, essay)\n- Solve a math problem or code issue\n- Plan or brainstorm (projects, trips, writing)\n- Quick lesson or overview on something new\n\nWhat would you like to do or chat about?"
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": false,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 7,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 472,
+        "output_tokens_details": {
+          "reasoning_tokens": 384
+        },
+        "total_tokens": 479
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 91
+  }
+]

--- a/payloads/snapshots/storeDisabledParam/responses/response.json
+++ b/payloads/snapshots/storeDisabledParam/responses/response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_0002364fb5cbe93c016967e27058e08193ad94c40a382dc310",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415864,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0002364fb5cbe93c016967e27283008193a8548ab1c3c0c7e8",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0002364fb5cbe93c016967e27680e8819393c41f600ba6e1a5",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi there! How can I help today?\n\nIf you’re not sure yet, here are a few things I can do:\n- Answer questions or explain concepts\n- Help with writing, editing, or brainstorming\n- Assist with coding or debugging\n- Summarize or translate text\n- Plan a project, trip, meal, or study schedule\n- Provide explanations, examples, or practice problems\n\nTell me what you’re working on or what you’d like to learn, and we’ll go from there."
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": false,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 7,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 364,
+    "output_tokens_details": {
+      "reasoning_tokens": 256
+    },
+    "total_tokens": 371
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Hi there! How can I help today?\n\nIf you’re not sure yet, here are a few things I can do:\n- Answer questions or explain concepts\n- Help with writing, editing, or brainstorming\n- Assist with coding or debugging\n- Summarize or translate text\n- Plan a project, trip, meal, or study schedule\n- Provide explanations, examples, or practice problems\n\nTell me what you’re working on or what you’d like to learn, and we’ll go from there."
+}

--- a/payloads/snapshots/textFormatJsonObjectParam/responses/followup-request.json
+++ b/payloads/snapshots/textFormatJsonObjectParam/responses/followup-request.json
@@ -1,0 +1,37 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Return JSON with a=1"
+    },
+    {
+      "id": "rs_0165a328b6b2bb52006967e2724a3c8196b9741550dce02f32",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0165a328b6b2bb52006967e275aa68819696c7da050af3fb03",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"a\":1}"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "text": {
+    "format": {
+      "type": "json_object"
+    }
+  }
+}

--- a/payloads/snapshots/textFormatJsonObjectParam/responses/followup-response.json
+++ b/payloads/snapshots/textFormatJsonObjectParam/responses/followup-response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_0165a328b6b2bb52006967e27671148196a8ee12ae03ffd343",
+  "object": "response",
+  "created_at": 1768415862,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415879,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0165a328b6b2bb52006967e276cf9c8196bfcb723ce6c3c8f6",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0165a328b6b2bb52006967e287275c8196a2649960c0517e50",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"a\":1}"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "json_object"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 33,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1227,
+    "output_tokens_details": {
+      "reasoning_tokens": 1216
+    },
+    "total_tokens": 1260
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "{\"a\":1}"
+}

--- a/payloads/snapshots/textFormatJsonObjectParam/responses/request.json
+++ b/payloads/snapshots/textFormatJsonObjectParam/responses/request.json
@@ -1,0 +1,14 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Return JSON with a=1"
+    }
+  ],
+  "text": {
+    "format": {
+      "type": "json_object"
+    }
+  }
+}

--- a/payloads/snapshots/textFormatJsonObjectParam/responses/response-streaming.json
+++ b/payloads/snapshots/textFormatJsonObjectParam/responses/response-streaming.json
@@ -1,0 +1,319 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_09338a417cc3bd5f006967e2a5afd8819fbccce1455e9c2e4a",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "json_object"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_09338a417cc3bd5f006967e2a5afd8819fbccce1455e9c2e4a",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "json_object"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_09338a417cc3bd5f006967e2a5ea68819f94fa04c30b01d5ff",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_09338a417cc3bd5f006967e2a5ea68819f94fa04c30b01d5ff",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "{\"",
+    "item_id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+    "logprobs": [],
+    "obfuscation": "3EXkj9GtcUuZSe",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "a",
+    "item_id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+    "logprobs": [],
+    "obfuscation": "rSrErecXphwDVWu",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\":",
+    "item_id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+    "logprobs": [],
+    "obfuscation": "FP0pTcvYjrNB7y",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+    "logprobs": [],
+    "obfuscation": "y1wueOXJoxPorcc",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "1",
+    "item_id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+    "logprobs": [],
+    "obfuscation": "N96Y605Hqcl4XP2",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "}",
+    "item_id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+    "logprobs": [],
+    "obfuscation": "gq7lto94OUnenmh",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 12,
+    "text": "{\"a\": 1}"
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "{\"a\": 1}"
+    },
+    "sequence_number": 13
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"a\": 1}"
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_09338a417cc3bd5f006967e2a5afd8819fbccce1455e9c2e4a",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415912,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_09338a417cc3bd5f006967e2a5ea68819f94fa04c30b01d5ff",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_09338a417cc3bd5f006967e2a87360819f9704089853fcf8f4",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "{\"a\": 1}"
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "json_object"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 12,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 204,
+        "output_tokens_details": {
+          "reasoning_tokens": 192
+        },
+        "total_tokens": 216
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 15
+  }
+]

--- a/payloads/snapshots/textFormatJsonObjectParam/responses/response.json
+++ b/payloads/snapshots/textFormatJsonObjectParam/responses/response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_0165a328b6b2bb52006967e270329c8196be3f20fb8421b81a",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415861,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0165a328b6b2bb52006967e2724a3c8196b9741550dce02f32",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0165a328b6b2bb52006967e275aa68819696c7da050af3fb03",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"a\":1}"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "json_object"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 12,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 203,
+    "output_tokens_details": {
+      "reasoning_tokens": 192
+    },
+    "total_tokens": 215
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "{\"a\":1}"
+}

--- a/payloads/snapshots/textFormatJsonSchemaParam/responses/followup-request.json
+++ b/payloads/snapshots/textFormatJsonSchemaParam/responses/followup-request.json
@@ -1,0 +1,55 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Name: John, Age: 25"
+    },
+    {
+      "id": "rs_0a72ad71d1777e16006967e2726ae081a287cf8160a732ffce",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0a72ad71d1777e16006967e2758b7c81a2aedcde18aa1e3d6d",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"name\":\"John\",\"age\":25}"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "name": "person_info",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "age"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}

--- a/payloads/snapshots/textFormatJsonSchemaParam/responses/followup-response.json
+++ b/payloads/snapshots/textFormatJsonSchemaParam/responses/followup-response.json
@@ -1,0 +1,96 @@
+{
+  "id": "resp_0a72ad71d1777e16006967e27661b081a28f1c4793f030523e",
+  "object": "response",
+  "created_at": 1768415862,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415878,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0a72ad71d1777e16006967e276a48c81a2b40c49e4c16a716c",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0a72ad71d1777e16006967e286622881a29a9bea1bd494edf7",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"name\":\"John\",\"age\":25}"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "description": null,
+      "name": "person_info",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "age"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 71,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1235,
+    "output_tokens_details": {
+      "reasoning_tokens": 1216
+    },
+    "total_tokens": 1306
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "{\"name\":\"John\",\"age\":25}"
+}

--- a/payloads/snapshots/textFormatJsonSchemaParam/responses/request.json
+++ b/payloads/snapshots/textFormatJsonSchemaParam/responses/request.json
@@ -1,0 +1,32 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Name: John, Age: 25"
+    }
+  ],
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "name": "person_info",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "age"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}

--- a/payloads/snapshots/textFormatJsonSchemaParam/responses/response-streaming.json
+++ b/payloads/snapshots/textFormatJsonSchemaParam/responses/response-streaming.json
@@ -1,0 +1,406 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0fa1ac7003f4ce68006967e2a5b76481968b2548a14c22ed3e",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "json_schema",
+          "description": null,
+          "name": "person_info",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "age": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "name",
+              "age"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0fa1ac7003f4ce68006967e2a5b76481968b2548a14c22ed3e",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "json_schema",
+          "description": null,
+          "name": "person_info",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "age": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "name",
+              "age"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0fa1ac7003f4ce68006967e2a60f0c819682b4b1b56530e870",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0fa1ac7003f4ce68006967e2a60f0c819682b4b1b56530e870",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "{\"",
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "logprobs": [],
+    "obfuscation": "SY3sGh75Rv66yX",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "name",
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "logprobs": [],
+    "obfuscation": "tUdNC0Z5Dp9g",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\":\"",
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "logprobs": [],
+    "obfuscation": "4qr2oHcvmzYnN",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "John",
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "logprobs": [],
+    "obfuscation": "gVjRpopiaHgH",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\",\"",
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "logprobs": [],
+    "obfuscation": "ASsZ48XyZjYEX",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "age",
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "logprobs": [],
+    "obfuscation": "z7Uibv7EthVEm",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\":",
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "logprobs": [],
+    "obfuscation": "EZztKvOdd2p3Lz",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "25",
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "logprobs": [],
+    "obfuscation": "O98hRNOA88hqdl",
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "}",
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "logprobs": [],
+    "obfuscation": "a5LVysjHwbg1zSF",
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 15,
+    "text": "{\"name\":\"John\",\"age\":25}"
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "{\"name\":\"John\",\"age\":25}"
+    },
+    "sequence_number": 16
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"name\":\"John\",\"age\":25}"
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0fa1ac7003f4ce68006967e2a5b76481968b2548a14c22ed3e",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415914,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_0fa1ac7003f4ce68006967e2a60f0c819682b4b1b56530e870",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_0fa1ac7003f4ce68006967e2aa33e48196a2b7a5860928aa95",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "{\"name\":\"John\",\"age\":25}"
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "json_schema",
+          "description": null,
+          "name": "person_info",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "age": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "name",
+              "age"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 43,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 211,
+        "output_tokens_details": {
+          "reasoning_tokens": 192
+        },
+        "total_tokens": 254
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 18
+  }
+]

--- a/payloads/snapshots/textFormatJsonSchemaParam/responses/response.json
+++ b/payloads/snapshots/textFormatJsonSchemaParam/responses/response.json
@@ -1,0 +1,96 @@
+{
+  "id": "resp_0a72ad71d1777e16006967e2704c8081a2893dfd632c2498b3",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415861,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_0a72ad71d1777e16006967e2726ae081a287cf8160a732ffce",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0a72ad71d1777e16006967e2758b7c81a2aedcde18aa1e3d6d",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"name\":\"John\",\"age\":25}"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "description": null,
+      "name": "person_info",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "age"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 43,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 211,
+    "output_tokens_details": {
+      "reasoning_tokens": 192
+    },
+    "total_tokens": 254
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "{\"name\":\"John\",\"age\":25}"
+}

--- a/payloads/snapshots/toolChoiceRequiredParam/responses/followup-request.json
+++ b/payloads/snapshots/toolChoiceRequiredParam/responses/followup-request.json
@@ -1,0 +1,51 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Tokyo weather"
+    },
+    {
+      "id": "rs_053fea6d108a617e006967e27263ac81a0a9158e161cb9ec28",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "fc_053fea6d108a617e006967e27895b081a0bf97756b2f5e96b1",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"location\":\"Tokyo, Japan\"}",
+      "call_id": "call_4Zx8kwz2y8nCCNHDpVpNONhx",
+      "name": "get_weather"
+    },
+    {
+      "type": "function_call_output",
+      "call_id": "call_4Zx8kwz2y8nCCNHDpVpNONhx",
+      "output": "71 degrees"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "name": "get_weather",
+      "description": "Get weather",
+      "strict": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "location"
+        ],
+        "additionalProperties": false
+      }
+    }
+  ],
+  "tool_choice": {
+    "type": "function",
+    "name": "get_weather"
+  }
+}

--- a/payloads/snapshots/toolChoiceRequiredParam/responses/followup-response.json
+++ b/payloads/snapshots/toolChoiceRequiredParam/responses/followup-response.json
@@ -1,0 +1,113 @@
+{
+  "id": "resp_053fea6d108a617e006967e279193c81a084b33fa6889f1238",
+  "object": "response",
+  "created_at": 1768415865,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415873,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_053fea6d108a617e006967e279737081a0a13c92cc5b36f515",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "rs_053fea6d108a617e006967e280183081a0b5864f9192c395ce",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "rs_053fea6d108a617e006967e280fd7081a08ee33a3baab8c3bc",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "rs_053fea6d108a617e006967e2810a4081a0ae317d788a9f9374",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "rs_053fea6d108a617e006967e2812bec81a0a5a5a84fb6691d00",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "fc_053fea6d108a617e006967e28155e081a0ad82282ddb8db347",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"location\":\"Tokyo, Japan\"}",
+      "call_id": "call_r5mX4K8DkqxD9i6Ba6AhjPa4",
+      "name": "get_weather"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": {
+    "type": "function",
+    "name": "get_weather"
+  },
+  "tools": [
+    {
+      "type": "function",
+      "description": "Get weather",
+      "name": "get_weather",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "location"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 435,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 598,
+    "output_tokens_details": {
+      "reasoning_tokens": 576
+    },
+    "total_tokens": 1033
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": ""
+}

--- a/payloads/snapshots/toolChoiceRequiredParam/responses/request.json
+++ b/payloads/snapshots/toolChoiceRequiredParam/responses/request.json
@@ -1,0 +1,33 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Tokyo weather"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "name": "get_weather",
+      "description": "Get weather",
+      "strict": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "location"
+        ],
+        "additionalProperties": false
+      }
+    }
+  ],
+  "tool_choice": {
+    "type": "function",
+    "name": "get_weather"
+  }
+}

--- a/payloads/snapshots/toolChoiceRequiredParam/responses/response-streaming.json
+++ b/payloads/snapshots/toolChoiceRequiredParam/responses/response-streaming.json
@@ -1,0 +1,326 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_082c7482a7dba678006967e2a5aff48197a69d06ea70ac1ee3",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": {
+        "type": "function",
+        "name": "get_weather"
+      },
+      "tools": [
+        {
+          "type": "function",
+          "description": "Get weather",
+          "name": "get_weather",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "location"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_082c7482a7dba678006967e2a5aff48197a69d06ea70ac1ee3",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": {
+        "type": "function",
+        "name": "get_weather"
+      },
+      "tools": [
+        {
+          "type": "function",
+          "description": "Get weather",
+          "name": "get_weather",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "location"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_082c7482a7dba678006967e2a606a48197b206b46685bf2240",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_082c7482a7dba678006967e2a606a48197b206b46685bf2240",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "fc_082c7482a7dba678006967e2a8f3a88197a35758778a7ebc3e",
+      "type": "function_call",
+      "status": "in_progress",
+      "arguments": "",
+      "call_id": "call_5UbkK7PZgXxP2jQneauozPaL",
+      "name": "get_weather"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": "{\"",
+    "item_id": "fc_082c7482a7dba678006967e2a8f3a88197a35758778a7ebc3e",
+    "obfuscation": "O9lFoAPbG5Bd51",
+    "output_index": 1,
+    "sequence_number": 5
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": "location",
+    "item_id": "fc_082c7482a7dba678006967e2a8f3a88197a35758778a7ebc3e",
+    "obfuscation": "gAsvA4Ej",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": "\":\"",
+    "item_id": "fc_082c7482a7dba678006967e2a8f3a88197a35758778a7ebc3e",
+    "obfuscation": "WHhjb8BDpJcjg",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": "Tokyo",
+    "item_id": "fc_082c7482a7dba678006967e2a8f3a88197a35758778a7ebc3e",
+    "obfuscation": "ljbztBH9WNB",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "delta": "\"}",
+    "item_id": "fc_082c7482a7dba678006967e2a8f3a88197a35758778a7ebc3e",
+    "obfuscation": "ygmMYGnNNSpJEe",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.function_call_arguments.done",
+    "arguments": "{\"location\":\"Tokyo\"}",
+    "item_id": "fc_082c7482a7dba678006967e2a8f3a88197a35758778a7ebc3e",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "fc_082c7482a7dba678006967e2a8f3a88197a35758778a7ebc3e",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"location\":\"Tokyo\"}",
+      "call_id": "call_5UbkK7PZgXxP2jQneauozPaL",
+      "name": "get_weather"
+    },
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_082c7482a7dba678006967e2a5aff48197a69d06ea70ac1ee3",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415913,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_082c7482a7dba678006967e2a606a48197b206b46685bf2240",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "fc_082c7482a7dba678006967e2a8f3a88197a35758778a7ebc3e",
+          "type": "function_call",
+          "status": "completed",
+          "arguments": "{\"location\":\"Tokyo\"}",
+          "call_id": "call_5UbkK7PZgXxP2jQneauozPaL",
+          "name": "get_weather"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": {
+        "type": "function",
+        "name": "get_weather"
+      },
+      "tools": [
+        {
+          "type": "function",
+          "description": "Get weather",
+          "name": "get_weather",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "location"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 41,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 276,
+        "output_tokens_details": {
+          "reasoning_tokens": 256
+        },
+        "total_tokens": 317
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 12
+  }
+]

--- a/payloads/snapshots/toolChoiceRequiredParam/responses/response.json
+++ b/payloads/snapshots/toolChoiceRequiredParam/responses/response.json
@@ -1,0 +1,93 @@
+{
+  "id": "resp_053fea6d108a617e006967e2704a0c81a0b61937074cd2c46a",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415864,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_053fea6d108a617e006967e27263ac81a0a9158e161cb9ec28",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "fc_053fea6d108a617e006967e27895b081a0bf97756b2f5e96b1",
+      "type": "function_call",
+      "status": "completed",
+      "arguments": "{\"location\":\"Tokyo, Japan\"}",
+      "call_id": "call_4Zx8kwz2y8nCCNHDpVpNONhx",
+      "name": "get_weather"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": {
+    "type": "function",
+    "name": "get_weather"
+  },
+  "tools": [
+    {
+      "type": "function",
+      "description": "Get weather",
+      "name": "get_weather",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "location"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 41,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 342,
+    "output_tokens_details": {
+      "reasoning_tokens": 320
+    },
+    "total_tokens": 383
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": ""
+}

--- a/payloads/snapshots/truncationAutoParam/responses/followup-request.json
+++ b/payloads/snapshots/truncationAutoParam/responses/followup-request.json
@@ -1,0 +1,33 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    },
+    {
+      "id": "rs_02f1203a2a9c36a8006967e27263e8819e82352d0a6375e58e",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_02f1203a2a9c36a8006967e27593a8819e9242f4341d3310a4",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi there! How can I help today? If you’re not sure where to start, you can ask me about science, math, coding, writing, planning something, or just ask for ideas. What would you like to do?"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "truncation": "auto"
+}

--- a/payloads/snapshots/truncationAutoParam/responses/followup-response.json
+++ b/payloads/snapshots/truncationAutoParam/responses/followup-response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_02f1203a2a9c36a8006967e277124c819e8ab6c1a3a79b52b3",
+  "object": "response",
+  "created_at": 1768415863,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415879,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_02f1203a2a9c36a8006967e2775658819ea3fe849d8c58e7d7",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_02f1203a2a9c36a8006967e282d378819ea4e3d34fe8b8675a",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Nice question. To tailor it, tell me a bit about your goals and time. In the meantime, here are quick, practical options you can start with right now:\n\n- Quick productivity win (25 minutes):\n  - Pick one small task you’ve been putting off.\n  - Set a timer for 25 minutes and focus on just that task.\n  - Take a 5-minute break, repeat once or twice.\n\n- Learn something new (10–15 minutes today):\n  - Choose a topic you’re curious about and I’ll give you a mini plan (a quick article, short video, and a tiny exercise) for the next few days.\n\n- Tiny creative kick (5–10 minutes):\n  - Write a 100-word micro-story from a random prompt, or brainstorm 20 ideas for a project you care about.\n\n- Quick fitness booster (10–15 minutes):\n  - Do a 10–15 minute bodyweight workout or a brisk walk.\n\n- Organize or plan (5–15 minutes):\n  - Write down your top 3 priorities for tomorrow.\n  - Do a 2-minute tidy-up of your workspace.\n\n- Coding or tech mini-project (30 minutes max):\n  - Create a small project starter (e.g., a to-do app, a basic script) and I’ll guide you through the steps.\n\nIf you tell me:\n- What you want to focus on (productivity, learning, creativity, health, coding, etc.)\n- How much time you have\n- Any constraints or goals\n\nI’ll give you a concrete, step-by-step plan tailored to you. Want me to pick one and lay out a quick plan?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "auto",
+  "usage": {
+    "input_tokens": 70,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1366,
+    "output_tokens_details": {
+      "reasoning_tokens": 1024
+    },
+    "total_tokens": 1436
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Nice question. To tailor it, tell me a bit about your goals and time. In the meantime, here are quick, practical options you can start with right now:\n\n- Quick productivity win (25 minutes):\n  - Pick one small task you’ve been putting off.\n  - Set a timer for 25 minutes and focus on just that task.\n  - Take a 5-minute break, repeat once or twice.\n\n- Learn something new (10–15 minutes today):\n  - Choose a topic you’re curious about and I’ll give you a mini plan (a quick article, short video, and a tiny exercise) for the next few days.\n\n- Tiny creative kick (5–10 minutes):\n  - Write a 100-word micro-story from a random prompt, or brainstorm 20 ideas for a project you care about.\n\n- Quick fitness booster (10–15 minutes):\n  - Do a 10–15 minute bodyweight workout or a brisk walk.\n\n- Organize or plan (5–15 minutes):\n  - Write down your top 3 priorities for tomorrow.\n  - Do a 2-minute tidy-up of your workspace.\n\n- Coding or tech mini-project (30 minutes max):\n  - Create a small project starter (e.g., a to-do app, a basic script) and I’ll guide you through the steps.\n\nIf you tell me:\n- What you want to focus on (productivity, learning, creativity, health, coding, etc.)\n- How much time you have\n- Any constraints or goals\n\nI’ll give you a concrete, step-by-step plan tailored to you. Want me to pick one and lay out a quick plan?"
+}

--- a/payloads/snapshots/truncationAutoParam/responses/request.json
+++ b/payloads/snapshots/truncationAutoParam/responses/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Hi"
+    }
+  ],
+  "truncation": "auto"
+}

--- a/payloads/snapshots/truncationAutoParam/responses/response-streaming.json
+++ b/payloads/snapshots/truncationAutoParam/responses/response-streaming.json
@@ -1,0 +1,879 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0498576ac1017b7a006967e2a5abfc819eacf314679eeccba4",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "auto",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0498576ac1017b7a006967e2a5abfc819eacf314679eeccba4",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "auto",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0498576ac1017b7a006967e2a5ecf8819ebb1fdf74c6881ab2",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0498576ac1017b7a006967e2a5ecf8819ebb1fdf74c6881ab2",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Hi",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "k23c6yC1ppc4lH",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " there",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "0gkAOHr0tn",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "!",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "ssDuKngBSgrrM5H",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " How",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "DT3YTZNw37Lp",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "eC5Mt017EPwU",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "wPSUy5Eb2BieA1",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " help",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "z8NlkN0nZqy",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " today",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "BYMGMxvT76",
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "?",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "g4RdxejIO9mtkRD",
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "K9wyMos6VyQrQC",
+    "output_index": 1,
+    "sequence_number": 15
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "CFW2miWxV4gY",
+    "output_index": 1,
+    "sequence_number": 16
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " explain",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "cjSzXwvW",
+    "output_index": 1,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " topics",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "7cASrr65X",
+    "output_index": 1,
+    "sequence_number": 18
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "2bSVR86yDyUZUNQ",
+    "output_index": 1,
+    "sequence_number": 19
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " answer",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "giXw0nURA",
+    "output_index": 1,
+    "sequence_number": 20
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " questions",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "VFMh7y",
+    "output_index": 1,
+    "sequence_number": 21
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "UFirWexOlIjpvbi",
+    "output_index": 1,
+    "sequence_number": 22
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " help",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "VuOExkLsmGs",
+    "output_index": 1,
+    "sequence_number": 23
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " with",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "mQhCKucntef",
+    "output_index": 1,
+    "sequence_number": 24
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " writing",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "ipnbppvS",
+    "output_index": 1,
+    "sequence_number": 25
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "LLCuMZJEqC1cq",
+    "output_index": 1,
+    "sequence_number": 26
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " coding",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "N9vV1Mq6c",
+    "output_index": 1,
+    "sequence_number": 27
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "As6vt7lAmI87CyV",
+    "output_index": 1,
+    "sequence_number": 28
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " do",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "075pbSrBpKtci",
+    "output_index": 1,
+    "sequence_number": 29
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " math",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "YDG01ERDuYr",
+    "output_index": 1,
+    "sequence_number": 30
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "zUoGLWrzA3XhdnR",
+    "output_index": 1,
+    "sequence_number": 31
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " translate",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "baYLif",
+    "output_index": 1,
+    "sequence_number": 32
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "aIY0UZNeqSA5X9K",
+    "output_index": 1,
+    "sequence_number": 33
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " brainstorm",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "dGFBa",
+    "output_index": 1,
+    "sequence_number": 34
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ideas",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "w7XReZyWJ3",
+    "output_index": 1,
+    "sequence_number": 35
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "L4jliRugnrY6uQO",
+    "output_index": 1,
+    "sequence_number": 36
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "f1xhHunzOi5sE",
+    "output_index": 1,
+    "sequence_number": 37
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " plan",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "w3LDYJsfOME",
+    "output_index": 1,
+    "sequence_number": 38
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " things",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "CheR4U4lT",
+    "output_index": 1,
+    "sequence_number": 39
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "3RaOKXrJiaIDPZk",
+    "output_index": 1,
+    "sequence_number": 40
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " If",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "GPpuJoNFdfJdb",
+    "output_index": 1,
+    "sequence_number": 41
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "cg20WwlC6Da2",
+    "output_index": 1,
+    "sequence_number": 42
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’re",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "LbMALGkGXuXYt",
+    "output_index": 1,
+    "sequence_number": 43
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " not",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "WBGvD32ldboR",
+    "output_index": 1,
+    "sequence_number": 44
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " sure",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "CEB2nrJk8NL",
+    "output_index": 1,
+    "sequence_number": 45
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "l32pVnuxynrRbag",
+    "output_index": 1,
+    "sequence_number": 46
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " tell",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "XTjPwibxJCN",
+    "output_index": 1,
+    "sequence_number": 47
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " me",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "0ThhCACkZifhe",
+    "output_index": 1,
+    "sequence_number": 48
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " what",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "0S11Q9p0YWd",
+    "output_index": 1,
+    "sequence_number": 49
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "f2zKWJV1I7Br",
+    "output_index": 1,
+    "sequence_number": 50
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’re",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "TyuU24uYo8JkF",
+    "output_index": 1,
+    "sequence_number": 51
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " working",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "WF7iHrre",
+    "output_index": 1,
+    "sequence_number": 52
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " on",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "ue96MvxikQBXk",
+    "output_index": 1,
+    "sequence_number": 53
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "SLalujTkSVO4i",
+    "output_index": 1,
+    "sequence_number": 54
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " give",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "e6bbVNXD749",
+    "output_index": 1,
+    "sequence_number": 55
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " me",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "yl0Q9pizkQh96",
+    "output_index": 1,
+    "sequence_number": 56
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "ANCweQHj70o2BR",
+    "output_index": 1,
+    "sequence_number": 57
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " quick",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "qHBiDBn6hP",
+    "output_index": 1,
+    "sequence_number": 58
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " task",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "Z7cO5YHJ7Ub",
+    "output_index": 1,
+    "sequence_number": 59
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "hEshVmrRkzte4Cz",
+    "output_index": 1,
+    "sequence_number": 60
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "JI3oCZ7UHsNM",
+    "output_index": 1,
+    "sequence_number": 61
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "NB53MmrOEy57uG",
+    "output_index": 1,
+    "sequence_number": 62
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’ll",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "KaNxiMtbEq0Wp",
+    "output_index": 1,
+    "sequence_number": 63
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " jump",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "3Y4956fizPM",
+    "output_index": 1,
+    "sequence_number": 64
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " right",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "tgjgM5YpyL",
+    "output_index": 1,
+    "sequence_number": 65
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " in",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "HdC4DCcPq1n6D",
+    "output_index": 1,
+    "sequence_number": 66
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "obfuscation": "LS7uA96X2Y2mkLW",
+    "output_index": 1,
+    "sequence_number": 67
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 68,
+    "text": "Hi there! How can I help today? I can explain topics, answer questions, help with writing or coding, do math, translate, brainstorm ideas, or plan things. If you’re not sure, tell me what you’re working on or give me a quick task, and I’ll jump right in."
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "Hi there! How can I help today? I can explain topics, answer questions, help with writing or coding, do math, translate, brainstorm ideas, or plan things. If you’re not sure, tell me what you’re working on or give me a quick task, and I’ll jump right in."
+    },
+    "sequence_number": 69
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi there! How can I help today? I can explain topics, answer questions, help with writing or coding, do math, translate, brainstorm ideas, or plan things. If you’re not sure, tell me what you’re working on or give me a quick task, and I’ll jump right in."
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 70
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0498576ac1017b7a006967e2a5abfc819eacf314679eeccba4",
+      "object": "response",
+      "created_at": 1768415909,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768415913,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_0498576ac1017b7a006967e2a5ecf8819ebb1fdf74c6881ab2",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_0498576ac1017b7a006967e2a94964819e8c05dca9e07b5eda",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "Hi there! How can I help today? I can explain topics, answer questions, help with writing or coding, do math, translate, brainstorm ideas, or plan things. If you’re not sure, tell me what you’re working on or give me a quick task, and I’ll jump right in."
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "auto",
+      "usage": {
+        "input_tokens": 7,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 324,
+        "output_tokens_details": {
+          "reasoning_tokens": 256
+        },
+        "total_tokens": 331
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 71
+  }
+]

--- a/payloads/snapshots/truncationAutoParam/responses/response.json
+++ b/payloads/snapshots/truncationAutoParam/responses/response.json
@@ -1,0 +1,77 @@
+{
+  "id": "resp_02f1203a2a9c36a8006967e270546c819ea3ccf40a296b2157",
+  "object": "response",
+  "created_at": 1768415856,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768415862,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_02f1203a2a9c36a8006967e27263e8819e82352d0a6375e58e",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_02f1203a2a9c36a8006967e27593a8819e9242f4341d3310a4",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Hi there! How can I help today? If you’re not sure where to start, you can ask me about science, math, coding, writing, planning something, or just ask for ideas. What would you like to do?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "auto",
+  "usage": {
+    "input_tokens": 7,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 245,
+    "output_tokens_details": {
+      "reasoning_tokens": 192
+    },
+    "total_tokens": 252
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Hi there! How can I help today? If you’re not sure where to start, you can ask me about science, math, coding, writing, planning something, or just ask for ideas. What would you like to do?"
+}

--- a/payloads/snapshots/webSearchToolParam/responses/followup-request.json
+++ b/payloads/snapshots/webSearchToolParam/responses/followup-request.json
@@ -1,0 +1,259 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Latest OpenAI news"
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e394060c8195a483b810bf58f033",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e396195c819585bc281f374b8fcb",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "OpenAI latest news January 2026",
+          "OpenAI news 2026 2025 2024",
+          "OpenAI announces 2026 product",
+          "GPT-5 OpenAI 2026"
+        ],
+        "query": "OpenAI latest news January 2026"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3976de881959ac5d9233a3f2aaf",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e39d7b948195bf179ece164b18b5",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "ChatGPT Atlas OpenAI announced October 21 2025",
+          "OpenAI Atlas browser OpenAI 2025"
+        ],
+        "query": "ChatGPT Atlas OpenAI announced October 21 2025"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e39eaacc8195bd016f19e269ac21",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e39fcc508195982baa2520401ae2",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-gpt-5/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3a1484c819581b0494b5e7ad36b",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3a1c3d481958e85b835f25a75bb",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-chatgpt-atlas/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3a3d424819593e14fc80b4a6264",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3a44c04819588874160899d6d53",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-gpt-5/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3a55a008195af23172b50158d8d",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3a5d6308195832b3e396a964d71",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/openai-for-healthcare/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3a6e5908195b57c9b52e5b4f1c8",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3a771248195b1d4768566394f5e",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-chatgpt-health/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3a867248195826def79169b8ed8",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3aa082881958d4e0873f9395be1",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-gpt-5-2/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3ab13d48195b2e6e85eb56a6a4b",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3ada2788195b5cb5aabbc02d169",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/developers-can-now-submit-apps-to-chatgpt/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3af12d48195909feb2c53c1140a",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3b07c448195a8ff30b0c8beff2b",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "Introducing GPT-5.2 Codex OpenAI December 18 2025",
+          "GPT-5.2 Codex OpenAI page"
+        ],
+        "query": "Introducing GPT-5.2 Codex OpenAI December 18 2025"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3b47da481958c04ae1aec201446",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3b6eabc81959c75bd521dc7a87d",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "OpenAI January 2026 news ChatGPT Health",
+          "OpenAI 2026 January press release"
+        ],
+        "query": "OpenAI January 2026 news ChatGPT Health"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3b9a5688195aad294d78a59d9b9",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_013f459640bf1f2f006967e3c49e048195b8195339d330e4dc",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [
+            {
+              "type": "url_citation",
+              "end_index": 438,
+              "start_index": 375,
+              "title": "Introducing OpenAI for Healthcare | OpenAI",
+              "url": "https://openai.com/index/openai-for-healthcare/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 804,
+              "start_index": 736,
+              "title": "Introducing ChatGPT Health | OpenAI",
+              "url": "https://openai.com/index/introducing-chatgpt-health/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1086,
+              "start_index": 1019,
+              "title": "Introducing ChatGPT Atlas | OpenAI",
+              "url": "https://openai.com/index/introducing-chatgpt-atlas/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1444,
+              "start_index": 1304,
+              "title": "OpenAI ramps up developer push with more powerful models in its API  | TechCrunch",
+              "url": "https://techcrunch.com/2025/10/06/openai-ramps-up-developer-push-with-more-powerful-models-in-its-api/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1759,
+              "start_index": 1698,
+              "title": "Introducing GPT-5.2 | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5-2/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 2071,
+              "start_index": 1986,
+              "title": "Introducing GPT-5.2-Codex | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 2433,
+              "start_index": 2293,
+              "title": "OpenAI launches GPT-5.2 after 'code red' push to counter Google's Gemini 3",
+              "url": "https://www.reuters.com/technology/openai-launches-gpt-52-ai-model-with-improved-capabilities-2025-12-11/?utm_source=openai"
+            }
+          ],
+          "logprobs": [],
+          "text": "Here are the most recent OpenAI news and product updates, with exact dates for clarity:\n\n- January 8, 2026: OpenAI for Healthcare launches. A suite of HIPAA-compliant, enterprise-grade health products, including ChatGPT for Healthcare and an OpenAI API for healthcare workflows. This is aimed at helping healthcare organizations scale high-quality care while protecting PHI. ([openai.com](https://openai.com/index/openai-for-healthcare/))\n\n- January 7, 2026: ChatGPT Health debuts. A dedicated health space in ChatGPT that securely connects health data (medical records and wellness apps like Apple Health, MyFitnessPal, Function, etc.) to ground conversations in health context, with strong privacy controls and a waitlist for access. ([openai.com](https://openai.com/index/introducing-chatgpt-health/))\n\n- October 21, 2025: Introducing ChatGPT Atlas. OpenAI’s new AI-powered web browser built with ChatGPT at its core, featuring agent mode and browser memories. Atlas lands first on macOS for Free/Plus/Pro/Go users. ([openai.com](https://openai.com/index/introducing-chatgpt-atlas/))\n\n- October 6, 2025: OpenAI Dev Day updates for developers. Announced GPT-5 Pro, Sora 2 (video generation), a cheaper voice model, and new agent-focused tooling to build apps in ChatGPT and elsewhere in the ecosystem. ([techcrunch.com](https://techcrunch.com/2025/10/06/openai-ramps-up-developer-push-with-more-powerful-models-in-its-api/?utm_source=openai))\n\n- December 11, 2025: GPT-5.2 released. The latest GPT-5 family upgrade focused on professional knowledge work—improved long-context handling, tool use, coding, and reliability. Available in ChatGPT (Instant/Thinking/Pro) and in the API for developers. ([openai.com](https://openai.com/index/introducing-gpt-5-2/))\n\n- December 18, 2025: GPT-5.2-Codex released. A Codex-optimized variant of GPT‑5.2 for agentic coding and real-world software engineering, with stronger cybersecurity capabilities and better performance in long-horizon tasks. ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n\n- Related context (December 2025): Disney announced a major investment tied to OpenAI capabilities and partnerships around Sora and related tech. This underscores industry interest in OpenAI’s evolving models and tools. ([reuters.com](https://www.reuters.com/technology/openai-launches-gpt-52-ai-model-with-improved-capabilities-2025-12-11/?utm_source=openai))\n\nWant me to pull direct links to each item or summarize what these updates mean for developers, healthcare, or consumer users? I can also add more headlines from other outlets (Reuters, TechCrunch, The Verge) if you’d like."
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "tools": [
+    {
+      "type": "web_search_preview"
+    }
+  ]
+}

--- a/payloads/snapshots/webSearchToolParam/responses/followup-response.json
+++ b/payloads/snapshots/webSearchToolParam/responses/followup-response.json
@@ -1,0 +1,190 @@
+{
+  "id": "resp_013f459640bf1f2f006967e3c9e8ec8195b07aa0b5f99d8d99",
+  "object": "response",
+  "created_at": 1768416201,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768416243,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_013f459640bf1f2f006967e3ca75308195afb2d3674a0202b5",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3d840748195983f67db334b2dec",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "OpenAI for Healthcare January 8 2026 site:openai.com",
+          "Introducing ChatGPT Health January 7 2026 site:openai.com",
+          "Introducing ChatGPT Atlas October 21 2025 site:openai.com",
+          "OpenAI Dev Day October 6 2025 site:openai.com",
+          "GPT-5.2 December 11 2025 site:openai.com",
+          "GPT-5.2-Codex December 18 2025 site:openai.com",
+          "Disney investment OpenAI December 2025 Reuters"
+        ],
+        "query": "OpenAI for Healthcare January 8 2026 site:openai.com"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3db7730819592962330540d58b4",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_013f459640bf1f2f006967e3e6ffd081958430116d44d3e3e6",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [
+            {
+              "type": "url_citation",
+              "end_index": 426,
+              "start_index": 341,
+              "title": "Introducing GPT-5.2-Codex | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 653,
+              "start_index": 571,
+              "title": "Introducing OpenAI for Healthcare | OpenAI",
+              "url": "https://openai.com/index/openai-for-healthcare//?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 861,
+              "start_index": 776,
+              "title": "Introducing GPT-5.2-Codex | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1077,
+              "start_index": 992,
+              "title": "Introducing GPT-5.2-Codex | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1267,
+              "start_index": 1181,
+              "title": "Introducing ChatGPT Atlas | OpenAI",
+              "url": "https://openai.com/index/introducing-chatgpt-atlas//?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1459,
+              "start_index": 1377,
+              "title": "OpenAI DevDay is back and bigger than ever | OpenAI",
+              "url": "https://openai.com/index/announcing-devday-2025/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1726,
+              "start_index": 1569,
+              "title": "Disney to invest $1 billion in OpenAI, license characters for Sora video tool",
+              "url": "https://www.reuters.com/business/media-telecom/disney-makes-1-billion-investment-openai-brings-characters-sora-2025-12-11/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 2283,
+              "start_index": 2198,
+              "title": "Introducing GPT-5.2-Codex | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 2558,
+              "start_index": 2473,
+              "title": "Introducing GPT-5.2-Codex | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 3034,
+              "start_index": 2952,
+              "title": "Introducing OpenAI for Healthcare | OpenAI",
+              "url": "https://openai.com/index/openai-for-healthcare//?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 3662,
+              "start_index": 3576,
+              "title": "Introducing ChatGPT Atlas | OpenAI",
+              "url": "https://openai.com/index/introducing-chatgpt-atlas//?utm_source=openai"
+            }
+          ],
+          "logprobs": [],
+          "text": "Short answer: here are concrete next steps you can take now, plus a quick recap of the very latest OpenAI moves (dates exact so you’re not guessing).\n\nWhat happened recently (as of Jan 14, 2026)\n- Jan 7, 2026 — ChatGPT Health launches (health-focused space with private health data handling). See the related OpenAI Health page for details. ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n- Jan 8, 2026 — OpenAI for Healthcare announced (HIPAA-compliant, enterprise health products including ChatGPT for Healthcare and API support). ([openai.com](https://openai.com/index/openai-for-healthcare//?utm_source=openai))\n- Dec 11, 2025 — GPT-5.2 released (general upgrade for professional knowledge work; long-context, tool use, reliability). ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n- Dec 18, 2025 — GPT-5.2-Codex released (Codex-optimized for agentic coding and cybersecurity; strong long-horizon capabilities). ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n- Oct 21, 2025 — Introducing ChatGPT Atlas (AI-powered web browser with ChatGPT; agent mode previews). ([openai.com](https://openai.com/index/introducing-chatgpt-atlas//?utm_source=openai))\n- Oct 6, 2025 — OpenAI Dev Day updates (new developer-focused tools, incl. GPT-5 Pro and new agent tooling). ([openai.com](https://openai.com/index/announcing-devday-2025/?utm_source=openai))\n- Dec 11, 2025 — Disney announced a $1B investment with OpenAI tied to Sora video and broader collaboration. ([reuters.com](https://www.reuters.com/business/media-telecom/disney-makes-1-billion-investment-openai-brings-characters-sora-2025-12-11/?utm_source=openai))\n\nWhat you should do next (tailored by role)\n- If you’re a developer or product builder\n  - Action: check your access to GPT-5.2 and GPT‑5.2 Codex in the OpenAI API; review the new Codex system card for safety and usage rules. Then run a small pilot project (e.g., a coding assistant or a tool that uses long-context reasoning).\n  - Why now: GPT-5.2 and Codex bring longer context, better tool use, and stronger cybersecurity controls—great for production-like workflows. ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n  - Next steps to do this week: read the GPT-5.2 release notes, try a small coding task with Codex, and experiment with agent-mode tasks in Atlas if you’re already using the Atlas preview. ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n\n- If you’re in healthcare or deploying health tech\n  - Action: evaluate OpenAI for Healthcare for your org, start a compliance/pHI-handling checklist, and consider a limited pilot with non-PHI data first, then plan PHI workflows compliant with HIPAA.\n  - Why now: OpenAI has launched HIPAA-friendly healthcare offerings and an API for healthcare workflows, with real hospital adopters cited. ([openai.com](https://openai.com/index/openai-for-healthcare//?utm_source=openai))\n  - Next steps: sign up for the healthcare program, map patient data flows, and coordinate with your privacy/compliance leads.\n\n- If you’re a business leader or enterprise customer\n  - Action: explore Atlas for knowledge-work automation (and its agent mode) and consider partnerships around Sora/Codex capabilities. Also assess the business impact of the OpenAI-Disney collaboration on content and IP workflows.\n  - Why now: Atlas enables in-browser agent actions; there are high-profile enterprise use cases and ongoing ecosystem activity. ([openai.com](https://openai.com/index/introducing-chatgpt-atlas//?utm_source=openai))\n  - Next steps: set up a small cross-functional pilot (e.g., research briefing automation or rapid prototyping of internal knowledge briefs) and reach out to OpenAI’s enterprise team for a pilot/match.\n\n- If you just want a quick knowledge update and don’t want to dive deep yet\n  - Action: pick one item that matters to you (healthcare, coding, or a browser/tooling use case) and skim the official pages to get a sense of capabilities and constraints. I can pull the exact docs and a 1-page plan for you.\n\nQuick plan for a 2-week run (easy to adapt)\n- Day 1–2: choose your focus (developer tooling, healthcare, business efficiency) and confirm access (GPT-5.2, Codex, Atlas, or OpenAI for Healthcare).\n- Day 3–7: run a small pilot aligned to your focus (e.g., a coding task with Codex, a healthcare data workflow mock, or an Atlas-assisted research task).\n- Day 8–12: measure outcomes (speed, accuracy, risk factors), document safeguards and data handling.\n- Day 13–14: decide on a broader rollout, timeline, and any policy/compliance steps needed.\n\nWould you like me to:\n- pull direct links to each official OpenAI page (for GPT-5.2, GPT-5.2-Codex, Atlas, and OpenAI for Healthcare) plus key press coverage, so you can read the primary docs?\n- tailor a step-by-step 14-day plan for your exact role (developer, healthcare, or business) with concrete tasks and checklists? \n\nTell me which track fits you best (developer, healthcare/enterprise, business, or general user), and I’ll customize a compact, date-stamped plan and pull the exact official docs for you."
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "web_search_preview",
+      "search_context_size": "medium",
+      "user_location": {
+        "type": "approximate",
+        "city": null,
+        "country": "US",
+        "region": null,
+        "timezone": null
+      }
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 11348,
+    "input_tokens_details": {
+      "cached_tokens": 4096
+    },
+    "output_tokens": 4077,
+    "output_tokens_details": {
+      "reasoning_tokens": 2880
+    },
+    "total_tokens": 15425
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Short answer: here are concrete next steps you can take now, plus a quick recap of the very latest OpenAI moves (dates exact so you’re not guessing).\n\nWhat happened recently (as of Jan 14, 2026)\n- Jan 7, 2026 — ChatGPT Health launches (health-focused space with private health data handling). See the related OpenAI Health page for details. ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n- Jan 8, 2026 — OpenAI for Healthcare announced (HIPAA-compliant, enterprise health products including ChatGPT for Healthcare and API support). ([openai.com](https://openai.com/index/openai-for-healthcare//?utm_source=openai))\n- Dec 11, 2025 — GPT-5.2 released (general upgrade for professional knowledge work; long-context, tool use, reliability). ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n- Dec 18, 2025 — GPT-5.2-Codex released (Codex-optimized for agentic coding and cybersecurity; strong long-horizon capabilities). ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n- Oct 21, 2025 — Introducing ChatGPT Atlas (AI-powered web browser with ChatGPT; agent mode previews). ([openai.com](https://openai.com/index/introducing-chatgpt-atlas//?utm_source=openai))\n- Oct 6, 2025 — OpenAI Dev Day updates (new developer-focused tools, incl. GPT-5 Pro and new agent tooling). ([openai.com](https://openai.com/index/announcing-devday-2025/?utm_source=openai))\n- Dec 11, 2025 — Disney announced a $1B investment with OpenAI tied to Sora video and broader collaboration. ([reuters.com](https://www.reuters.com/business/media-telecom/disney-makes-1-billion-investment-openai-brings-characters-sora-2025-12-11/?utm_source=openai))\n\nWhat you should do next (tailored by role)\n- If you’re a developer or product builder\n  - Action: check your access to GPT-5.2 and GPT‑5.2 Codex in the OpenAI API; review the new Codex system card for safety and usage rules. Then run a small pilot project (e.g., a coding assistant or a tool that uses long-context reasoning).\n  - Why now: GPT-5.2 and Codex bring longer context, better tool use, and stronger cybersecurity controls—great for production-like workflows. ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n  - Next steps to do this week: read the GPT-5.2 release notes, try a small coding task with Codex, and experiment with agent-mode tasks in Atlas if you’re already using the Atlas preview. ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n\n- If you’re in healthcare or deploying health tech\n  - Action: evaluate OpenAI for Healthcare for your org, start a compliance/pHI-handling checklist, and consider a limited pilot with non-PHI data first, then plan PHI workflows compliant with HIPAA.\n  - Why now: OpenAI has launched HIPAA-friendly healthcare offerings and an API for healthcare workflows, with real hospital adopters cited. ([openai.com](https://openai.com/index/openai-for-healthcare//?utm_source=openai))\n  - Next steps: sign up for the healthcare program, map patient data flows, and coordinate with your privacy/compliance leads.\n\n- If you’re a business leader or enterprise customer\n  - Action: explore Atlas for knowledge-work automation (and its agent mode) and consider partnerships around Sora/Codex capabilities. Also assess the business impact of the OpenAI-Disney collaboration on content and IP workflows.\n  - Why now: Atlas enables in-browser agent actions; there are high-profile enterprise use cases and ongoing ecosystem activity. ([openai.com](https://openai.com/index/introducing-chatgpt-atlas//?utm_source=openai))\n  - Next steps: set up a small cross-functional pilot (e.g., research briefing automation or rapid prototyping of internal knowledge briefs) and reach out to OpenAI’s enterprise team for a pilot/match.\n\n- If you just want a quick knowledge update and don’t want to dive deep yet\n  - Action: pick one item that matters to you (healthcare, coding, or a browser/tooling use case) and skim the official pages to get a sense of capabilities and constraints. I can pull the exact docs and a 1-page plan for you.\n\nQuick plan for a 2-week run (easy to adapt)\n- Day 1–2: choose your focus (developer tooling, healthcare, business efficiency) and confirm access (GPT-5.2, Codex, Atlas, or OpenAI for Healthcare).\n- Day 3–7: run a small pilot aligned to your focus (e.g., a coding task with Codex, a healthcare data workflow mock, or an Atlas-assisted research task).\n- Day 8–12: measure outcomes (speed, accuracy, risk factors), document safeguards and data handling.\n- Day 13–14: decide on a broader rollout, timeline, and any policy/compliance steps needed.\n\nWould you like me to:\n- pull direct links to each official OpenAI page (for GPT-5.2, GPT-5.2-Codex, Atlas, and OpenAI for Healthcare) plus key press coverage, so you can read the primary docs?\n- tailor a step-by-step 14-day plan for your exact role (developer, healthcare, or business) with concrete tasks and checklists? \n\nTell me which track fits you best (developer, healthcare/enterprise, business, or general user), and I’ll customize a compact, date-stamped plan and pull the exact official docs for you."
+}

--- a/payloads/snapshots/webSearchToolParam/responses/request.json
+++ b/payloads/snapshots/webSearchToolParam/responses/request.json
@@ -1,0 +1,14 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Latest OpenAI news"
+    }
+  ],
+  "tools": [
+    {
+      "type": "web_search_preview"
+    }
+  ]
+}

--- a/payloads/snapshots/webSearchToolParam/responses/response-streaming.json
+++ b/payloads/snapshots/webSearchToolParam/responses/response-streaming.json
@@ -1,0 +1,2424 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0a86a18275d7aaf3006967e3fbe9dc819097e0917662fe54eb",
+      "object": "response",
+      "created_at": 1768416251,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "web_search_preview",
+          "search_context_size": "medium",
+          "user_location": {
+            "type": "approximate",
+            "city": null,
+            "country": "US",
+            "region": null,
+            "timezone": null
+          }
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0a86a18275d7aaf3006967e3fbe9dc819097e0917662fe54eb",
+      "object": "response",
+      "created_at": 1768416251,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "web_search_preview",
+          "search_context_size": "medium",
+          "user_location": {
+            "type": "approximate",
+            "city": null,
+            "country": "US",
+            "region": null,
+            "timezone": null
+          }
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e3fc405881908cfc72c15fea8d78",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e3fc405881908cfc72c15fea8d78",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e3fded688190a711ffc89c13f032",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e3fded688190a711ffc89c13f032",
+    "output_index": 1,
+    "sequence_number": 5
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e3fded688190a711ffc89c13f032",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e3fded688190a711ffc89c13f032",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e3fded688190a711ffc89c13f032",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "OpenAI news January 2026",
+          "OpenAI GPT-5 release 2026",
+          "OpenAI latest news 2025 2026"
+        ],
+        "query": "OpenAI news January 2026"
+      }
+    },
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e3ff4ea08190ba716f4d08512909",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 2,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e3ff4ea08190ba716f4d08512909",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 2,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e403721881908712839cfe3a5807",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 3,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e403721881908712839cfe3a5807",
+    "output_index": 3,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e403721881908712839cfe3a5807",
+    "output_index": 3,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e403721881908712839cfe3a5807",
+    "output_index": 3,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e403721881908712839cfe3a5807",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-gpt-5/"
+      }
+    },
+    "output_index": 3,
+    "sequence_number": 15
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e40420f0819094865532f62ef541",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 4,
+    "sequence_number": 16
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e40420f0819094865532f62ef541",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 4,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e407a7948190bdd4dbfa816d7fb9",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 5,
+    "sequence_number": 18
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e407a7948190bdd4dbfa816d7fb9",
+    "output_index": 5,
+    "sequence_number": 19
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e407a7948190bdd4dbfa816d7fb9",
+    "output_index": 5,
+    "sequence_number": 20
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e407a7948190bdd4dbfa816d7fb9",
+    "output_index": 5,
+    "sequence_number": 21
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e407a7948190bdd4dbfa816d7fb9",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch"
+      }
+    },
+    "output_index": 5,
+    "sequence_number": 22
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e40841e0819083be75cc41fb9955",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 6,
+    "sequence_number": 23
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e40841e0819083be75cc41fb9955",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 6,
+    "sequence_number": 24
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e408b45c81908dca676198988b09",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 7,
+    "sequence_number": 25
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e408b45c81908dca676198988b09",
+    "output_index": 7,
+    "sequence_number": 26
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e408b45c81908dca676198988b09",
+    "output_index": 7,
+    "sequence_number": 27
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e408b45c81908dca676198988b09",
+    "output_index": 7,
+    "sequence_number": 28
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e408b45c81908dca676198988b09",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/"
+      }
+    },
+    "output_index": 7,
+    "sequence_number": 29
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e409bd808190bc030959ca632674",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 8,
+    "sequence_number": 30
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e409bd808190bc030959ca632674",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 8,
+    "sequence_number": 31
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e40a322481909225984468831289",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 9,
+    "sequence_number": 32
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e40a322481909225984468831289",
+    "output_index": 9,
+    "sequence_number": 33
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e40a322481909225984468831289",
+    "output_index": 9,
+    "sequence_number": 34
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e40a322481909225984468831289",
+    "output_index": 9,
+    "sequence_number": 35
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e40a322481909225984468831289",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1"
+      }
+    },
+    "output_index": 9,
+    "sequence_number": 36
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e40b2c3081908846ecadc35c80aa",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 10,
+    "sequence_number": 37
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e40b2c3081908846ecadc35c80aa",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 10,
+    "sequence_number": 38
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e40bcda08190baef1553eefece2e",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 11,
+    "sequence_number": 39
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e40bcda08190baef1553eefece2e",
+    "output_index": 11,
+    "sequence_number": 40
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e40bcda08190baef1553eefece2e",
+    "output_index": 11,
+    "sequence_number": 41
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e40bcda08190baef1553eefece2e",
+    "output_index": 11,
+    "sequence_number": 42
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e40bcda08190baef1553eefece2e",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php"
+      }
+    },
+    "output_index": 11,
+    "sequence_number": 43
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e40cbc488190847bf704dd4c0aca",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 12,
+    "sequence_number": 44
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e40cbc488190847bf704dd4c0aca",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 12,
+    "sequence_number": 45
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e40d331c8190a1da1bba74eb1ca8",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 13,
+    "sequence_number": 46
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e40d331c8190a1da1bba74eb1ca8",
+    "output_index": 13,
+    "sequence_number": 47
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e40d331c8190a1da1bba74eb1ca8",
+    "output_index": 13,
+    "sequence_number": 48
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e40d331c8190a1da1bba74eb1ca8",
+    "output_index": 13,
+    "sequence_number": 49
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e40d331c8190a1da1bba74eb1ca8",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-gpt-5/"
+      }
+    },
+    "output_index": 13,
+    "sequence_number": 50
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e40e2a308190b5852e4ab6040a86",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 14,
+    "sequence_number": 51
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e40e2a308190b5852e4ab6040a86",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 14,
+    "sequence_number": 52
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e40e9ee08190bacaa336f5812caa",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 15,
+    "sequence_number": 53
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e40e9ee08190bacaa336f5812caa",
+    "output_index": 15,
+    "sequence_number": 54
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e40e9ee08190bacaa336f5812caa",
+    "output_index": 15,
+    "sequence_number": 55
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e40e9ee08190bacaa336f5812caa",
+    "output_index": 15,
+    "sequence_number": 56
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e40e9ee08190bacaa336f5812caa",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "OpenAI ChatGPT Health January 7 2026 OpenAI",
+          "Introducing OpenAI for Healthcare January 8 2026"
+        ],
+        "query": "OpenAI ChatGPT Health January 7 2026 OpenAI"
+      }
+    },
+    "output_index": 15,
+    "sequence_number": 57
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e41129ac8190bd2d4de7ad86bf08",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 16,
+    "sequence_number": 58
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e41129ac8190bd2d4de7ad86bf08",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 16,
+    "sequence_number": 59
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e411ee20819084f82a410d07b7f1",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 17,
+    "sequence_number": 60
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e411ee20819084f82a410d07b7f1",
+    "output_index": 17,
+    "sequence_number": 61
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e411ee20819084f82a410d07b7f1",
+    "output_index": 17,
+    "sequence_number": 62
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e411ee20819084f82a410d07b7f1",
+    "output_index": 17,
+    "sequence_number": 63
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e411ee20819084f82a410d07b7f1",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/openai-for-healthcare//"
+      }
+    },
+    "output_index": 17,
+    "sequence_number": 64
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e412e3248190b3670365447ead5e",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 18,
+    "sequence_number": 65
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e412e3248190b3670365447ead5e",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 18,
+    "sequence_number": 66
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e413d35c8190a1849cb87f656330",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 19,
+    "sequence_number": 67
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e413d35c8190a1849cb87f656330",
+    "output_index": 19,
+    "sequence_number": 68
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e413d35c8190a1849cb87f656330",
+    "output_index": 19,
+    "sequence_number": 69
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e413d35c8190a1849cb87f656330",
+    "output_index": 19,
+    "sequence_number": 70
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e413d35c8190a1849cb87f656330",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/"
+      }
+    },
+    "output_index": 19,
+    "sequence_number": 71
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e414cfe4819095d18627857b606e",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 20,
+    "sequence_number": 72
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e414cfe4819095d18627857b606e",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 20,
+    "sequence_number": 73
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e41670b08190aa0d977cc674a53c",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 21,
+    "sequence_number": 74
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e41670b08190aa0d977cc674a53c",
+    "output_index": 21,
+    "sequence_number": 75
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e41670b08190aa0d977cc674a53c",
+    "output_index": 21,
+    "sequence_number": 76
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e41670b08190aa0d977cc674a53c",
+    "output_index": 21,
+    "sequence_number": 77
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e41670b08190aa0d977cc674a53c",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "Musk Altman OpenAI trial 2026 date April 27 2026 Reuters",
+          "OpenAI legal case Musk Altman update January 2026"
+        ],
+        "query": "Musk Altman OpenAI trial 2026 date April 27 2026 Reuters"
+      }
+    },
+    "output_index": 21,
+    "sequence_number": 78
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e41980b4819086e018affa69061f",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 22,
+    "sequence_number": 79
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e41980b4819086e018affa69061f",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 22,
+    "sequence_number": 80
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e41a62f88190ae4340aa9b2eb714",
+      "type": "web_search_call",
+      "status": "in_progress"
+    },
+    "output_index": 23,
+    "sequence_number": 81
+  },
+  {
+    "type": "response.web_search_call.in_progress",
+    "item_id": "ws_0a86a18275d7aaf3006967e41a62f88190ae4340aa9b2eb714",
+    "output_index": 23,
+    "sequence_number": 82
+  },
+  {
+    "type": "response.web_search_call.searching",
+    "item_id": "ws_0a86a18275d7aaf3006967e41a62f88190ae4340aa9b2eb714",
+    "output_index": 23,
+    "sequence_number": 83
+  },
+  {
+    "type": "response.web_search_call.completed",
+    "item_id": "ws_0a86a18275d7aaf3006967e41a62f88190ae4340aa9b2eb714",
+    "output_index": 23,
+    "sequence_number": 84
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "ws_0a86a18275d7aaf3006967e41a62f88190ae4340aa9b2eb714",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-gpt-5-2/"
+      }
+    },
+    "output_index": 23,
+    "sequence_number": 85
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e41b8a908190a7ccd9361afc9c8f",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 24,
+    "sequence_number": 86
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0a86a18275d7aaf3006967e41b8a908190a7ccd9361afc9c8f",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 24,
+    "sequence_number": 87
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 25,
+    "sequence_number": 88
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "output_index": 25,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 89
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Here are the latest OpenAI news items, with",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "s7t3R",
+    "output_index": 25,
+    "sequence_number": 90
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " exact dates, so you have a clear timeline",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "7wmqXY",
+    "output_index": 25,
+    "sequence_number": 91
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (all as of January 14, ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "MjhG2kUx",
+    "output_index": 25,
+    "sequence_number": 92
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "2026 in the United States):\n\n-",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "B3",
+    "output_index": 25,
+    "sequence_number": 93
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Jan 7, 2026 — Open",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "zLTmHmqhWwSaG",
+    "output_index": 25,
+    "sequence_number": 94
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "AI launches ChatGPT Health\n  -",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "Vl",
+    "output_index": 25,
+    "sequence_number": 95
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " A dedicated health space in ChatGPT",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "k2Tu4P8AMlU9",
+    "output_index": 25,
+    "sequence_number": 96
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " that lets users upload medical records and connect wellness",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "kwXc",
+    "output_index": 25,
+    "sequence_number": 97
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " apps (e.g., Apple Health, My",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "qCh",
+    "output_index": 25,
+    "sequence_number": 98
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "FitnessPal). Health",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "TckcNqwCszutU",
+    "output_index": 25,
+    "sequence_number": 99
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " conversations are isolated from general Chat",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "Bro",
+    "output_index": 25,
+    "sequence_number": 100
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "GPT chats and are not used to train the",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "KReTzijpc",
+    "output_index": 25,
+    "sequence_number": 101
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " base models. Initial access is",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "4",
+    "output_index": 25,
+    "sequence_number": 102
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " limited via a waitlist, with broader rollout",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "vM5",
+    "output_index": 25,
+    "sequence_number": 103
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " planned in the coming weeks. ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "qu",
+    "output_index": 25,
+    "sequence_number": 104
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "([reuters.com](https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/)",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "mO0c",
+    "output_index": 25,
+    "sequence_number": 105
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ")\n\n- Jan 8, 202",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "4",
+    "output_index": 25,
+    "sequence_number": 106
+  },
+  {
+    "type": "response.output_text.annotation.added",
+    "annotation": {
+      "type": "url_citation",
+      "end_index": 679,
+      "start_index": 522,
+      "title": "OpenAI launches ChatGPT Health to connect medical records, wellness apps | Reuters",
+      "url": "https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/"
+    },
+    "annotation_index": 0,
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "output_index": 25,
+    "sequence_number": 107
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "6 — OpenAI introduces OpenAI",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "Q64s",
+    "output_index": 25,
+    "sequence_number": 108
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " for Healthcare\n  - A portfolio of",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "5fghiwxdgPrvAG",
+    "output_index": 25,
+    "sequence_number": 109
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " healthcare offerings, including ChatGPT for Healthcare",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "Fp0z0NpkE",
+    "output_index": 25,
+    "sequence_number": 110
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and an API for healthcare workflows, designed to",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "Xgx6VRt5GbYXhJV",
+    "output_index": 25,
+    "sequence_number": 111
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " support HIPAA-compliant deployment in institutions.",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "MOdKPNVN97fx",
+    "output_index": 25,
+    "sequence_number": 112
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Early hospital partners are listed (e.g.,",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "sR3hwl",
+    "output_index": 25,
+    "sequence_number": 113
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " AdventHealth, Stanford, UCSF, Mayo",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "AWooJR8EDWg87",
+    "output_index": 25,
+    "sequence_number": 114
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-like institutions). ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "W9S1tLqMWLz",
+    "output_index": 25,
+    "sequence_number": 115
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "([openai.com](https://openai.com/index/openai-for-healthcare//))\n",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "UIST0cm1xpEk01K",
+    "output_index": 25,
+    "sequence_number": 116
+  },
+  {
+    "type": "response.output_text.annotation.added",
+    "annotation": {
+      "type": "url_citation",
+      "end_index": 1073,
+      "start_index": 1009,
+      "title": "Introducing OpenAI for Healthcare | OpenAI",
+      "url": "https://openai.com/index/openai-for-healthcare//"
+    },
+    "annotation_index": 1,
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "output_index": 25,
+    "sequence_number": 117
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n- Jan 12, 2026 —",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "HGKOuzG8JIM8l4s",
+    "output_index": 25,
+    "sequence_number": 118
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " OpenAI acquires Torch (health tech",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "oMEsJ2UZknpvD",
+    "output_index": 25,
+    "sequence_number": 119
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ")\n  - OpenAI announced it has",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "6dW",
+    "output_index": 25,
+    "sequence_number": 120
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " acquired Torch, a startup that integrates lab results",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "G0QIwGdPjS",
+    "output_index": 25,
+    "sequence_number": 121
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ", medications and visit records, in",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "KDwdvhcoHTUcz",
+    "output_index": 25,
+    "sequence_number": 122
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a deal reportedly valued at",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "qab4",
+    "output_index": 25,
+    "sequence_number": 123
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " about $",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "YNKD11xg",
+    "output_index": 25,
+    "sequence_number": 124
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "100 million in equity.",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "UmbQSyBZBY",
+    "output_index": 25,
+    "sequence_number": 125
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " This signals OpenAI’s push to monetize",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "qwjUcx2rq",
+    "output_index": 25,
+    "sequence_number": 126
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " healthcare workflows",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "MPtBoik1ky3",
+    "output_index": 25,
+    "sequence_number": 127
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "N4ZCmNxm74QGsKw",
+    "output_index": 25,
+    "sequence_number": 128
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "Ppl09Dr7WIxzoTA",
+    "output_index": 25,
+    "sequence_number": 129
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "([axios.com](https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch))\n\n- Jan 8–9,",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "4CeA9dnhtHh",
+    "output_index": 25,
+    "sequence_number": 130
+  },
+  {
+    "type": "response.output_text.annotation.added",
+    "annotation": {
+      "type": "url_citation",
+      "end_index": 1453,
+      "start_index": 1364,
+      "title": "OpenAI acquires health tech company Torch",
+      "url": "https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch"
+    },
+    "annotation_index": 2,
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "output_index": 25,
+    "sequence_number": 131
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " 2026 — OpenAI eyes a bigger",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "QkmC",
+    "output_index": 25,
+    "sequence_number": 132
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " San Francisco footprint\n  - OpenAI",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "3PJjQFzV6TcUS",
+    "output_index": 25,
+    "sequence_number": 133
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " is in talks to sublease 200",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "68Kt",
+    "output_index": 25,
+    "sequence_number": 134
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",000–250,000 sq",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "t",
+    "output_index": 25,
+    "sequence_number": 135
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ft at 1800 Owens St.",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "YwMliNXwtkZ",
+    "output_index": 25,
+    "sequence_number": 136
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " in Mission Bay, potentially pushing its SF footprint",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "rRfBAuPvI4t",
+    "output_index": 25,
+    "sequence_number": 137
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " to about 1 million sq ft. No",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "i8F",
+    "output_index": 25,
+    "sequence_number": 138
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " deal is closed yet. ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "vj3aMDb4f7T",
+    "output_index": 25,
+    "sequence_number": 139
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "([sfchronicle.com](https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php))\n\n- Jan 7",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "b6Z",
+    "output_index": 25,
+    "sequence_number": 140
+  },
+  {
+    "type": "response.output_text.annotation.added",
+    "annotation": {
+      "type": "url_citation",
+      "end_index": 1795,
+      "start_index": 1695,
+      "title": "OpenAI in talks to expand San Francisco office footprint",
+      "url": "https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php"
+    },
+    "annotation_index": 3,
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "output_index": 25,
+    "sequence_number": 141
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "–8, 2026 — Musk",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "V",
+    "output_index": 25,
+    "sequence_number": 142
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " v. Altman: trial date",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "ZLkosewRWo",
+    "output_index": 25,
+    "sequence_number": 143
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " set\n  - A federal judge ruled Elon",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "nmu4rXE7UhOyO",
+    "output_index": 25,
+    "sequence_number": 144
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Musk’s lawsuit against OpenAI can proceed",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "RZz15f",
+    "output_index": 25,
+    "sequence_number": 145
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " to a jury trial. Jury selection is",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "5FY4ijTr7IeyQ",
+    "output_index": 25,
+    "sequence_number": 146
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " slated for April 27, 2026",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "HztWe2",
+    "output_index": 25,
+    "sequence_number": 147
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ", with the trial running potentially through May",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "",
+    "output_index": 25,
+    "sequence_number": 148
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " 22, 2026 (previous",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "2darJaISSz66X",
+    "output_index": 25,
+    "sequence_number": 149
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " March 30",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "l8G76XX",
+    "output_index": 25,
+    "sequence_number": 150
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " date canceled).",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "",
+    "output_index": 25,
+    "sequence_number": 151
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "RMfqWVDyAdsKmBO",
+    "output_index": 25,
+    "sequence_number": 152
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "([reuters.com](https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/))\n  - Additional",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "",
+    "output_index": 25,
+    "sequence_number": 153
+  },
+  {
+    "type": "response.output_text.annotation.added",
+    "annotation": {
+      "type": "url_citation",
+      "end_index": 2217,
+      "start_index": 2072,
+      "title": "Musk lawsuit over OpenAI for-profit conversion can head to trial, US judge says | Reuters",
+      "url": "https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/"
+    },
+    "annotation_index": 4,
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "output_index": 25,
+    "sequence_number": 154
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " reporting confirms the spring 2026",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "jZgmREyHBoNYe",
+    "output_index": 25,
+    "sequence_number": 155
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " jury trial window (April–May ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "1L",
+    "output_index": 25,
+    "sequence_number": 156
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "2026) as the plan moving forward.",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "bzbVzYA7BAIXcw2",
+    "output_index": 25,
+    "sequence_number": 157
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "FqUYdCz5KHacZNw",
+    "output_index": 25,
+    "sequence_number": 158
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "([businessinsider.com](https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1))\n\n- Background context — recent Open",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "esyM9cpA5AXlRrE",
+    "output_index": 25,
+    "sequence_number": 159
+  },
+  {
+    "type": "response.output_text.annotation.added",
+    "annotation": {
+      "type": "url_citation",
+      "end_index": 2424,
+      "start_index": 2331,
+      "title": "Judge Sets New Trial Date for Musk Vs Altman - Business Insider",
+      "url": "https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1"
+    },
+    "annotation_index": 5,
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "output_index": 25,
+    "sequence_number": 160
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "AI model updates\n  - GPT-",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "Fo4QppL",
+    "output_index": 25,
+    "sequence_number": 161
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "5 was introduced by OpenAI on August ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "MYc7wdTvEJi",
+    "output_index": 25,
+    "sequence_number": 162
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "7, 2025, described",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "t52TAieIAMlG4R",
+    "output_index": 25,
+    "sequence_number": 163
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " as their most",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "nz",
+    "output_index": 25,
+    "sequence_number": 164
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " capable model at the time, with a unified",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "PtBnFj",
+    "output_index": 25,
+    "sequence_number": 165
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " system and expanded capabilities.",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "F8BPTUXVv5KxGY",
+    "output_index": 25,
+    "sequence_number": 166
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "yDfMOaFaH9Ts6Md",
+    "output_index": 25,
+    "sequence_number": 167
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "([openai.com](https://openai.com/index/introducing-gpt-5/))\n  - GPT-5.",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "n8PGXZ14CC",
+    "output_index": 25,
+    "sequence_number": 168
+  },
+  {
+    "type": "response.output_text.annotation.added",
+    "annotation": {
+      "type": "url_citation",
+      "end_index": 2690,
+      "start_index": 2631,
+      "title": "Introducing GPT-5 | OpenAI",
+      "url": "https://openai.com/index/introducing-gpt-5/"
+    },
+    "annotation_index": 6,
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "output_index": 25,
+    "sequence_number": 169
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "2, a follow-up focused on",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "vlmSeIK",
+    "output_index": 25,
+    "sequence_number": 170
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " professional knowledge work",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "xO3Y",
+    "output_index": 25,
+    "sequence_number": 171
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and longer",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "TYDy2",
+    "output_index": 25,
+    "sequence_number": 172
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " contexts, was",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "vg",
+    "output_index": 25,
+    "sequence_number": 173
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " announced December ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "QzK5tnpYRMrR",
+    "output_index": 25,
+    "sequence_number": 174
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "11, ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "C6yXJm8u63gA",
+    "output_index": 25,
+    "sequence_number": 175
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "2025, with enhanced coding,",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "DHQoM",
+    "output_index": 25,
+    "sequence_number": 176
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " spreadsheets/presentations, and",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "",
+    "output_index": 25,
+    "sequence_number": 177
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " long-context reasoning; it’s available in",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "sVKBvb",
+    "output_index": 25,
+    "sequence_number": 178
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ChatGPT Enterprise and to API users.",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "yKazbtDD5nW",
+    "output_index": 25,
+    "sequence_number": 179
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "yaybnIqiJLeoRsD",
+    "output_index": 25,
+    "sequence_number": 180
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "([openai.com](https://openai.com/index/introducing-gpt-5-2/))\n\nWant deeper details on any",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "wCUJfva",
+    "output_index": 25,
+    "sequence_number": 181
+  },
+  {
+    "type": "response.output_text.annotation.added",
+    "annotation": {
+      "type": "url_citation",
+      "end_index": 3003,
+      "start_index": 2942,
+      "title": "Introducing GPT-5.2 | OpenAI",
+      "url": "https://openai.com/index/introducing-gpt-5-2/"
+    },
+    "annotation_index": 7,
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "output_index": 25,
+    "sequence_number": 182
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " single item (e.g., how",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "Pt8jgeiOc",
+    "output_index": 25,
+    "sequence_number": 183
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ChatGPT Health handles data privacy, or the legal",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "ym41eQzleibpMT",
+    "output_index": 25,
+    "sequence_number": 184
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " case timeline), or should I pull more",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "vsDIn86m1B",
+    "output_index": 25,
+    "sequence_number": 185
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " sources for a broader roundup (investor",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "W8MXztIO",
+    "output_index": 25,
+    "sequence_number": 186
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " angle, market reactions, etc.)?",
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "obfuscation": "",
+    "output_index": 25,
+    "sequence_number": 187
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "logprobs": [],
+    "output_index": 25,
+    "sequence_number": 188,
+    "text": "Here are the latest OpenAI news items, with exact dates, so you have a clear timeline (all as of January 14, 2026 in the United States):\n\n- Jan 7, 2026 — OpenAI launches ChatGPT Health\n  - A dedicated health space in ChatGPT that lets users upload medical records and connect wellness apps (e.g., Apple Health, MyFitnessPal). Health conversations are isolated from general ChatGPT chats and are not used to train the base models. Initial access is limited via a waitlist, with broader rollout planned in the coming weeks. ([reuters.com](https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/))\n\n- Jan 8, 2026 — OpenAI introduces OpenAI for Healthcare\n  - A portfolio of healthcare offerings, including ChatGPT for Healthcare and an API for healthcare workflows, designed to support HIPAA-compliant deployment in institutions. Early hospital partners are listed (e.g., AdventHealth, Stanford, UCSF, Mayo-like institutions). ([openai.com](https://openai.com/index/openai-for-healthcare//))\n\n- Jan 12, 2026 — OpenAI acquires Torch (health tech)\n  - OpenAI announced it has acquired Torch, a startup that integrates lab results, medications and visit records, in a deal reportedly valued at about $100 million in equity. This signals OpenAI’s push to monetize healthcare workflows. ([axios.com](https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch))\n\n- Jan 8–9, 2026 — OpenAI eyes a bigger San Francisco footprint\n  - OpenAI is in talks to sublease 200,000–250,000 sq ft at 1800 Owens St. in Mission Bay, potentially pushing its SF footprint to about 1 million sq ft. No deal is closed yet. ([sfchronicle.com](https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php))\n\n- Jan 7–8, 2026 — Musk v. Altman: trial date set\n  - A federal judge ruled Elon Musk’s lawsuit against OpenAI can proceed to a jury trial. Jury selection is slated for April 27, 2026, with the trial running potentially through May 22, 2026 (previous March 30 date canceled). ([reuters.com](https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/))\n  - Additional reporting confirms the spring 2026 jury trial window (April–May 2026) as the plan moving forward. ([businessinsider.com](https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1))\n\n- Background context — recent OpenAI model updates\n  - GPT-5 was introduced by OpenAI on August 7, 2025, described as their most capable model at the time, with a unified system and expanded capabilities. ([openai.com](https://openai.com/index/introducing-gpt-5/))\n  - GPT-5.2, a follow-up focused on professional knowledge work and longer contexts, was announced December 11, 2025, with enhanced coding, spreadsheets/presentations, and long-context reasoning; it’s available in ChatGPT Enterprise and to API users. ([openai.com](https://openai.com/index/introducing-gpt-5-2/))\n\nWant deeper details on any single item (e.g., how ChatGPT Health handles data privacy, or the legal case timeline), or should I pull more sources for a broader roundup (investor angle, market reactions, etc.)?"
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+    "output_index": 25,
+    "part": {
+      "type": "output_text",
+      "annotations": [
+        {
+          "type": "url_citation",
+          "end_index": 679,
+          "start_index": 522,
+          "title": "OpenAI launches ChatGPT Health to connect medical records, wellness apps | Reuters",
+          "url": "https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/"
+        },
+        {
+          "type": "url_citation",
+          "end_index": 1073,
+          "start_index": 1009,
+          "title": "Introducing OpenAI for Healthcare | OpenAI",
+          "url": "https://openai.com/index/openai-for-healthcare//"
+        },
+        {
+          "type": "url_citation",
+          "end_index": 1453,
+          "start_index": 1364,
+          "title": "OpenAI acquires health tech company Torch",
+          "url": "https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch"
+        },
+        {
+          "type": "url_citation",
+          "end_index": 1795,
+          "start_index": 1695,
+          "title": "OpenAI in talks to expand San Francisco office footprint",
+          "url": "https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php"
+        },
+        {
+          "type": "url_citation",
+          "end_index": 2217,
+          "start_index": 2072,
+          "title": "Musk lawsuit over OpenAI for-profit conversion can head to trial, US judge says | Reuters",
+          "url": "https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/"
+        },
+        {
+          "type": "url_citation",
+          "end_index": 2424,
+          "start_index": 2331,
+          "title": "Judge Sets New Trial Date for Musk Vs Altman - Business Insider",
+          "url": "https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1"
+        },
+        {
+          "type": "url_citation",
+          "end_index": 2690,
+          "start_index": 2631,
+          "title": "Introducing GPT-5 | OpenAI",
+          "url": "https://openai.com/index/introducing-gpt-5/"
+        },
+        {
+          "type": "url_citation",
+          "end_index": 3003,
+          "start_index": 2942,
+          "title": "Introducing GPT-5.2 | OpenAI",
+          "url": "https://openai.com/index/introducing-gpt-5-2/"
+        }
+      ],
+      "logprobs": [],
+      "text": "Here are the latest OpenAI news items, with exact dates, so you have a clear timeline (all as of January 14, 2026 in the United States):\n\n- Jan 7, 2026 — OpenAI launches ChatGPT Health\n  - A dedicated health space in ChatGPT that lets users upload medical records and connect wellness apps (e.g., Apple Health, MyFitnessPal). Health conversations are isolated from general ChatGPT chats and are not used to train the base models. Initial access is limited via a waitlist, with broader rollout planned in the coming weeks. ([reuters.com](https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/))\n\n- Jan 8, 2026 — OpenAI introduces OpenAI for Healthcare\n  - A portfolio of healthcare offerings, including ChatGPT for Healthcare and an API for healthcare workflows, designed to support HIPAA-compliant deployment in institutions. Early hospital partners are listed (e.g., AdventHealth, Stanford, UCSF, Mayo-like institutions). ([openai.com](https://openai.com/index/openai-for-healthcare//))\n\n- Jan 12, 2026 — OpenAI acquires Torch (health tech)\n  - OpenAI announced it has acquired Torch, a startup that integrates lab results, medications and visit records, in a deal reportedly valued at about $100 million in equity. This signals OpenAI’s push to monetize healthcare workflows. ([axios.com](https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch))\n\n- Jan 8–9, 2026 — OpenAI eyes a bigger San Francisco footprint\n  - OpenAI is in talks to sublease 200,000–250,000 sq ft at 1800 Owens St. in Mission Bay, potentially pushing its SF footprint to about 1 million sq ft. No deal is closed yet. ([sfchronicle.com](https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php))\n\n- Jan 7–8, 2026 — Musk v. Altman: trial date set\n  - A federal judge ruled Elon Musk’s lawsuit against OpenAI can proceed to a jury trial. Jury selection is slated for April 27, 2026, with the trial running potentially through May 22, 2026 (previous March 30 date canceled). ([reuters.com](https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/))\n  - Additional reporting confirms the spring 2026 jury trial window (April–May 2026) as the plan moving forward. ([businessinsider.com](https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1))\n\n- Background context — recent OpenAI model updates\n  - GPT-5 was introduced by OpenAI on August 7, 2025, described as their most capable model at the time, with a unified system and expanded capabilities. ([openai.com](https://openai.com/index/introducing-gpt-5/))\n  - GPT-5.2, a follow-up focused on professional knowledge work and longer contexts, was announced December 11, 2025, with enhanced coding, spreadsheets/presentations, and long-context reasoning; it’s available in ChatGPT Enterprise and to API users. ([openai.com](https://openai.com/index/introducing-gpt-5-2/))\n\nWant deeper details on any single item (e.g., how ChatGPT Health handles data privacy, or the legal case timeline), or should I pull more sources for a broader roundup (investor angle, market reactions, etc.)?"
+    },
+    "sequence_number": 189
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [
+            {
+              "type": "url_citation",
+              "end_index": 679,
+              "start_index": 522,
+              "title": "OpenAI launches ChatGPT Health to connect medical records, wellness apps | Reuters",
+              "url": "https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1073,
+              "start_index": 1009,
+              "title": "Introducing OpenAI for Healthcare | OpenAI",
+              "url": "https://openai.com/index/openai-for-healthcare//"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1453,
+              "start_index": 1364,
+              "title": "OpenAI acquires health tech company Torch",
+              "url": "https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1795,
+              "start_index": 1695,
+              "title": "OpenAI in talks to expand San Francisco office footprint",
+              "url": "https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 2217,
+              "start_index": 2072,
+              "title": "Musk lawsuit over OpenAI for-profit conversion can head to trial, US judge says | Reuters",
+              "url": "https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 2424,
+              "start_index": 2331,
+              "title": "Judge Sets New Trial Date for Musk Vs Altman - Business Insider",
+              "url": "https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 2690,
+              "start_index": 2631,
+              "title": "Introducing GPT-5 | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 3003,
+              "start_index": 2942,
+              "title": "Introducing GPT-5.2 | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5-2/"
+            }
+          ],
+          "logprobs": [],
+          "text": "Here are the latest OpenAI news items, with exact dates, so you have a clear timeline (all as of January 14, 2026 in the United States):\n\n- Jan 7, 2026 — OpenAI launches ChatGPT Health\n  - A dedicated health space in ChatGPT that lets users upload medical records and connect wellness apps (e.g., Apple Health, MyFitnessPal). Health conversations are isolated from general ChatGPT chats and are not used to train the base models. Initial access is limited via a waitlist, with broader rollout planned in the coming weeks. ([reuters.com](https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/))\n\n- Jan 8, 2026 — OpenAI introduces OpenAI for Healthcare\n  - A portfolio of healthcare offerings, including ChatGPT for Healthcare and an API for healthcare workflows, designed to support HIPAA-compliant deployment in institutions. Early hospital partners are listed (e.g., AdventHealth, Stanford, UCSF, Mayo-like institutions). ([openai.com](https://openai.com/index/openai-for-healthcare//))\n\n- Jan 12, 2026 — OpenAI acquires Torch (health tech)\n  - OpenAI announced it has acquired Torch, a startup that integrates lab results, medications and visit records, in a deal reportedly valued at about $100 million in equity. This signals OpenAI’s push to monetize healthcare workflows. ([axios.com](https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch))\n\n- Jan 8–9, 2026 — OpenAI eyes a bigger San Francisco footprint\n  - OpenAI is in talks to sublease 200,000–250,000 sq ft at 1800 Owens St. in Mission Bay, potentially pushing its SF footprint to about 1 million sq ft. No deal is closed yet. ([sfchronicle.com](https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php))\n\n- Jan 7–8, 2026 — Musk v. Altman: trial date set\n  - A federal judge ruled Elon Musk’s lawsuit against OpenAI can proceed to a jury trial. Jury selection is slated for April 27, 2026, with the trial running potentially through May 22, 2026 (previous March 30 date canceled). ([reuters.com](https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/))\n  - Additional reporting confirms the spring 2026 jury trial window (April–May 2026) as the plan moving forward. ([businessinsider.com](https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1))\n\n- Background context — recent OpenAI model updates\n  - GPT-5 was introduced by OpenAI on August 7, 2025, described as their most capable model at the time, with a unified system and expanded capabilities. ([openai.com](https://openai.com/index/introducing-gpt-5/))\n  - GPT-5.2, a follow-up focused on professional knowledge work and longer contexts, was announced December 11, 2025, with enhanced coding, spreadsheets/presentations, and long-context reasoning; it’s available in ChatGPT Enterprise and to API users. ([openai.com](https://openai.com/index/introducing-gpt-5-2/))\n\nWant deeper details on any single item (e.g., how ChatGPT Health handles data privacy, or the legal case timeline), or should I pull more sources for a broader roundup (investor angle, market reactions, etc.)?"
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 25,
+    "sequence_number": 190
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0a86a18275d7aaf3006967e3fbe9dc819097e0917662fe54eb",
+      "object": "response",
+      "created_at": 1768416251,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1768416311,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "output": [
+        {
+          "id": "rs_0a86a18275d7aaf3006967e3fc405881908cfc72c15fea8d78",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e3fded688190a711ffc89c13f032",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "search",
+            "queries": [
+              "OpenAI news January 2026",
+              "OpenAI GPT-5 release 2026",
+              "OpenAI latest news 2025 2026"
+            ],
+            "query": "OpenAI news January 2026"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e3ff4ea08190ba716f4d08512909",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e403721881908712839cfe3a5807",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "open_page",
+            "url": "https://openai.com/index/introducing-gpt-5/"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e40420f0819094865532f62ef541",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e407a7948190bdd4dbfa816d7fb9",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "open_page",
+            "url": "https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e40841e0819083be75cc41fb9955",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e408b45c81908dca676198988b09",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "open_page",
+            "url": "https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e409bd808190bc030959ca632674",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e40a322481909225984468831289",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "open_page",
+            "url": "https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e40b2c3081908846ecadc35c80aa",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e40bcda08190baef1553eefece2e",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "open_page",
+            "url": "https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e40cbc488190847bf704dd4c0aca",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e40d331c8190a1da1bba74eb1ca8",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "open_page",
+            "url": "https://openai.com/index/introducing-gpt-5/"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e40e2a308190b5852e4ab6040a86",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e40e9ee08190bacaa336f5812caa",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "search",
+            "queries": [
+              "OpenAI ChatGPT Health January 7 2026 OpenAI",
+              "Introducing OpenAI for Healthcare January 8 2026"
+            ],
+            "query": "OpenAI ChatGPT Health January 7 2026 OpenAI"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e41129ac8190bd2d4de7ad86bf08",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e411ee20819084f82a410d07b7f1",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "open_page",
+            "url": "https://openai.com/index/openai-for-healthcare//"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e412e3248190b3670365447ead5e",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e413d35c8190a1849cb87f656330",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "open_page",
+            "url": "https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e414cfe4819095d18627857b606e",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e41670b08190aa0d977cc674a53c",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "search",
+            "queries": [
+              "Musk Altman OpenAI trial 2026 date April 27 2026 Reuters",
+              "OpenAI legal case Musk Altman update January 2026"
+            ],
+            "query": "Musk Altman OpenAI trial 2026 date April 27 2026 Reuters"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e41980b4819086e018affa69061f",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "ws_0a86a18275d7aaf3006967e41a62f88190ae4340aa9b2eb714",
+          "type": "web_search_call",
+          "status": "completed",
+          "action": {
+            "type": "open_page",
+            "url": "https://openai.com/index/introducing-gpt-5-2/"
+          }
+        },
+        {
+          "id": "rs_0a86a18275d7aaf3006967e41b8a908190a7ccd9361afc9c8f",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "msg_0a86a18275d7aaf3006967e431185481909cb7203fc0eabec3",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [
+                {
+                  "type": "url_citation",
+                  "end_index": 679,
+                  "start_index": 522,
+                  "title": "OpenAI launches ChatGPT Health to connect medical records, wellness apps | Reuters",
+                  "url": "https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/"
+                },
+                {
+                  "type": "url_citation",
+                  "end_index": 1073,
+                  "start_index": 1009,
+                  "title": "Introducing OpenAI for Healthcare | OpenAI",
+                  "url": "https://openai.com/index/openai-for-healthcare//"
+                },
+                {
+                  "type": "url_citation",
+                  "end_index": 1453,
+                  "start_index": 1364,
+                  "title": "OpenAI acquires health tech company Torch",
+                  "url": "https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch"
+                },
+                {
+                  "type": "url_citation",
+                  "end_index": 1795,
+                  "start_index": 1695,
+                  "title": "OpenAI in talks to expand San Francisco office footprint",
+                  "url": "https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php"
+                },
+                {
+                  "type": "url_citation",
+                  "end_index": 2217,
+                  "start_index": 2072,
+                  "title": "Musk lawsuit over OpenAI for-profit conversion can head to trial, US judge says | Reuters",
+                  "url": "https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/"
+                },
+                {
+                  "type": "url_citation",
+                  "end_index": 2424,
+                  "start_index": 2331,
+                  "title": "Judge Sets New Trial Date for Musk Vs Altman - Business Insider",
+                  "url": "https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1"
+                },
+                {
+                  "type": "url_citation",
+                  "end_index": 2690,
+                  "start_index": 2631,
+                  "title": "Introducing GPT-5 | OpenAI",
+                  "url": "https://openai.com/index/introducing-gpt-5/"
+                },
+                {
+                  "type": "url_citation",
+                  "end_index": 3003,
+                  "start_index": 2942,
+                  "title": "Introducing GPT-5.2 | OpenAI",
+                  "url": "https://openai.com/index/introducing-gpt-5-2/"
+                }
+              ],
+              "logprobs": [],
+              "text": "Here are the latest OpenAI news items, with exact dates, so you have a clear timeline (all as of January 14, 2026 in the United States):\n\n- Jan 7, 2026 — OpenAI launches ChatGPT Health\n  - A dedicated health space in ChatGPT that lets users upload medical records and connect wellness apps (e.g., Apple Health, MyFitnessPal). Health conversations are isolated from general ChatGPT chats and are not used to train the base models. Initial access is limited via a waitlist, with broader rollout planned in the coming weeks. ([reuters.com](https://www.reuters.com/business/healthcare-pharmaceuticals/openai-launches-chatgpt-health-connect-medical-records-wellness-apps-2026-01-07/))\n\n- Jan 8, 2026 — OpenAI introduces OpenAI for Healthcare\n  - A portfolio of healthcare offerings, including ChatGPT for Healthcare and an API for healthcare workflows, designed to support HIPAA-compliant deployment in institutions. Early hospital partners are listed (e.g., AdventHealth, Stanford, UCSF, Mayo-like institutions). ([openai.com](https://openai.com/index/openai-for-healthcare//))\n\n- Jan 12, 2026 — OpenAI acquires Torch (health tech)\n  - OpenAI announced it has acquired Torch, a startup that integrates lab results, medications and visit records, in a deal reportedly valued at about $100 million in equity. This signals OpenAI’s push to monetize healthcare workflows. ([axios.com](https://www.axios.com/2026/01/12/openai-acquires-health-tech-company-torch))\n\n- Jan 8–9, 2026 — OpenAI eyes a bigger San Francisco footprint\n  - OpenAI is in talks to sublease 200,000–250,000 sq ft at 1800 Owens St. in Mission Bay, potentially pushing its SF footprint to about 1 million sq ft. No deal is closed yet. ([sfchronicle.com](https://www.sfchronicle.com/tech/article/openai-mission-bay-office-21284023.php))\n\n- Jan 7–8, 2026 — Musk v. Altman: trial date set\n  - A federal judge ruled Elon Musk’s lawsuit against OpenAI can proceed to a jury trial. Jury selection is slated for April 27, 2026, with the trial running potentially through May 22, 2026 (previous March 30 date canceled). ([reuters.com](https://www.reuters.com/legal/litigation/musk-lawsuit-over-openai-for-profit-conversion-can-head-trial-us-judge-says-2026-01-07/))\n  - Additional reporting confirms the spring 2026 jury trial window (April–May 2026) as the plan moving forward. ([businessinsider.com](https://www.businessinsider.com/trial-date-for-musk-vs-altman-2026-1))\n\n- Background context — recent OpenAI model updates\n  - GPT-5 was introduced by OpenAI on August 7, 2025, described as their most capable model at the time, with a unified system and expanded capabilities. ([openai.com](https://openai.com/index/introducing-gpt-5/))\n  - GPT-5.2, a follow-up focused on professional knowledge work and longer contexts, was announced December 11, 2025, with enhanced coding, spreadsheets/presentations, and long-context reasoning; it’s available in ChatGPT Enterprise and to API users. ([openai.com](https://openai.com/index/introducing-gpt-5-2/))\n\nWant deeper details on any single item (e.g., how ChatGPT Health handles data privacy, or the legal case timeline), or should I pull more sources for a broader roundup (investor angle, market reactions, etc.)?"
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "web_search_preview",
+          "search_context_size": "medium",
+          "user_location": {
+            "type": "approximate",
+            "city": null,
+            "country": "US",
+            "region": null,
+            "timezone": null
+          }
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 50032,
+        "input_tokens_details": {
+          "cached_tokens": 4224
+        },
+        "output_tokens": 4737,
+        "output_tokens_details": {
+          "reasoning_tokens": 4032
+        },
+        "total_tokens": 54769
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 191
+  }
+]

--- a/payloads/snapshots/webSearchToolParam/responses/response.json
+++ b/payloads/snapshots/webSearchToolParam/responses/response.json
@@ -1,0 +1,311 @@
+{
+  "id": "resp_013f459640bf1f2f006967e3939874819590ee4d7c3417e3b0",
+  "object": "response",
+  "created_at": 1768416147,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1768416201,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "output": [
+    {
+      "id": "rs_013f459640bf1f2f006967e394060c8195a483b810bf58f033",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e396195c819585bc281f374b8fcb",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "OpenAI latest news January 2026",
+          "OpenAI news 2026 2025 2024",
+          "OpenAI announces 2026 product",
+          "GPT-5 OpenAI 2026"
+        ],
+        "query": "OpenAI latest news January 2026"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3976de881959ac5d9233a3f2aaf",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e39d7b948195bf179ece164b18b5",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "ChatGPT Atlas OpenAI announced October 21 2025",
+          "OpenAI Atlas browser OpenAI 2025"
+        ],
+        "query": "ChatGPT Atlas OpenAI announced October 21 2025"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e39eaacc8195bd016f19e269ac21",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e39fcc508195982baa2520401ae2",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-gpt-5/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3a1484c819581b0494b5e7ad36b",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3a1c3d481958e85b835f25a75bb",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-chatgpt-atlas/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3a3d424819593e14fc80b4a6264",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3a44c04819588874160899d6d53",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-gpt-5/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3a55a008195af23172b50158d8d",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3a5d6308195832b3e396a964d71",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/openai-for-healthcare/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3a6e5908195b57c9b52e5b4f1c8",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3a771248195b1d4768566394f5e",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-chatgpt-health/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3a867248195826def79169b8ed8",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3aa082881958d4e0873f9395be1",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/introducing-gpt-5-2/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3ab13d48195b2e6e85eb56a6a4b",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3ada2788195b5cb5aabbc02d169",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "open_page",
+        "url": "https://openai.com/index/developers-can-now-submit-apps-to-chatgpt/"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3af12d48195909feb2c53c1140a",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3b07c448195a8ff30b0c8beff2b",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "Introducing GPT-5.2 Codex OpenAI December 18 2025",
+          "GPT-5.2 Codex OpenAI page"
+        ],
+        "query": "Introducing GPT-5.2 Codex OpenAI December 18 2025"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3b47da481958c04ae1aec201446",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ws_013f459640bf1f2f006967e3b6eabc81959c75bd521dc7a87d",
+      "type": "web_search_call",
+      "status": "completed",
+      "action": {
+        "type": "search",
+        "queries": [
+          "OpenAI January 2026 news ChatGPT Health",
+          "OpenAI 2026 January press release"
+        ],
+        "query": "OpenAI January 2026 news ChatGPT Health"
+      }
+    },
+    {
+      "id": "rs_013f459640bf1f2f006967e3b9a5688195aad294d78a59d9b9",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_013f459640bf1f2f006967e3c49e048195b8195339d330e4dc",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [
+            {
+              "type": "url_citation",
+              "end_index": 438,
+              "start_index": 375,
+              "title": "Introducing OpenAI for Healthcare | OpenAI",
+              "url": "https://openai.com/index/openai-for-healthcare/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 804,
+              "start_index": 736,
+              "title": "Introducing ChatGPT Health | OpenAI",
+              "url": "https://openai.com/index/introducing-chatgpt-health/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1086,
+              "start_index": 1019,
+              "title": "Introducing ChatGPT Atlas | OpenAI",
+              "url": "https://openai.com/index/introducing-chatgpt-atlas/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1444,
+              "start_index": 1304,
+              "title": "OpenAI ramps up developer push with more powerful models in its API  | TechCrunch",
+              "url": "https://techcrunch.com/2025/10/06/openai-ramps-up-developer-push-with-more-powerful-models-in-its-api/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 1759,
+              "start_index": 1698,
+              "title": "Introducing GPT-5.2 | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5-2/"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 2071,
+              "start_index": 1986,
+              "title": "Introducing GPT-5.2-Codex | OpenAI",
+              "url": "https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai"
+            },
+            {
+              "type": "url_citation",
+              "end_index": 2433,
+              "start_index": 2293,
+              "title": "OpenAI launches GPT-5.2 after 'code red' push to counter Google's Gemini 3",
+              "url": "https://www.reuters.com/technology/openai-launches-gpt-52-ai-model-with-improved-capabilities-2025-12-11/?utm_source=openai"
+            }
+          ],
+          "logprobs": [],
+          "text": "Here are the most recent OpenAI news and product updates, with exact dates for clarity:\n\n- January 8, 2026: OpenAI for Healthcare launches. A suite of HIPAA-compliant, enterprise-grade health products, including ChatGPT for Healthcare and an OpenAI API for healthcare workflows. This is aimed at helping healthcare organizations scale high-quality care while protecting PHI. ([openai.com](https://openai.com/index/openai-for-healthcare/))\n\n- January 7, 2026: ChatGPT Health debuts. A dedicated health space in ChatGPT that securely connects health data (medical records and wellness apps like Apple Health, MyFitnessPal, Function, etc.) to ground conversations in health context, with strong privacy controls and a waitlist for access. ([openai.com](https://openai.com/index/introducing-chatgpt-health/))\n\n- October 21, 2025: Introducing ChatGPT Atlas. OpenAI’s new AI-powered web browser built with ChatGPT at its core, featuring agent mode and browser memories. Atlas lands first on macOS for Free/Plus/Pro/Go users. ([openai.com](https://openai.com/index/introducing-chatgpt-atlas/))\n\n- October 6, 2025: OpenAI Dev Day updates for developers. Announced GPT-5 Pro, Sora 2 (video generation), a cheaper voice model, and new agent-focused tooling to build apps in ChatGPT and elsewhere in the ecosystem. ([techcrunch.com](https://techcrunch.com/2025/10/06/openai-ramps-up-developer-push-with-more-powerful-models-in-its-api/?utm_source=openai))\n\n- December 11, 2025: GPT-5.2 released. The latest GPT-5 family upgrade focused on professional knowledge work—improved long-context handling, tool use, coding, and reliability. Available in ChatGPT (Instant/Thinking/Pro) and in the API for developers. ([openai.com](https://openai.com/index/introducing-gpt-5-2/))\n\n- December 18, 2025: GPT-5.2-Codex released. A Codex-optimized variant of GPT‑5.2 for agentic coding and real-world software engineering, with stronger cybersecurity capabilities and better performance in long-horizon tasks. ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n\n- Related context (December 2025): Disney announced a major investment tied to OpenAI capabilities and partnerships around Sora and related tech. This underscores industry interest in OpenAI’s evolving models and tools. ([reuters.com](https://www.reuters.com/technology/openai-launches-gpt-52-ai-model-with-improved-capabilities-2025-12-11/?utm_source=openai))\n\nWant me to pull direct links to each item or summarize what these updates mean for developers, healthcare, or consumer users? I can also add more headlines from other outlets (Reuters, TechCrunch, The Verge) if you’d like."
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "web_search_preview",
+      "search_context_size": "medium",
+      "user_location": {
+        "type": "approximate",
+        "city": null,
+        "country": "US",
+        "region": null,
+        "timezone": null
+      }
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 50084,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 3952,
+    "output_tokens_details": {
+      "reasoning_tokens": 3392
+    },
+    "total_tokens": 54036
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Here are the most recent OpenAI news and product updates, with exact dates for clarity:\n\n- January 8, 2026: OpenAI for Healthcare launches. A suite of HIPAA-compliant, enterprise-grade health products, including ChatGPT for Healthcare and an OpenAI API for healthcare workflows. This is aimed at helping healthcare organizations scale high-quality care while protecting PHI. ([openai.com](https://openai.com/index/openai-for-healthcare/))\n\n- January 7, 2026: ChatGPT Health debuts. A dedicated health space in ChatGPT that securely connects health data (medical records and wellness apps like Apple Health, MyFitnessPal, Function, etc.) to ground conversations in health context, with strong privacy controls and a waitlist for access. ([openai.com](https://openai.com/index/introducing-chatgpt-health/))\n\n- October 21, 2025: Introducing ChatGPT Atlas. OpenAI’s new AI-powered web browser built with ChatGPT at its core, featuring agent mode and browser memories. Atlas lands first on macOS for Free/Plus/Pro/Go users. ([openai.com](https://openai.com/index/introducing-chatgpt-atlas/))\n\n- October 6, 2025: OpenAI Dev Day updates for developers. Announced GPT-5 Pro, Sora 2 (video generation), a cheaper voice model, and new agent-focused tooling to build apps in ChatGPT and elsewhere in the ecosystem. ([techcrunch.com](https://techcrunch.com/2025/10/06/openai-ramps-up-developer-push-with-more-powerful-models-in-its-api/?utm_source=openai))\n\n- December 11, 2025: GPT-5.2 released. The latest GPT-5 family upgrade focused on professional knowledge work—improved long-context handling, tool use, coding, and reliability. Available in ChatGPT (Instant/Thinking/Pro) and in the API for developers. ([openai.com](https://openai.com/index/introducing-gpt-5-2/))\n\n- December 18, 2025: GPT-5.2-Codex released. A Codex-optimized variant of GPT‑5.2 for agentic coding and real-world software engineering, with stronger cybersecurity capabilities and better performance in long-horizon tasks. ([openai.com](https://openai.com/index/introducing-gpt-5-2-codex/?utm_source=openai))\n\n- Related context (December 2025): Disney announced a major investment tied to OpenAI capabilities and partnerships around Sora and related tech. This underscores industry interest in OpenAI’s evolving models and tools. ([reuters.com](https://www.reuters.com/technology/openai-launches-gpt-52-ai-model-with-improved-capabilities-2025-12-11/?utm_source=openai))\n\nWant me to pull direct links to each item or summarize what these updates mean for developers, healthcare, or consumer users? I can also add more headlines from other outlets (Reuters, TechCrunch, The Verge) if you’d like."
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^1.34.0
         version: 1.34.0
       openai:
-        specifier: ^5.22.0
-        version: 5.23.2(ws@8.18.3)
+        specifier: ^6.16.0
+        version: 6.16.0(ws@8.18.3)
     devDependencies:
       '@types/node':
         specifier: ^22.9.0
@@ -1897,6 +1897,18 @@ packages:
     peerDependencies:
       ws: ^8.18.0
       zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openai@6.16.0:
+    resolution: {integrity: sha512-fZ1uBqjFUjXzbGc35fFtYKEOxd20kd9fDpFeqWtsOZWiubY8CZ1NAlXHW3iathaFvqmNtCWMIsosCuyeI7Joxg==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
         optional: true
@@ -4407,6 +4419,10 @@ snapshots:
       mimic-fn: 4.0.0
 
   openai@5.23.2(ws@8.18.3):
+    optionalDependencies:
+      ws: 8.18.3
+
+  openai@6.16.0(ws@8.18.3):
     optionalDependencies:
       ws: 8.18.3
 


### PR DESCRIPTION
Add parameter test cases for openai responses with the new `params.ts` file

new test coverage, got the request body from https://platform.openai.com/docs/api-reference/responses:

| Category | Before (existing) | After (new params.ts) |
| --- | --- | --- |
| Reasoning | effort (3 values), summary | ✓ (already covered) |
| Text config | verbosity | \+ json_object, json_schema |
| Tools | function type, auto choice | \+ web_search, code_interpreter, specific choice, parallel_tool_calls |
| Context | \- | \+ instructions, truncation |
| Storage | \- | \+ store |
| Caching | \- | \+ service_tier, prompt_cache_key |
| Metadata | \- | \+ metadata, safety_identifier |

cross compatability coverage report -> https://github.com/braintrustdata/lingua/actions/runs/21009330639