### PR TITLE
add chat completion parameter test cases

### DIFF
--- a/crates/lingua/src/providers/bedrock/adapter.rs
+++ b/crates/lingua/src/providers/bedrock/adapter.rs
@@ -419,8 +419,7 @@ impl ProviderAdapter for BedrockAdapter {
         }
 
         // Check for usage-only chunk
-        if chunk.choices.is_empty() && chunk.usage.is_some() {
-            let usage = chunk.usage.as_ref().unwrap();
+        if let (true, Some(usage)) = (chunk.choices.is_empty(), &chunk.usage) {
             return Ok(serde_json::json!({
                 "metadata": {
                     "usage": {

--- a/payloads/cases/models.ts
+++ b/payloads/cases/models.ts
@@ -1,6 +1,8 @@
 // Canonical model configuration - change these to update all test cases
 export const OPENAI_CHAT_COMPLETIONS_MODEL = "gpt-5-nano";
 export const OPENAI_RESPONSES_MODEL = "gpt-5-nano";
+// For parameters not supported by reasoning models (temperature, top_p, logprobs)
+export const OPENAI_NON_REASONING_MODEL = "gpt-4o-mini";
 export const ANTHROPIC_MODEL = "claude-sonnet-4-20250514";
 export const GOOGLE_MODEL = "gemini-2.5-flash";
 export const BEDROCK_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0";

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -1,14 +1,22 @@
 import { TestCaseCollection } from "./types";
-import { OPENAI_RESPONSES_MODEL } from "./models";
+import {
+  OPENAI_CHAT_COMPLETIONS_MODEL,
+  OPENAI_RESPONSES_MODEL,
+  OPENAI_NON_REASONING_MODEL,
+} from "./models";
 
-// OpenAI Responses API parameter test cases
-// Each test case exercises specific parameters from the Responses API
+// OpenAI Responses API and Chat Completions API parameter test cases
+// Each test case exercises specific parameters with bidirectional mappings where possible
 // Note: temperature, top_p, and logprobs are not supported with reasoning models (gpt-5-nano)
 export const paramsCases: TestCaseCollection = {
   // === Reasoning Configuration ===
 
   reasoningSummaryParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [{ role: "user", content: "What is 2+2?" }],
+      reasoning_effort: "medium",
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "2+2" }],
@@ -25,7 +33,11 @@ export const paramsCases: TestCaseCollection = {
   // === Text Response Configuration ===
 
   textFormatJsonObjectParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [{ role: "user", content: 'Return {"status": "ok"} as JSON.' }],
+      response_format: { type: "json_object" },
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "Return JSON with a=1" }],
@@ -41,7 +53,31 @@ export const paramsCases: TestCaseCollection = {
   },
 
   textFormatJsonSchemaParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [
+        {
+          role: "user",
+          content: "Extract: John is 25.",
+        },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "person_info",
+          schema: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              age: { type: "number" },
+            },
+            required: ["name", "age"],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      },
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "Name: John, Age: 25" }],
@@ -99,7 +135,27 @@ export const paramsCases: TestCaseCollection = {
   },
 
   toolChoiceRequiredParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [{ role: "user", content: "Tokyo weather" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            description: "Get weather",
+            strict: true,
+            parameters: {
+              type: "object",
+              properties: { location: { type: "string" } },
+              required: ["location"],
+              additionalProperties: false,
+            },
+          },
+        },
+      ],
+      tool_choice: { type: "function", function: { name: "get_weather" } },
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "Tokyo weather" }],
@@ -127,7 +183,27 @@ export const paramsCases: TestCaseCollection = {
   },
 
   parallelToolCallsDisabledParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [{ role: "user", content: "Weather in NYC and LA?" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            description: "Get weather",
+            strict: true,
+            parameters: {
+              type: "object",
+              properties: { location: { type: "string" } },
+              required: ["location"],
+              additionalProperties: false,
+            },
+          },
+        },
+      ],
+      parallel_tool_calls: false,
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "NYC and LA weather" }],
@@ -157,7 +233,13 @@ export const paramsCases: TestCaseCollection = {
   // === Context & State Management ===
 
   instructionsParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [
+        { role: "system", content: "Always say ok." },
+        { role: "user", content: "Hi" },
+      ],
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "Hi" }],
@@ -181,7 +263,11 @@ export const paramsCases: TestCaseCollection = {
   },
 
   storeDisabledParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [{ role: "user", content: "Say ok." }],
+      store: false,
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "Hi" }],
@@ -195,7 +281,11 @@ export const paramsCases: TestCaseCollection = {
   // === Caching & Performance ===
 
   serviceTierParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [{ role: "user", content: "Say ok." }],
+      service_tier: "default",
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "Hi" }],
@@ -207,7 +297,11 @@ export const paramsCases: TestCaseCollection = {
   },
 
   promptCacheKeyParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [{ role: "user", content: "Say ok." }],
+      prompt_cache_key: "user-123-ml-explanation",
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "Hi" }],
@@ -221,7 +315,16 @@ export const paramsCases: TestCaseCollection = {
   // === Metadata & Identification ===
 
   metadataParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [{ role: "user", content: "Say ok." }],
+      store: true,
+      metadata: {
+        request_id: "req-12345",
+        user_tier: "premium",
+        experiment: "control",
+      },
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "Hi" }],
@@ -233,12 +336,165 @@ export const paramsCases: TestCaseCollection = {
   },
 
   safetyIdentifierParam: {
-    "chat-completions": null,
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [{ role: "user", content: "Say ok." }],
+      safety_identifier: "hashed-user-id-abc123",
+    },
     responses: {
       model: OPENAI_RESPONSES_MODEL,
       input: [{ role: "user", content: "Hi" }],
       safety_identifier: "test-user",
     },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  // === Sampling Parameters (require non-reasoning model) ===
+
+  temperatureParam: {
+    "chat-completions": {
+      model: OPENAI_NON_REASONING_MODEL,
+      messages: [{ role: "user", content: "Say hi." }],
+      temperature: 0.7,
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  topPParam: {
+    "chat-completions": {
+      model: OPENAI_NON_REASONING_MODEL,
+      messages: [{ role: "user", content: "Say hi." }],
+      top_p: 0.9,
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  frequencyPenaltyParam: {
+    "chat-completions": {
+      model: OPENAI_NON_REASONING_MODEL,
+      messages: [{ role: "user", content: "Say ok." }],
+      frequency_penalty: 0.5,
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  presencePenaltyParam: {
+    "chat-completions": {
+      model: OPENAI_NON_REASONING_MODEL,
+      messages: [{ role: "user", content: "Say ok." }],
+      presence_penalty: 0.5,
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  logprobsParam: {
+    "chat-completions": {
+      model: OPENAI_NON_REASONING_MODEL,
+      messages: [{ role: "user", content: "What is 2 + 2?" }],
+      logprobs: true,
+      top_logprobs: 2,
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  // === Output Control ===
+
+  nMultipleCompletionsParam: {
+    "chat-completions": {
+      model: OPENAI_NON_REASONING_MODEL,
+      messages: [{ role: "user", content: "Say a word." }],
+      n: 2,
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  stopSequencesParam: {
+    "chat-completions": {
+      model: OPENAI_NON_REASONING_MODEL,
+      messages: [{ role: "user", content: "Count from 1 to 20." }],
+      stop: ["10", "ten"],
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  maxCompletionTokensParam: {
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [{ role: "user", content: "Say ok." }],
+      max_completion_tokens: 500,
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  // === Advanced Parameters ===
+
+  predictionParam: {
+    "chat-completions": {
+      model: OPENAI_NON_REASONING_MODEL,
+      messages: [
+        {
+          role: "user",
+          content:
+            "Update this function to add error handling:\n\nfunction divide(a, b) {\n  return a / b;\n}",
+        },
+      ],
+      prediction: {
+        type: "content",
+        content:
+          "function divide(a, b) {\n  if (b === 0) {\n    throw new Error('Cannot divide by zero');\n  }\n  return a / b;\n}",
+      },
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  seedParam: {
+    "chat-completions": {
+      model: OPENAI_NON_REASONING_MODEL,
+      messages: [{ role: "user", content: "Pick a number." }],
+      seed: 12345,
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  logitBiasParam: {
+    "chat-completions": {
+      model: OPENAI_NON_REASONING_MODEL,
+      messages: [{ role: "user", content: "Say hello." }],
+      logit_bias: { "15339": -100 },
+    },
+    responses: null,
     anthropic: null,
     google: null,
     bedrock: null,

--- a/payloads/snapshots/frequencyPenaltyParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/frequencyPenaltyParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    },
+    {
+      "role": "assistant",
+      "content": "Ok!",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "frequency_penalty": 0.5
+}

--- a/payloads/snapshots/frequencyPenaltyParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/frequencyPenaltyParam/chat-completions/followup-response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz2ZRjg1ccZrJos1hmLHeTSPVeI",
+  "object": "chat.completion",
+  "created": 1768411808,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "It depends on what you're looking to do! Here are a few options:\n\n1. **Learn Something New**: Pick a topic or skill you’re interested in and look up resources to start learning.\n2. **Read a Book**: If you enjoy reading, consider picking up a book you've been wanting to dive into.\n3. **Get Creative**: Try drawing, writing, or doing some other form of art.\n4. **Exercise**: Go for a walk, do some yoga, or engage in any physical activity you enjoy.\n5. **Connect with Someone**: Reach out to a friend or family member for a chat or make plans to catch up.\n\nLet me know if you need specific advice on any of these suggestions!",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 26,
+    "completion_tokens": 149,
+    "total_tokens": 175,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/frequencyPenaltyParam/chat-completions/request.json
+++ b/payloads/snapshots/frequencyPenaltyParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    }
+  ],
+  "frequency_penalty": 0.5
+}

--- a/payloads/snapshots/frequencyPenaltyParam/chat-completions/response.json
+++ b/payloads/snapshots/frequencyPenaltyParam/chat-completions/response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz17nuQSEN515QJOstsD88quFhH",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Ok!",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 2,
+    "total_tokens": 12,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/instructionsParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/instructionsParam/chat-completions/followup-request.json
@@ -1,0 +1,23 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "system",
+      "content": "Always say ok."
+    },
+    {
+      "role": "user",
+      "content": "Hi"
+    },
+    {
+      "role": "assistant",
+      "content": "ok",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ]
+}

--- a/payloads/snapshots/instructionsParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/instructionsParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz3HUYPjFqpvWzzRPDcneBchYNT",
+  "object": "chat.completion",
+  "created": 1768411809,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "ok, I can help. What are you trying to do? If you’re not sure yet, here are general next steps you can try:\n\n- Define a clear goal and the desired outcome.\n- Break the goal into 2–5 concrete tasks or milestones.\n- Gather the resources or information you’ll need.\n- Start with the first task, set a short deadline, and begin.\n- Create a simple plan or checklist to track progress.\n- Review what you learned and adjust the plan as needed.\n\nIf you tell me your area (study, coding, writing, planning a project, etc.), I’ll tailor the steps to fit.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 32,
+    "completion_tokens": 969,
+    "total_tokens": 1001,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 832,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/instructionsParam/chat-completions/request.json
+++ b/payloads/snapshots/instructionsParam/chat-completions/request.json
@@ -1,0 +1,13 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "system",
+      "content": "Always say ok."
+    },
+    {
+      "role": "user",
+      "content": "Hi"
+    }
+  ]
+}

--- a/payloads/snapshots/instructionsParam/chat-completions/response.json
+++ b/payloads/snapshots/instructionsParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz1AvrWz7EjB9PXXLQND7YmSx0C",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "ok",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 15,
+    "completion_tokens": 138,
+    "total_tokens": 153,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 128,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/logitBiasParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/logitBiasParam/chat-completions/followup-request.json
@@ -1,0 +1,22 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say hello."
+    },
+    {
+      "role": "assistant",
+      "content": "Hello! How can I assist you today?",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "logit_bias": {
+    "15339": -100
+  }
+}

--- a/payloads/snapshots/logitBiasParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/logitBiasParam/chat-completions/followup-response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz1f2C5gMCfa1olipvvf1LMRSon",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "That depends on what you’re looking to accomplish! Here are a few suggestions based on different areas:\n\n1. **Personal Development**: Consider setting a new goal or learning a new skill.\n2. **Relaxation**: Take a break and do something enjoyable like reading a book or going for a walk.\n3. **Productivity**: Make a to-do list of tasks you need to tackle.\n4. **Socializing**: Reach out to a friend or family member for a chat.\n5. **Health**: Prepare a healthy meal or do some exercise.\n\nIf you have a specific context or interest in mind, let me know, and I can provide more tailored suggestions!",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 33,
+    "completion_tokens": 138,
+    "total_tokens": 171,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/logitBiasParam/chat-completions/request.json
+++ b/payloads/snapshots/logitBiasParam/chat-completions/request.json
@@ -1,0 +1,12 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say hello."
+    }
+  ],
+  "logit_bias": {
+    "15339": -100
+  }
+}

--- a/payloads/snapshots/logitBiasParam/chat-completions/response.json
+++ b/payloads/snapshots/logitBiasParam/chat-completions/response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz18Ne8mpjc2xVCTxWUKTJXgTTn",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hello! How can I assist you today?",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 9,
+    "total_tokens": 19,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/logprobsParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/logprobsParam/chat-completions/followup-request.json
@@ -1,0 +1,21 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is 2 + 2?"
+    },
+    {
+      "role": "assistant",
+      "content": "2 + 2 equals 4.",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "logprobs": true,
+  "top_logprobs": 2
+}

--- a/payloads/snapshots/logprobsParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/logprobsParam/chat-completions/followup-response.json
@@ -1,0 +1,5149 @@
+{
+  "id": "chatcmpl-Cxyz277gbGOjYtbe7rLkFHmNtdHHE",
+  "object": "chat.completion",
+  "created": 1768411808,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "What you should do next depends on your current situation and goals. Here are a few suggestions based on different contexts:\n\n1. **If you're working on a task:** Prioritize your tasks and focus on the most important one.\n2. **If you're taking a break:** Consider doing something relaxing like stretching, reading, or taking a walk.\n3. **If you're planning your day:** Review your to-do list and schedule any appointments or deadlines.\n4. **If you're looking for inspiration:** Read a book, watch a documentary, or explore a new hobby.\n5. **If you have a question in mind:** Feel free to ask me, and I’ll do my best to help you!\n\nLet me know if you have a specific context in mind!",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": {
+        "content": [
+          {
+            "token": "What",
+            "logprob": -0.3144475519657135,
+            "bytes": [
+              87,
+              104,
+              97,
+              116
+            ],
+            "top_logprobs": [
+              {
+                "token": "What",
+                "logprob": -0.3144475519657135,
+                "bytes": [
+                  87,
+                  104,
+                  97,
+                  116
+                ]
+              },
+              {
+                "token": "That",
+                "logprob": -1.5644475221633911,
+                "bytes": [
+                  84,
+                  104,
+                  97,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " you",
+            "logprob": -0.04877959564328194,
+            "bytes": [
+              32,
+              121,
+              111,
+              117
+            ],
+            "top_logprobs": [
+              {
+                "token": " you",
+                "logprob": -0.04877959564328194,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117
+                ]
+              },
+              {
+                "token": " to",
+                "logprob": -3.0487794876098633,
+                "bytes": [
+                  32,
+                  116,
+                  111
+                ]
+              }
+            ]
+          },
+          {
+            "token": " should",
+            "logprob": -0.3244202136993408,
+            "bytes": [
+              32,
+              115,
+              104,
+              111,
+              117,
+              108,
+              100
+            ],
+            "top_logprobs": [
+              {
+                "token": " should",
+                "logprob": -0.3244202136993408,
+                "bytes": [
+                  32,
+                  115,
+                  104,
+                  111,
+                  117,
+                  108,
+                  100
+                ]
+              },
+              {
+                "token": " do",
+                "logprob": -1.3244202136993408,
+                "bytes": [
+                  32,
+                  100,
+                  111
+                ]
+              }
+            ]
+          },
+          {
+            "token": " do",
+            "logprob": 0,
+            "bytes": [
+              32,
+              100,
+              111
+            ],
+            "top_logprobs": [
+              {
+                "token": " do",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  100,
+                  111
+                ]
+              },
+              {
+                "token": " next",
+                "logprob": -18.875,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  120,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " next",
+            "logprob": 0,
+            "bytes": [
+              32,
+              110,
+              101,
+              120,
+              116
+            ],
+            "top_logprobs": [
+              {
+                "token": " next",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  120,
+                  116
+                ]
+              },
+              {
+                "token": " depends",
+                "logprob": -17.625,
+                "bytes": [
+                  32,
+                  100,
+                  101,
+                  112,
+                  101,
+                  110,
+                  100,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": " depends",
+            "logprob": -0.002034634118899703,
+            "bytes": [
+              32,
+              100,
+              101,
+              112,
+              101,
+              110,
+              100,
+              115
+            ],
+            "top_logprobs": [
+              {
+                "token": " depends",
+                "logprob": -0.002034634118899703,
+                "bytes": [
+                  32,
+                  100,
+                  101,
+                  112,
+                  101,
+                  110,
+                  100,
+                  115
+                ]
+              },
+              {
+                "token": " really",
+                "logprob": -6.502034664154053,
+                "bytes": [
+                  32,
+                  114,
+                  101,
+                  97,
+                  108,
+                  108,
+                  121
+                ]
+              }
+            ]
+          },
+          {
+            "token": " on",
+            "logprob": -9.088346359931165e-7,
+            "bytes": [
+              32,
+              111,
+              110
+            ],
+            "top_logprobs": [
+              {
+                "token": " on",
+                "logprob": -9.088346359931165e-7,
+                "bytes": [
+                  32,
+                  111,
+                  110
+                ]
+              },
+              {
+                "token": " largely",
+                "logprob": -14.375000953674316,
+                "bytes": [
+                  32,
+                  108,
+                  97,
+                  114,
+                  103,
+                  101,
+                  108,
+                  121
+                ]
+              }
+            ]
+          },
+          {
+            "token": " your",
+            "logprob": -0.017720459029078484,
+            "bytes": [
+              32,
+              121,
+              111,
+              117,
+              114
+            ],
+            "top_logprobs": [
+              {
+                "token": " your",
+                "logprob": -0.017720459029078484,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  114
+                ]
+              },
+              {
+                "token": " what",
+                "logprob": -4.2677202224731445,
+                "bytes": [
+                  32,
+                  119,
+                  104,
+                  97,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " current",
+            "logprob": -0.4949939250946045,
+            "bytes": [
+              32,
+              99,
+              117,
+              114,
+              114,
+              101,
+              110,
+              116
+            ],
+            "top_logprobs": [
+              {
+                "token": " current",
+                "logprob": -0.4949939250946045,
+                "bytes": [
+                  32,
+                  99,
+                  117,
+                  114,
+                  114,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "token": " goals",
+                "logprob": -0.9949939250946045,
+                "bytes": [
+                  32,
+                  103,
+                  111,
+                  97,
+                  108,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": " situation",
+            "logprob": -0.2162012904882431,
+            "bytes": [
+              32,
+              115,
+              105,
+              116,
+              117,
+              97,
+              116,
+              105,
+              111,
+              110
+            ],
+            "top_logprobs": [
+              {
+                "token": " situation",
+                "logprob": -0.2162012904882431,
+                "bytes": [
+                  32,
+                  115,
+                  105,
+                  116,
+                  117,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "token": " goals",
+                "logprob": -1.7162013053894043,
+                "bytes": [
+                  32,
+                  103,
+                  111,
+                  97,
+                  108,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": " and",
+            "logprob": -0.11023439466953278,
+            "bytes": [
+              32,
+              97,
+              110,
+              100
+            ],
+            "top_logprobs": [
+              {
+                "token": " and",
+                "logprob": -0.11023439466953278,
+                "bytes": [
+                  32,
+                  97,
+                  110,
+                  100
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -2.360234498977661,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " goals",
+            "logprob": -0.025679580867290497,
+            "bytes": [
+              32,
+              103,
+              111,
+              97,
+              108,
+              115
+            ],
+            "top_logprobs": [
+              {
+                "token": " goals",
+                "logprob": -0.025679580867290497,
+                "bytes": [
+                  32,
+                  103,
+                  111,
+                  97,
+                  108,
+                  115
+                ]
+              },
+              {
+                "token": " what",
+                "logprob": -4.275679588317871,
+                "bytes": [
+                  32,
+                  119,
+                  104,
+                  97,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".",
+            "logprob": -0.16022463142871857,
+            "bytes": [
+              46
+            ],
+            "top_logprobs": [
+              {
+                "token": ".",
+                "logprob": -0.16022463142871857,
+                "bytes": [
+                  46
+                ]
+              },
+              {
+                "token": "!",
+                "logprob": -1.9102246761322021,
+                "bytes": [
+                  33
+                ]
+              }
+            ]
+          },
+          {
+            "token": " Here",
+            "logprob": -0.003552319947630167,
+            "bytes": [
+              32,
+              72,
+              101,
+              114,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " Here",
+                "logprob": -0.003552319947630167,
+                "bytes": [
+                  32,
+                  72,
+                  101,
+                  114,
+                  101
+                ]
+              },
+              {
+                "token": " If",
+                "logprob": -5.753552436828613,
+                "bytes": [
+                  32,
+                  73,
+                  102
+                ]
+              }
+            ]
+          },
+          {
+            "token": " are",
+            "logprob": -0.0000011472419600977446,
+            "bytes": [
+              32,
+              97,
+              114,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " are",
+                "logprob": -0.0000011472419600977446,
+                "bytes": [
+                  32,
+                  97,
+                  114,
+                  101
+                ]
+              },
+              {
+                "token": "’s",
+                "logprob": -14.500000953674316,
+                "bytes": [
+                  226,
+                  128,
+                  153,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": " a",
+            "logprob": -0.02977166697382927,
+            "bytes": [
+              32,
+              97
+            ],
+            "top_logprobs": [
+              {
+                "token": " a",
+                "logprob": -0.02977166697382927,
+                "bytes": [
+                  32,
+                  97
+                ]
+              },
+              {
+                "token": " some",
+                "logprob": -3.529771566390991,
+                "bytes": [
+                  32,
+                  115,
+                  111,
+                  109,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " few",
+            "logprob": -1.9361264946837764e-7,
+            "bytes": [
+              32,
+              102,
+              101,
+              119
+            ],
+            "top_logprobs": [
+              {
+                "token": " few",
+                "logprob": -1.9361264946837764e-7,
+                "bytes": [
+                  32,
+                  102,
+                  101,
+                  119
+                ]
+              },
+              {
+                "token": " variety",
+                "logprob": -17.25,
+                "bytes": [
+                  32,
+                  118,
+                  97,
+                  114,
+                  105,
+                  101,
+                  116,
+                  121
+                ]
+              }
+            ]
+          },
+          {
+            "token": " suggestions",
+            "logprob": -0.3663240969181061,
+            "bytes": [
+              32,
+              115,
+              117,
+              103,
+              103,
+              101,
+              115,
+              116,
+              105,
+              111,
+              110,
+              115
+            ],
+            "top_logprobs": [
+              {
+                "token": " suggestions",
+                "logprob": -0.3663240969181061,
+                "bytes": [
+                  32,
+                  115,
+                  117,
+                  103,
+                  103,
+                  101,
+                  115,
+                  116,
+                  105,
+                  111,
+                  110,
+                  115
+                ]
+              },
+              {
+                "token": " options",
+                "logprob": -1.3663240671157837,
+                "bytes": [
+                  32,
+                  111,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": " based",
+            "logprob": -0.23226138949394226,
+            "bytes": [
+              32,
+              98,
+              97,
+              115,
+              101,
+              100
+            ],
+            "top_logprobs": [
+              {
+                "token": " based",
+                "logprob": -0.23226138949394226,
+                "bytes": [
+                  32,
+                  98,
+                  97,
+                  115,
+                  101,
+                  100
+                ]
+              },
+              {
+                "token": ":\n\n",
+                "logprob": -1.6072614192962646,
+                "bytes": [
+                  58,
+                  10,
+                  10
+                ]
+              }
+            ]
+          },
+          {
+            "token": " on",
+            "logprob": 0,
+            "bytes": [
+              32,
+              111,
+              110
+            ],
+            "top_logprobs": [
+              {
+                "token": " on",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  111,
+                  110
+                ]
+              },
+              {
+                "token": " upon",
+                "logprob": -17.125,
+                "bytes": [
+                  32,
+                  117,
+                  112,
+                  111,
+                  110
+                ]
+              }
+            ]
+          },
+          {
+            "token": " different",
+            "logprob": -0.16692031919956207,
+            "bytes": [
+              32,
+              100,
+              105,
+              102,
+              102,
+              101,
+              114,
+              101,
+              110,
+              116
+            ],
+            "top_logprobs": [
+              {
+                "token": " different",
+                "logprob": -0.16692031919956207,
+                "bytes": [
+                  32,
+                  100,
+                  105,
+                  102,
+                  102,
+                  101,
+                  114,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "token": " common",
+                "logprob": -1.9169203042984009,
+                "bytes": [
+                  32,
+                  99,
+                  111,
+                  109,
+                  109,
+                  111,
+                  110
+                ]
+              }
+            ]
+          },
+          {
+            "token": " contexts",
+            "logprob": -0.08145559579133987,
+            "bytes": [
+              32,
+              99,
+              111,
+              110,
+              116,
+              101,
+              120,
+              116,
+              115
+            ],
+            "top_logprobs": [
+              {
+                "token": " contexts",
+                "logprob": -0.08145559579133987,
+                "bytes": [
+                  32,
+                  99,
+                  111,
+                  110,
+                  116,
+                  101,
+                  120,
+                  116,
+                  115
+                ]
+              },
+              {
+                "token": " scenarios",
+                "logprob": -2.581455707550049,
+                "bytes": [
+                  32,
+                  115,
+                  99,
+                  101,
+                  110,
+                  97,
+                  114,
+                  105,
+                  111,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": ":\n\n",
+            "logprob": -0.0006341627449728549,
+            "bytes": [
+              58,
+              10,
+              10
+            ],
+            "top_logprobs": [
+              {
+                "token": ":\n\n",
+                "logprob": -0.0006341627449728549,
+                "bytes": [
+                  58,
+                  10,
+                  10
+                ]
+              },
+              {
+                "token": ":",
+                "logprob": -7.37563419342041,
+                "bytes": [
+                  58
+                ]
+              }
+            ]
+          },
+          {
+            "token": "1",
+            "logprob": -0.0001605115394340828,
+            "bytes": [
+              49
+            ],
+            "top_logprobs": [
+              {
+                "token": "1",
+                "logprob": -0.0001605115394340828,
+                "bytes": [
+                  49
+                ]
+              },
+              {
+                "token": "-",
+                "logprob": -8.750160217285156,
+                "bytes": [
+                  45
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".",
+            "logprob": 0,
+            "bytes": [
+              46
+            ],
+            "top_logprobs": [
+              {
+                "token": ".",
+                "logprob": 0,
+                "bytes": [
+                  46
+                ]
+              },
+              {
+                "token": ")",
+                "logprob": -22.75,
+                "bytes": [
+                  41
+                ]
+              }
+            ]
+          },
+          {
+            "token": " **",
+            "logprob": -0.000002696889623621246,
+            "bytes": [
+              32,
+              42,
+              42
+            ],
+            "top_logprobs": [
+              {
+                "token": " **",
+                "logprob": -0.000002696889623621246,
+                "bytes": [
+                  32,
+                  42,
+                  42
+                ]
+              },
+              {
+                "token": " If",
+                "logprob": -13.12500286102295,
+                "bytes": [
+                  32,
+                  73,
+                  102
+                ]
+              }
+            ]
+          },
+          {
+            "token": "If",
+            "logprob": -0.056057196110486984,
+            "bytes": [
+              73,
+              102
+            ],
+            "top_logprobs": [
+              {
+                "token": "If",
+                "logprob": -0.056057196110486984,
+                "bytes": [
+                  73,
+                  102
+                ]
+              },
+              {
+                "token": "Product",
+                "logprob": -4.181056976318359,
+                "bytes": [
+                  80,
+                  114,
+                  111,
+                  100,
+                  117,
+                  99,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " you're",
+            "logprob": -0.26643800735473633,
+            "bytes": [
+              32,
+              121,
+              111,
+              117,
+              39,
+              114,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " you're",
+                "logprob": -0.26643800735473633,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  39,
+                  114,
+                  101
+                ]
+              },
+              {
+                "token": " you",
+                "logprob": -1.5164380073547363,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117
+                ]
+              }
+            ]
+          },
+          {
+            "token": " working",
+            "logprob": -1.2267353534698486,
+            "bytes": [
+              32,
+              119,
+              111,
+              114,
+              107,
+              105,
+              110,
+              103
+            ],
+            "top_logprobs": [
+              {
+                "token": " studying",
+                "logprob": -0.6017354130744934,
+                "bytes": [
+                  32,
+                  115,
+                  116,
+                  117,
+                  100,
+                  121,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " working",
+                "logprob": -1.2267353534698486,
+                "bytes": [
+                  32,
+                  119,
+                  111,
+                  114,
+                  107,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " on",
+            "logprob": -0.2004212588071823,
+            "bytes": [
+              32,
+              111,
+              110
+            ],
+            "top_logprobs": [
+              {
+                "token": " on",
+                "logprob": -0.2004212588071823,
+                "bytes": [
+                  32,
+                  111,
+                  110
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -1.8254212141036987,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " a",
+            "logprob": -0.019129645079374313,
+            "bytes": [
+              32,
+              97
+            ],
+            "top_logprobs": [
+              {
+                "token": " a",
+                "logprob": -0.019129645079374313,
+                "bytes": [
+                  32,
+                  97
+                ]
+              },
+              {
+                "token": " something",
+                "logprob": -4.019129753112793,
+                "bytes": [
+                  32,
+                  115,
+                  111,
+                  109,
+                  101,
+                  116,
+                  104,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " task",
+            "logprob": -0.6935439109802246,
+            "bytes": [
+              32,
+              116,
+              97,
+              115,
+              107
+            ],
+            "top_logprobs": [
+              {
+                "token": " project",
+                "logprob": -0.6935439109802246,
+                "bytes": [
+                  32,
+                  112,
+                  114,
+                  111,
+                  106,
+                  101,
+                  99,
+                  116
+                ]
+              },
+              {
+                "token": " task",
+                "logprob": -0.6935439109802246,
+                "bytes": [
+                  32,
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              }
+            ]
+          },
+          {
+            "token": ":**",
+            "logprob": -0.9876421689987183,
+            "bytes": [
+              58,
+              42,
+              42
+            ],
+            "top_logprobs": [
+              {
+                "token": " or",
+                "logprob": -0.8626421689987183,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              },
+              {
+                "token": ":**",
+                "logprob": -0.9876421689987183,
+                "bytes": [
+                  58,
+                  42,
+                  42
+                ]
+              }
+            ]
+          },
+          {
+            "token": " Prior",
+            "logprob": -1.4749724864959717,
+            "bytes": [
+              32,
+              80,
+              114,
+              105,
+              111,
+              114
+            ],
+            "top_logprobs": [
+              {
+                "token": " Continue",
+                "logprob": -1.4749724864959717,
+                "bytes": [
+                  32,
+                  67,
+                  111,
+                  110,
+                  116,
+                  105,
+                  110,
+                  117,
+                  101
+                ]
+              },
+              {
+                "token": " Prior",
+                "logprob": -1.4749724864959717,
+                "bytes": [
+                  32,
+                  80,
+                  114,
+                  105,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": "itize",
+            "logprob": -6.704273118884885e-7,
+            "bytes": [
+              105,
+              116,
+              105,
+              122,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": "itize",
+                "logprob": -6.704273118884885e-7,
+                "bytes": [
+                  105,
+                  116,
+                  105,
+                  122,
+                  101
+                ]
+              },
+              {
+                "token": "it",
+                "logprob": -14.375000953674316,
+                "bytes": [
+                  105,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " your",
+            "logprob": -0.11289279162883759,
+            "bytes": [
+              32,
+              121,
+              111,
+              117,
+              114
+            ],
+            "top_logprobs": [
+              {
+                "token": " your",
+                "logprob": -0.11289279162883759,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  114
+                ]
+              },
+              {
+                "token": " the",
+                "logprob": -2.8628928661346436,
+                "bytes": [
+                  32,
+                  116,
+                  104,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " tasks",
+            "logprob": -1.3411924839019775,
+            "bytes": [
+              32,
+              116,
+              97,
+              115,
+              107,
+              115
+            ],
+            "top_logprobs": [
+              {
+                "token": " next",
+                "logprob": -0.8411924839019775,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  120,
+                  116
+                ]
+              },
+              {
+                "token": " to",
+                "logprob": -1.2161924839019775,
+                "bytes": [
+                  32,
+                  116,
+                  111
+                ]
+              }
+            ]
+          },
+          {
+            "token": " and",
+            "logprob": -0.04784148558974266,
+            "bytes": [
+              32,
+              97,
+              110,
+              100
+            ],
+            "top_logprobs": [
+              {
+                "token": " and",
+                "logprob": -0.04784148558974266,
+                "bytes": [
+                  32,
+                  97,
+                  110,
+                  100
+                ]
+              },
+              {
+                "token": ",",
+                "logprob": -3.7978415489196777,
+                "bytes": [
+                  44
+                ]
+              }
+            ]
+          },
+          {
+            "token": " focus",
+            "logprob": -0.9014371633529663,
+            "bytes": [
+              32,
+              102,
+              111,
+              99,
+              117,
+              115
+            ],
+            "top_logprobs": [
+              {
+                "token": " tackle",
+                "logprob": -0.7764371633529663,
+                "bytes": [
+                  32,
+                  116,
+                  97,
+                  99,
+                  107,
+                  108,
+                  101
+                ]
+              },
+              {
+                "token": " focus",
+                "logprob": -0.9014371633529663,
+                "bytes": [
+                  32,
+                  102,
+                  111,
+                  99,
+                  117,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": " on",
+            "logprob": -1.9361264946837764e-7,
+            "bytes": [
+              32,
+              111,
+              110
+            ],
+            "top_logprobs": [
+              {
+                "token": " on",
+                "logprob": -1.9361264946837764e-7,
+                "bytes": [
+                  32,
+                  111,
+                  110
+                ]
+              },
+              {
+                "token": " next",
+                "logprob": -16.875,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  120,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " the",
+            "logprob": -0.08746299892663956,
+            "bytes": [
+              32,
+              116,
+              104,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " the",
+                "logprob": -0.08746299892663956,
+                "bytes": [
+                  32,
+                  116,
+                  104,
+                  101
+                ]
+              },
+              {
+                "token": " completing",
+                "logprob": -2.837462902069092,
+                "bytes": [
+                  32,
+                  99,
+                  111,
+                  109,
+                  112,
+                  108,
+                  101,
+                  116,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " most",
+            "logprob": -0.1677953004837036,
+            "bytes": [
+              32,
+              109,
+              111,
+              115,
+              116
+            ],
+            "top_logprobs": [
+              {
+                "token": " most",
+                "logprob": -0.1677953004837036,
+                "bytes": [
+                  32,
+                  109,
+                  111,
+                  115,
+                  116
+                ]
+              },
+              {
+                "token": " next",
+                "logprob": -1.9177953004837036,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  120,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " important",
+            "logprob": -0.10492005944252014,
+            "bytes": [
+              32,
+              105,
+              109,
+              112,
+              111,
+              114,
+              116,
+              97,
+              110,
+              116
+            ],
+            "top_logprobs": [
+              {
+                "token": " important",
+                "logprob": -0.10492005944252014,
+                "bytes": [
+                  32,
+                  105,
+                  109,
+                  112,
+                  111,
+                  114,
+                  116,
+                  97,
+                  110,
+                  116
+                ]
+              },
+              {
+                "token": " urgent",
+                "logprob": -2.3549201488494873,
+                "bytes": [
+                  32,
+                  117,
+                  114,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " one",
+            "logprob": -0.05397335812449455,
+            "bytes": [
+              32,
+              111,
+              110,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " one",
+                "logprob": -0.05397335812449455,
+                "bytes": [
+                  32,
+                  111,
+                  110,
+                  101
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -3.053973436355591,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".\n",
+            "logprob": -0.3812916576862335,
+            "bytes": [
+              46,
+              10
+            ],
+            "top_logprobs": [
+              {
+                "token": ".\n",
+                "logprob": -0.3812916576862335,
+                "bytes": [
+                  46,
+                  10
+                ]
+              },
+              {
+                "token": " next",
+                "logprob": -1.8812916278839111,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  120,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": "2",
+            "logprob": -0.017168236896395683,
+            "bytes": [
+              50
+            ],
+            "top_logprobs": [
+              {
+                "token": "2",
+                "logprob": -0.017168236896395683,
+                "bytes": [
+                  50
+                ]
+              },
+              {
+                "token": "  \n",
+                "logprob": -4.767168045043945,
+                "bytes": [
+                  32,
+                  32,
+                  10
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".",
+            "logprob": 0,
+            "bytes": [
+              46
+            ],
+            "top_logprobs": [
+              {
+                "token": ".",
+                "logprob": 0,
+                "bytes": [
+                  46
+                ]
+              },
+              {
+                "token": ":",
+                "logprob": -23.75,
+                "bytes": [
+                  58
+                ]
+              }
+            ]
+          },
+          {
+            "token": " **",
+            "logprob": 0,
+            "bytes": [
+              32,
+              42,
+              42
+            ],
+            "top_logprobs": [
+              {
+                "token": " **",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  42,
+                  42
+                ]
+              },
+              {
+                "token": " ",
+                "logprob": -19.125,
+                "bytes": [
+                  32
+                ]
+              }
+            ]
+          },
+          {
+            "token": "If",
+            "logprob": -0.00022928470571059734,
+            "bytes": [
+              73,
+              102
+            ],
+            "top_logprobs": [
+              {
+                "token": "If",
+                "logprob": -0.00022928470571059734,
+                "bytes": [
+                  73,
+                  102
+                ]
+              },
+              {
+                "token": "For",
+                "logprob": -8.500228881835938,
+                "bytes": [
+                  70,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " you're",
+            "logprob": -0.2522451877593994,
+            "bytes": [
+              32,
+              121,
+              111,
+              117,
+              39,
+              114,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " you're",
+                "logprob": -0.2522451877593994,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  39,
+                  114,
+                  101
+                ]
+              },
+              {
+                "token": " you",
+                "logprob": -1.5022451877593994,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117
+                ]
+              }
+            ]
+          },
+          {
+            "token": " taking",
+            "logprob": -2.8169751167297363,
+            "bytes": [
+              32,
+              116,
+              97,
+              107,
+              105,
+              110,
+              103
+            ],
+            "top_logprobs": [
+              {
+                "token": " looking",
+                "logprob": -0.8169751167297363,
+                "bytes": [
+                  32,
+                  108,
+                  111,
+                  111,
+                  107,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " studying",
+                "logprob": -1.3169751167297363,
+                "bytes": [
+                  32,
+                  115,
+                  116,
+                  117,
+                  100,
+                  121,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " a",
+            "logprob": -0.000012113979209971149,
+            "bytes": [
+              32,
+              97
+            ],
+            "top_logprobs": [
+              {
+                "token": " a",
+                "logprob": -0.000012113979209971149,
+                "bytes": [
+                  32,
+                  97
+                ]
+              },
+              {
+                "token": " time",
+                "logprob": -11.625012397766113,
+                "bytes": [
+                  32,
+                  116,
+                  105,
+                  109,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " break",
+            "logprob": -0.000003531315314830863,
+            "bytes": [
+              32,
+              98,
+              114,
+              101,
+              97,
+              107
+            ],
+            "top_logprobs": [
+              {
+                "token": " break",
+                "logprob": -0.000003531315314830863,
+                "bytes": [
+                  32,
+                  98,
+                  114,
+                  101,
+                  97,
+                  107
+                ]
+              },
+              {
+                "token": " study",
+                "logprob": -12.750003814697266,
+                "bytes": [
+                  32,
+                  115,
+                  116,
+                  117,
+                  100,
+                  121
+                ]
+              }
+            ]
+          },
+          {
+            "token": ":**",
+            "logprob": -0.00005264322317088954,
+            "bytes": [
+              58,
+              42,
+              42
+            ],
+            "top_logprobs": [
+              {
+                "token": ":**",
+                "logprob": -0.00005264322317088954,
+                "bytes": [
+                  58,
+                  42,
+                  42
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -10.125052452087402,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " Consider",
+            "logprob": -0.05617767572402954,
+            "bytes": [
+              32,
+              67,
+              111,
+              110,
+              115,
+              105,
+              100,
+              101,
+              114
+            ],
+            "top_logprobs": [
+              {
+                "token": " Consider",
+                "logprob": -0.05617767572402954,
+                "bytes": [
+                  32,
+                  67,
+                  111,
+                  110,
+                  115,
+                  105,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "token": " Relax",
+                "logprob": -3.4311776161193848,
+                "bytes": [
+                  32,
+                  82,
+                  101,
+                  108,
+                  97,
+                  120
+                ]
+              }
+            ]
+          },
+          {
+            "token": " doing",
+            "logprob": -1.4167927503585815,
+            "bytes": [
+              32,
+              100,
+              111,
+              105,
+              110,
+              103
+            ],
+            "top_logprobs": [
+              {
+                "token": " stretching",
+                "logprob": -1.0417927503585815,
+                "bytes": [
+                  32,
+                  115,
+                  116,
+                  114,
+                  101,
+                  116,
+                  99,
+                  104,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " going",
+                "logprob": -1.1667927503585815,
+                "bytes": [
+                  32,
+                  103,
+                  111,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " something",
+            "logprob": -0.06690479815006256,
+            "bytes": [
+              32,
+              115,
+              111,
+              109,
+              101,
+              116,
+              104,
+              105,
+              110,
+              103
+            ],
+            "top_logprobs": [
+              {
+                "token": " something",
+                "logprob": -0.06690479815006256,
+                "bytes": [
+                  32,
+                  115,
+                  111,
+                  109,
+                  101,
+                  116,
+                  104,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " a",
+                "logprob": -2.8169047832489014,
+                "bytes": [
+                  32,
+                  97
+                ]
+              }
+            ]
+          },
+          {
+            "token": " relaxing",
+            "logprob": -0.008736773394048214,
+            "bytes": [
+              32,
+              114,
+              101,
+              108,
+              97,
+              120,
+              105,
+              110,
+              103
+            ],
+            "top_logprobs": [
+              {
+                "token": " relaxing",
+                "logprob": -0.008736773394048214,
+                "bytes": [
+                  32,
+                  114,
+                  101,
+                  108,
+                  97,
+                  120,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " enjoyable",
+                "logprob": -5.508736610412598,
+                "bytes": [
+                  32,
+                  101,
+                  110,
+                  106,
+                  111,
+                  121,
+                  97,
+                  98,
+                  108,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " like",
+            "logprob": -3.2769582271575928,
+            "bytes": [
+              32,
+              108,
+              105,
+              107,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": ",",
+                "logprob": -0.1519581526517868,
+                "bytes": [
+                  44
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -2.2769582271575928,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " stretching",
+            "logprob": -1.180336356163025,
+            "bytes": [
+              32,
+              115,
+              116,
+              114,
+              101,
+              116,
+              99,
+              104,
+              105,
+              110,
+              103
+            ],
+            "top_logprobs": [
+              {
+                "token": " going",
+                "logprob": -0.6803363561630249,
+                "bytes": [
+                  32,
+                  103,
+                  111,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " stretching",
+                "logprob": -1.180336356163025,
+                "bytes": [
+                  32,
+                  115,
+                  116,
+                  114,
+                  101,
+                  116,
+                  99,
+                  104,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": ",",
+            "logprob": -0.0024756586644798517,
+            "bytes": [
+              44
+            ],
+            "top_logprobs": [
+              {
+                "token": ",",
+                "logprob": -0.0024756586644798517,
+                "bytes": [
+                  44
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -6.002475738525391,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " reading",
+            "logprob": -3.325901508331299,
+            "bytes": [
+              32,
+              114,
+              101,
+              97,
+              100,
+              105,
+              110,
+              103
+            ],
+            "top_logprobs": [
+              {
+                "token": " going",
+                "logprob": -0.8259016275405884,
+                "bytes": [
+                  32,
+                  103,
+                  111,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " med",
+                "logprob": -1.2009016275405884,
+                "bytes": [
+                  32,
+                  109,
+                  101,
+                  100
+                ]
+              }
+            ]
+          },
+          {
+            "token": ",",
+            "logprob": -0.04861303046345711,
+            "bytes": [
+              44
+            ],
+            "top_logprobs": [
+              {
+                "token": ",",
+                "logprob": -0.04861303046345711,
+                "bytes": [
+                  44
+                ]
+              },
+              {
+                "token": " a",
+                "logprob": -3.0486130714416504,
+                "bytes": [
+                  32,
+                  97
+                ]
+              }
+            ]
+          },
+          {
+            "token": " or",
+            "logprob": -0.0000012664456789934775,
+            "bytes": [
+              32,
+              111,
+              114
+            ],
+            "top_logprobs": [
+              {
+                "token": " or",
+                "logprob": -0.0000012664456789934775,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              },
+              {
+                "token": " listening",
+                "logprob": -14.250000953674316,
+                "bytes": [
+                  32,
+                  108,
+                  105,
+                  115,
+                  116,
+                  101,
+                  110,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " taking",
+            "logprob": -1.5760998725891113,
+            "bytes": [
+              32,
+              116,
+              97,
+              107,
+              105,
+              110,
+              103
+            ],
+            "top_logprobs": [
+              {
+                "token": " going",
+                "logprob": -0.8260998129844666,
+                "bytes": [
+                  32,
+                  103,
+                  111,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " taking",
+                "logprob": -1.5760998725891113,
+                "bytes": [
+                  32,
+                  116,
+                  97,
+                  107,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " a",
+            "logprob": -0.0000015048530030981055,
+            "bytes": [
+              32,
+              97
+            ],
+            "top_logprobs": [
+              {
+                "token": " a",
+                "logprob": -0.0000015048530030981055,
+                "bytes": [
+                  32,
+                  97
+                ]
+              },
+              {
+                "token": " some",
+                "logprob": -14.250001907348633,
+                "bytes": [
+                  32,
+                  115,
+                  111,
+                  109,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " walk",
+            "logprob": -1.5060739517211914,
+            "bytes": [
+              32,
+              119,
+              97,
+              108,
+              107
+            ],
+            "top_logprobs": [
+              {
+                "token": " short",
+                "logprob": -0.2560739517211914,
+                "bytes": [
+                  32,
+                  115,
+                  104,
+                  111,
+                  114,
+                  116
+                ]
+              },
+              {
+                "token": " walk",
+                "logprob": -1.5060739517211914,
+                "bytes": [
+                  32,
+                  119,
+                  97,
+                  108,
+                  107
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".\n",
+            "logprob": -0.0007488752016797662,
+            "bytes": [
+              46,
+              10
+            ],
+            "top_logprobs": [
+              {
+                "token": ".\n",
+                "logprob": -0.0007488752016797662,
+                "bytes": [
+                  46,
+                  10
+                ]
+              },
+              {
+                "token": " to",
+                "logprob": -7.375749111175537,
+                "bytes": [
+                  32,
+                  116,
+                  111
+                ]
+              }
+            ]
+          },
+          {
+            "token": "3",
+            "logprob": 0,
+            "bytes": [
+              51
+            ],
+            "top_logprobs": [
+              {
+                "token": "3",
+                "logprob": 0,
+                "bytes": [
+                  51
+                ]
+              },
+              {
+                "token": "4",
+                "logprob": -18.625,
+                "bytes": [
+                  52
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".",
+            "logprob": 0,
+            "bytes": [
+              46
+            ],
+            "top_logprobs": [
+              {
+                "token": ".",
+                "logprob": 0,
+                "bytes": [
+                  46
+                ]
+              },
+              {
+                "token": ",",
+                "logprob": -23.5,
+                "bytes": [
+                  44
+                ]
+              }
+            ]
+          },
+          {
+            "token": " **",
+            "logprob": 0,
+            "bytes": [
+              32,
+              42,
+              42
+            ],
+            "top_logprobs": [
+              {
+                "token": " **",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  42,
+                  42
+                ]
+              },
+              {
+                "token": " ",
+                "logprob": -19.375,
+                "bytes": [
+                  32
+                ]
+              }
+            ]
+          },
+          {
+            "token": "If",
+            "logprob": -0.000031186566047836095,
+            "bytes": [
+              73,
+              102
+            ],
+            "top_logprobs": [
+              {
+                "token": "If",
+                "logprob": -0.000031186566047836095,
+                "bytes": [
+                  73,
+                  102
+                ]
+              },
+              {
+                "token": "For",
+                "logprob": -11.125031471252441,
+                "bytes": [
+                  70,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " you're",
+            "logprob": -0.22580476105213165,
+            "bytes": [
+              32,
+              121,
+              111,
+              117,
+              39,
+              114,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " you're",
+                "logprob": -0.22580476105213165,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  39,
+                  114,
+                  101
+                ]
+              },
+              {
+                "token": " you",
+                "logprob": -1.6008048057556152,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117
+                ]
+              }
+            ]
+          },
+          {
+            "token": " planning",
+            "logprob": -1.1315233707427979,
+            "bytes": [
+              32,
+              112,
+              108,
+              97,
+              110,
+              110,
+              105,
+              110,
+              103
+            ],
+            "top_logprobs": [
+              {
+                "token": " looking",
+                "logprob": -1.1315233707427979,
+                "bytes": [
+                  32,
+                  108,
+                  111,
+                  111,
+                  107,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " planning",
+                "logprob": -1.1315233707427979,
+                "bytes": [
+                  32,
+                  112,
+                  108,
+                  97,
+                  110,
+                  110,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " your",
+            "logprob": -0.2920282483100891,
+            "bytes": [
+              32,
+              121,
+              111,
+              117,
+              114
+            ],
+            "top_logprobs": [
+              {
+                "token": " your",
+                "logprob": -0.2920282483100891,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  114
+                ]
+              },
+              {
+                "token": ":**",
+                "logprob": -1.7920281887054443,
+                "bytes": [
+                  58,
+                  42,
+                  42
+                ]
+              }
+            ]
+          },
+          {
+            "token": " day",
+            "logprob": -0.0008314246661029756,
+            "bytes": [
+              32,
+              100,
+              97,
+              121
+            ],
+            "top_logprobs": [
+              {
+                "token": " day",
+                "logprob": -0.0008314246661029756,
+                "bytes": [
+                  32,
+                  100,
+                  97,
+                  121
+                ]
+              },
+              {
+                "token": " next",
+                "logprob": -7.750831604003906,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  120,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": ":**",
+            "logprob": -0.00023119196703191847,
+            "bytes": [
+              58,
+              42,
+              42
+            ],
+            "top_logprobs": [
+              {
+                "token": ":**",
+                "logprob": -0.00023119196703191847,
+                "bytes": [
+                  58,
+                  42,
+                  42
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -8.50023078918457,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " Review",
+            "logprob": -0.8928170800209045,
+            "bytes": [
+              32,
+              82,
+              101,
+              118,
+              105,
+              101,
+              119
+            ],
+            "top_logprobs": [
+              {
+                "token": " Make",
+                "logprob": -0.8928170800209045,
+                "bytes": [
+                  32,
+                  77,
+                  97,
+                  107,
+                  101
+                ]
+              },
+              {
+                "token": " Review",
+                "logprob": -0.8928170800209045,
+                "bytes": [
+                  32,
+                  82,
+                  101,
+                  118,
+                  105,
+                  101,
+                  119
+                ]
+              }
+            ]
+          },
+          {
+            "token": " your",
+            "logprob": -0.0012376103550195694,
+            "bytes": [
+              32,
+              121,
+              111,
+              117,
+              114
+            ],
+            "top_logprobs": [
+              {
+                "token": " your",
+                "logprob": -0.0012376103550195694,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  114
+                ]
+              },
+              {
+                "token": " what",
+                "logprob": -7.126237392425537,
+                "bytes": [
+                  32,
+                  119,
+                  104,
+                  97,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " to",
+            "logprob": -1.615683674812317,
+            "bytes": [
+              32,
+              116,
+              111
+            ],
+            "top_logprobs": [
+              {
+                "token": " schedule",
+                "logprob": -0.3656837046146393,
+                "bytes": [
+                  32,
+                  115,
+                  99,
+                  104,
+                  101,
+                  100,
+                  117,
+                  108,
+                  101
+                ]
+              },
+              {
+                "token": " to",
+                "logprob": -1.615683674812317,
+                "bytes": [
+                  32,
+                  116,
+                  111
+                ]
+              }
+            ]
+          },
+          {
+            "token": "-do",
+            "logprob": -0.00001306760805164231,
+            "bytes": [
+              45,
+              100,
+              111
+            ],
+            "top_logprobs": [
+              {
+                "token": "-do",
+                "logprob": -0.00001306760805164231,
+                "bytes": [
+                  45,
+                  100,
+                  111
+                ]
+              },
+              {
+                "token": "-d",
+                "logprob": -11.25001335144043,
+                "bytes": [
+                  45,
+                  100
+                ]
+              }
+            ]
+          },
+          {
+            "token": " list",
+            "logprob": -0.0000012664456789934775,
+            "bytes": [
+              32,
+              108,
+              105,
+              115,
+              116
+            ],
+            "top_logprobs": [
+              {
+                "token": " list",
+                "logprob": -0.0000012664456789934775,
+                "bytes": [
+                  32,
+                  108,
+                  105,
+                  115,
+                  116
+                ]
+              },
+              {
+                "token": " lists",
+                "logprob": -13.750000953674316,
+                "bytes": [
+                  32,
+                  108,
+                  105,
+                  115,
+                  116,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": " and",
+            "logprob": -0.14678436517715454,
+            "bytes": [
+              32,
+              97,
+              110,
+              100
+            ],
+            "top_logprobs": [
+              {
+                "token": " and",
+                "logprob": -0.14678436517715454,
+                "bytes": [
+                  32,
+                  97,
+                  110,
+                  100
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -2.0217843055725098,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " schedule",
+            "logprob": -2.203786849975586,
+            "bytes": [
+              32,
+              115,
+              99,
+              104,
+              101,
+              100,
+              117,
+              108,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " set",
+                "logprob": -0.2037869691848755,
+                "bytes": [
+                  32,
+                  115,
+                  101,
+                  116
+                ]
+              },
+              {
+                "token": " schedule",
+                "logprob": -2.203786849975586,
+                "bytes": [
+                  32,
+                  115,
+                  99,
+                  104,
+                  101,
+                  100,
+                  117,
+                  108,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " any",
+            "logprob": -1.0901646614074707,
+            "bytes": [
+              32,
+              97,
+              110,
+              121
+            ],
+            "top_logprobs": [
+              {
+                "token": " your",
+                "logprob": -0.7151647210121155,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  114
+                ]
+              },
+              {
+                "token": " any",
+                "logprob": -1.0901646614074707,
+                "bytes": [
+                  32,
+                  97,
+                  110,
+                  121
+                ]
+              }
+            ]
+          },
+          {
+            "token": " appointments",
+            "logprob": -1.82143235206604,
+            "bytes": [
+              32,
+              97,
+              112,
+              112,
+              111,
+              105,
+              110,
+              116,
+              109,
+              101,
+              110,
+              116,
+              115
+            ],
+            "top_logprobs": [
+              {
+                "token": " necessary",
+                "logprob": -1.07143235206604,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  99,
+                  101,
+                  115,
+                  115,
+                  97,
+                  114,
+                  121
+                ]
+              },
+              {
+                "token": " remaining",
+                "logprob": -1.44643235206604,
+                "bytes": [
+                  32,
+                  114,
+                  101,
+                  109,
+                  97,
+                  105,
+                  110,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " or",
+            "logprob": -0.023840127512812614,
+            "bytes": [
+              32,
+              111,
+              114
+            ],
+            "top_logprobs": [
+              {
+                "token": " or",
+                "logprob": -0.023840127512812614,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              },
+              {
+                "token": ".\n",
+                "logprob": -4.023839950561523,
+                "bytes": [
+                  46,
+                  10
+                ]
+              }
+            ]
+          },
+          {
+            "token": " deadlines",
+            "logprob": -2.246274471282959,
+            "bytes": [
+              32,
+              100,
+              101,
+              97,
+              100,
+              108,
+              105,
+              110,
+              101,
+              115
+            ],
+            "top_logprobs": [
+              {
+                "token": " activities",
+                "logprob": -0.621274471282959,
+                "bytes": [
+                  32,
+                  97,
+                  99,
+                  116,
+                  105,
+                  118,
+                  105,
+                  116,
+                  105,
+                  101,
+                  115
+                ]
+              },
+              {
+                "token": " tasks",
+                "logprob": -1.621274471282959,
+                "bytes": [
+                  32,
+                  116,
+                  97,
+                  115,
+                  107,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".\n",
+            "logprob": -0.027743615210056305,
+            "bytes": [
+              46,
+              10
+            ],
+            "top_logprobs": [
+              {
+                "token": ".\n",
+                "logprob": -0.027743615210056305,
+                "bytes": [
+                  46,
+                  10
+                ]
+              },
+              {
+                "token": " you",
+                "logprob": -3.6527435779571533,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117
+                ]
+              }
+            ]
+          },
+          {
+            "token": "4",
+            "logprob": 0,
+            "bytes": [
+              52
+            ],
+            "top_logprobs": [
+              {
+                "token": "4",
+                "logprob": 0,
+                "bytes": [
+                  52
+                ]
+              },
+              {
+                "token": "5",
+                "logprob": -17,
+                "bytes": [
+                  53
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".",
+            "logprob": 0,
+            "bytes": [
+              46
+            ],
+            "top_logprobs": [
+              {
+                "token": ".",
+                "logprob": 0,
+                "bytes": [
+                  46
+                ]
+              },
+              {
+                "token": ",",
+                "logprob": -21.625,
+                "bytes": [
+                  44
+                ]
+              }
+            ]
+          },
+          {
+            "token": " **",
+            "logprob": 0,
+            "bytes": [
+              32,
+              42,
+              42
+            ],
+            "top_logprobs": [
+              {
+                "token": " **",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  42,
+                  42
+                ]
+              },
+              {
+                "token": " ",
+                "logprob": -19.5,
+                "bytes": [
+                  32
+                ]
+              }
+            ]
+          },
+          {
+            "token": "If",
+            "logprob": -0.00012451570364646614,
+            "bytes": [
+              73,
+              102
+            ],
+            "top_logprobs": [
+              {
+                "token": "If",
+                "logprob": -0.00012451570364646614,
+                "bytes": [
+                  73,
+                  102
+                ]
+              },
+              {
+                "token": "For",
+                "logprob": -9.12512493133545,
+                "bytes": [
+                  70,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " you're",
+            "logprob": -0.20154285430908203,
+            "bytes": [
+              32,
+              121,
+              111,
+              117,
+              39,
+              114,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " you're",
+                "logprob": -0.20154285430908203,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  39,
+                  114,
+                  101
+                ]
+              },
+              {
+                "token": " you",
+                "logprob": -1.701542854309082,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117
+                ]
+              }
+            ]
+          },
+          {
+            "token": " looking",
+            "logprob": -0.5356529355049133,
+            "bytes": [
+              32,
+              108,
+              111,
+              111,
+              107,
+              105,
+              110,
+              103
+            ],
+            "top_logprobs": [
+              {
+                "token": " looking",
+                "logprob": -0.5356529355049133,
+                "bytes": [
+                  32,
+                  108,
+                  111,
+                  111,
+                  107,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " feeling",
+                "logprob": -1.7856528759002686,
+                "bytes": [
+                  32,
+                  102,
+                  101,
+                  101,
+                  108,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " for",
+            "logprob": -0.0788901224732399,
+            "bytes": [
+              32,
+              102,
+              111,
+              114
+            ],
+            "top_logprobs": [
+              {
+                "token": " for",
+                "logprob": -0.0788901224732399,
+                "bytes": [
+                  32,
+                  102,
+                  111,
+                  114
+                ]
+              },
+              {
+                "token": " to",
+                "logprob": -2.578890085220337,
+                "bytes": [
+                  32,
+                  116,
+                  111
+                ]
+              }
+            ]
+          },
+          {
+            "token": " inspiration",
+            "logprob": -1.4556074142456055,
+            "bytes": [
+              32,
+              105,
+              110,
+              115,
+              112,
+              105,
+              114,
+              97,
+              116,
+              105,
+              111,
+              110
+            ],
+            "top_logprobs": [
+              {
+                "token": " something",
+                "logprob": -0.8306073546409607,
+                "bytes": [
+                  32,
+                  115,
+                  111,
+                  109,
+                  101,
+                  116,
+                  104,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "token": " inspiration",
+                "logprob": -1.4556074142456055,
+                "bytes": [
+                  32,
+                  105,
+                  110,
+                  115,
+                  112,
+                  105,
+                  114,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ]
+          },
+          {
+            "token": ":**",
+            "logprob": -0.0021961715538054705,
+            "bytes": [
+              58,
+              42,
+              42
+            ],
+            "top_logprobs": [
+              {
+                "token": ":**",
+                "logprob": -0.0021961715538054705,
+                "bytes": [
+                  58,
+                  42,
+                  42
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -6.127196311950684,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " Read",
+            "logprob": -6.880104064941406,
+            "bytes": [
+              32,
+              82,
+              101,
+              97,
+              100
+            ],
+            "top_logprobs": [
+              {
+                "token": " Try",
+                "logprob": -0.6301040649414062,
+                "bytes": [
+                  32,
+                  84,
+                  114,
+                  121
+                ]
+              },
+              {
+                "token": " Explore",
+                "logprob": -0.8801040649414062,
+                "bytes": [
+                  32,
+                  69,
+                  120,
+                  112,
+                  108,
+                  111,
+                  114,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " a",
+            "logprob": -0.025807611644268036,
+            "bytes": [
+              32,
+              97
+            ],
+            "top_logprobs": [
+              {
+                "token": " a",
+                "logprob": -0.025807611644268036,
+                "bytes": [
+                  32,
+                  97
+                ]
+              },
+              {
+                "token": " something",
+                "logprob": -4.6508073806762695,
+                "bytes": [
+                  32,
+                  115,
+                  111,
+                  109,
+                  101,
+                  116,
+                  104,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " book",
+            "logprob": -0.0012553498381748796,
+            "bytes": [
+              32,
+              98,
+              111,
+              111,
+              107
+            ],
+            "top_logprobs": [
+              {
+                "token": " book",
+                "logprob": -0.0012553498381748796,
+                "bytes": [
+                  32,
+                  98,
+                  111,
+                  111,
+                  107
+                ]
+              },
+              {
+                "token": " new",
+                "logprob": -7.126255512237549,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  119
+                ]
+              }
+            ]
+          },
+          {
+            "token": ",",
+            "logprob": -0.018151231110095978,
+            "bytes": [
+              44
+            ],
+            "top_logprobs": [
+              {
+                "token": ",",
+                "logprob": -0.018151231110095978,
+                "bytes": [
+                  44
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -4.01815128326416,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " watch",
+            "logprob": -0.5993434190750122,
+            "bytes": [
+              32,
+              119,
+              97,
+              116,
+              99,
+              104
+            ],
+            "top_logprobs": [
+              {
+                "token": " watch",
+                "logprob": -0.5993434190750122,
+                "bytes": [
+                  32,
+                  119,
+                  97,
+                  116,
+                  99,
+                  104
+                ]
+              },
+              {
+                "token": " listen",
+                "logprob": -0.8493434190750122,
+                "bytes": [
+                  32,
+                  108,
+                  105,
+                  115,
+                  116,
+                  101,
+                  110
+                ]
+              }
+            ]
+          },
+          {
+            "token": " a",
+            "logprob": -0.04187367111444473,
+            "bytes": [
+              32,
+              97
+            ],
+            "top_logprobs": [
+              {
+                "token": " a",
+                "logprob": -0.04187367111444473,
+                "bytes": [
+                  32,
+                  97
+                ]
+              },
+              {
+                "token": " an",
+                "logprob": -3.2918736934661865,
+                "bytes": [
+                  32,
+                  97,
+                  110
+                ]
+              }
+            ]
+          },
+          {
+            "token": " documentary",
+            "logprob": -0.8566184639930725,
+            "bytes": [
+              32,
+              100,
+              111,
+              99,
+              117,
+              109,
+              101,
+              110,
+              116,
+              97,
+              114,
+              121
+            ],
+            "top_logprobs": [
+              {
+                "token": " documentary",
+                "logprob": -0.8566184639930725,
+                "bytes": [
+                  32,
+                  100,
+                  111,
+                  99,
+                  117,
+                  109,
+                  101,
+                  110,
+                  116,
+                  97,
+                  114,
+                  121
+                ]
+              },
+              {
+                "token": " motivational",
+                "logprob": -0.8566184639930725,
+                "bytes": [
+                  32,
+                  109,
+                  111,
+                  116,
+                  105,
+                  118,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  97,
+                  108
+                ]
+              }
+            ]
+          },
+          {
+            "token": ",",
+            "logprob": -0.00004036524842376821,
+            "bytes": [
+              44
+            ],
+            "top_logprobs": [
+              {
+                "token": ",",
+                "logprob": -0.00004036524842376821,
+                "bytes": [
+                  44
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -10.125040054321289,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " or",
+            "logprob": -0.000022007883671903983,
+            "bytes": [
+              32,
+              111,
+              114
+            ],
+            "top_logprobs": [
+              {
+                "token": " or",
+                "logprob": -0.000022007883671903983,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              },
+              {
+                "token": " listen",
+                "logprob": -11.625021934509277,
+                "bytes": [
+                  32,
+                  108,
+                  105,
+                  115,
+                  116,
+                  101,
+                  110
+                ]
+              }
+            ]
+          },
+          {
+            "token": " explore",
+            "logprob": -0.6772040128707886,
+            "bytes": [
+              32,
+              101,
+              120,
+              112,
+              108,
+              111,
+              114,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " explore",
+                "logprob": -0.6772040128707886,
+                "bytes": [
+                  32,
+                  101,
+                  120,
+                  112,
+                  108,
+                  111,
+                  114,
+                  101
+                ]
+              },
+              {
+                "token": " listen",
+                "logprob": -1.6772040128707886,
+                "bytes": [
+                  32,
+                  108,
+                  105,
+                  115,
+                  116,
+                  101,
+                  110
+                ]
+              }
+            ]
+          },
+          {
+            "token": " a",
+            "logprob": -0.09053189307451248,
+            "bytes": [
+              32,
+              97
+            ],
+            "top_logprobs": [
+              {
+                "token": " a",
+                "logprob": -0.09053189307451248,
+                "bytes": [
+                  32,
+                  97
+                ]
+              },
+              {
+                "token": " new",
+                "logprob": -2.590531826019287,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  119
+                ]
+              }
+            ]
+          },
+          {
+            "token": " new",
+            "logprob": -0.04500929266214371,
+            "bytes": [
+              32,
+              110,
+              101,
+              119
+            ],
+            "top_logprobs": [
+              {
+                "token": " new",
+                "logprob": -0.04500929266214371,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  119
+                ]
+              },
+              {
+                "token": " hobby",
+                "logprob": -3.2950093746185303,
+                "bytes": [
+                  32,
+                  104,
+                  111,
+                  98,
+                  98,
+                  121
+                ]
+              }
+            ]
+          },
+          {
+            "token": " hobby",
+            "logprob": -0.01118315476924181,
+            "bytes": [
+              32,
+              104,
+              111,
+              98,
+              98,
+              121
+            ],
+            "top_logprobs": [
+              {
+                "token": " hobby",
+                "logprob": -0.01118315476924181,
+                "bytes": [
+                  32,
+                  104,
+                  111,
+                  98,
+                  98,
+                  121
+                ]
+              },
+              {
+                "token": " topic",
+                "logprob": -4.636183261871338,
+                "bytes": [
+                  32,
+                  116,
+                  111,
+                  112,
+                  105,
+                  99
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".\n",
+            "logprob": -0.0656219944357872,
+            "bytes": [
+              46,
+              10
+            ],
+            "top_logprobs": [
+              {
+                "token": ".\n",
+                "logprob": -0.0656219944357872,
+                "bytes": [
+                  46,
+                  10
+                ]
+              },
+              {
+                "token": ".\n\n",
+                "logprob": -2.815622091293335,
+                "bytes": [
+                  46,
+                  10,
+                  10
+                ]
+              }
+            ]
+          },
+          {
+            "token": "5",
+            "logprob": -0.00026503115077503026,
+            "bytes": [
+              53
+            ],
+            "top_logprobs": [
+              {
+                "token": "5",
+                "logprob": -0.00026503115077503026,
+                "bytes": [
+                  53
+                ]
+              },
+              {
+                "token": "  \n",
+                "logprob": -8.875265121459961,
+                "bytes": [
+                  32,
+                  32,
+                  10
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".",
+            "logprob": 0,
+            "bytes": [
+              46
+            ],
+            "top_logprobs": [
+              {
+                "token": ".",
+                "logprob": 0,
+                "bytes": [
+                  46
+                ]
+              },
+              {
+                "token": ":",
+                "logprob": -22.75,
+                "bytes": [
+                  58
+                ]
+              }
+            ]
+          },
+          {
+            "token": " **",
+            "logprob": 0,
+            "bytes": [
+              32,
+              42,
+              42
+            ],
+            "top_logprobs": [
+              {
+                "token": " **",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  42,
+                  42
+                ]
+              },
+              {
+                "token": " ",
+                "logprob": -17.125,
+                "bytes": [
+                  32
+                ]
+              }
+            ]
+          },
+          {
+            "token": "If",
+            "logprob": -0.0002302383363712579,
+            "bytes": [
+              73,
+              102
+            ],
+            "top_logprobs": [
+              {
+                "token": "If",
+                "logprob": -0.0002302383363712579,
+                "bytes": [
+                  73,
+                  102
+                ]
+              },
+              {
+                "token": "For",
+                "logprob": -9.000229835510254,
+                "bytes": [
+                  70,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " you",
+            "logprob": -0.9757949113845825,
+            "bytes": [
+              32,
+              121,
+              111,
+              117
+            ],
+            "top_logprobs": [
+              {
+                "token": " you're",
+                "logprob": -0.4757949113845825,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  39,
+                  114,
+                  101
+                ]
+              },
+              {
+                "token": " you",
+                "logprob": -0.9757949113845825,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117
+                ]
+              }
+            ]
+          },
+          {
+            "token": " have",
+            "logprob": -1.8396108150482178,
+            "bytes": [
+              32,
+              104,
+              97,
+              118,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " need",
+                "logprob": -0.589610755443573,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  101,
+                  100
+                ]
+              },
+              {
+                "token": " have",
+                "logprob": -1.8396108150482178,
+                "bytes": [
+                  32,
+                  104,
+                  97,
+                  118,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " a",
+            "logprob": -0.3546936511993408,
+            "bytes": [
+              32,
+              97
+            ],
+            "top_logprobs": [
+              {
+                "token": " a",
+                "logprob": -0.3546936511993408,
+                "bytes": [
+                  32,
+                  97
+                ]
+              },
+              {
+                "token": " questions",
+                "logprob": -2.104693651199341,
+                "bytes": [
+                  32,
+                  113,
+                  117,
+                  101,
+                  115,
+                  116,
+                  105,
+                  111,
+                  110,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": " question",
+            "logprob": -1.7853052616119385,
+            "bytes": [
+              32,
+              113,
+              117,
+              101,
+              115,
+              116,
+              105,
+              111,
+              110
+            ],
+            "top_logprobs": [
+              {
+                "token": " specific",
+                "logprob": -0.4103052616119385,
+                "bytes": [
+                  32,
+                  115,
+                  112,
+                  101,
+                  99,
+                  105,
+                  102,
+                  105,
+                  99
+                ]
+              },
+              {
+                "token": " question",
+                "logprob": -1.7853052616119385,
+                "bytes": [
+                  32,
+                  113,
+                  117,
+                  101,
+                  115,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ]
+          },
+          {
+            "token": " in",
+            "logprob": -3.3536767959594727,
+            "bytes": [
+              32,
+              105,
+              110
+            ],
+            "top_logprobs": [
+              {
+                "token": " or",
+                "logprob": -0.35367685556411743,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              },
+              {
+                "token": ":**",
+                "logprob": -1.3536767959594727,
+                "bytes": [
+                  58,
+                  42,
+                  42
+                ]
+              }
+            ]
+          },
+          {
+            "token": " mind",
+            "logprob": -0.0011951096821576357,
+            "bytes": [
+              32,
+              109,
+              105,
+              110,
+              100
+            ],
+            "top_logprobs": [
+              {
+                "token": " mind",
+                "logprob": -0.0011951096821576357,
+                "bytes": [
+                  32,
+                  109,
+                  105,
+                  110,
+                  100
+                ]
+              },
+              {
+                "token": " your",
+                "logprob": -6.876194953918457,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": ":**",
+            "logprob": -0.0009511216776445508,
+            "bytes": [
+              58,
+              42,
+              42
+            ],
+            "top_logprobs": [
+              {
+                "token": ":**",
+                "logprob": -0.0009511216776445508,
+                "bytes": [
+                  58,
+                  42,
+                  42
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -7.125951290130615,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " Feel",
+            "logprob": -0.8565728068351746,
+            "bytes": [
+              32,
+              70,
+              101,
+              101,
+              108
+            ],
+            "top_logprobs": [
+              {
+                "token": " Feel",
+                "logprob": -0.8565728068351746,
+                "bytes": [
+                  32,
+                  70,
+                  101,
+                  101,
+                  108
+                ]
+              },
+              {
+                "token": " Research",
+                "logprob": -1.2315728664398193,
+                "bytes": [
+                  32,
+                  82,
+                  101,
+                  115,
+                  101,
+                  97,
+                  114,
+                  99,
+                  104
+                ]
+              }
+            ]
+          },
+          {
+            "token": " free",
+            "logprob": -3.128163257315464e-7,
+            "bytes": [
+              32,
+              102,
+              114,
+              101,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " free",
+                "logprob": -3.128163257315464e-7,
+                "bytes": [
+                  32,
+                  102,
+                  114,
+                  101,
+                  101
+                ]
+              },
+              {
+                "token": " Free",
+                "logprob": -15.75,
+                "bytes": [
+                  32,
+                  70,
+                  114,
+                  101,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " to",
+            "logprob": 0,
+            "bytes": [
+              32,
+              116,
+              111
+            ],
+            "top_logprobs": [
+              {
+                "token": " to",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  116,
+                  111
+                ]
+              },
+              {
+                "token": ",",
+                "logprob": -18.25,
+                "bytes": [
+                  44
+                ]
+              }
+            ]
+          },
+          {
+            "token": " ask",
+            "logprob": -0.003909557592123747,
+            "bytes": [
+              32,
+              97,
+              115,
+              107
+            ],
+            "top_logprobs": [
+              {
+                "token": " ask",
+                "logprob": -0.003909557592123747,
+                "bytes": [
+                  32,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "token": " share",
+                "logprob": -5.628909587860107,
+                "bytes": [
+                  32,
+                  115,
+                  104,
+                  97,
+                  114,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " me",
+            "logprob": -2.2439582347869873,
+            "bytes": [
+              32,
+              109,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": ",",
+                "logprob": -0.49395817518234253,
+                "bytes": [
+                  44
+                ]
+              },
+              {
+                "token": " for",
+                "logprob": -1.8689582347869873,
+                "bytes": [
+                  32,
+                  102,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": ",",
+            "logprob": -1.2222193479537964,
+            "bytes": [
+              44
+            ],
+            "top_logprobs": [
+              {
+                "token": " for",
+                "logprob": -0.7222193479537964,
+                "bytes": [
+                  32,
+                  102,
+                  111,
+                  114
+                ]
+              },
+              {
+                "token": ",",
+                "logprob": -1.2222193479537964,
+                "bytes": [
+                  44
+                ]
+              }
+            ]
+          },
+          {
+            "token": " and",
+            "logprob": -0.00016587569552939385,
+            "bytes": [
+              32,
+              97,
+              110,
+              100
+            ],
+            "top_logprobs": [
+              {
+                "token": " and",
+                "logprob": -0.00016587569552939385,
+                "bytes": [
+                  32,
+                  97,
+                  110,
+                  100
+                ]
+              },
+              {
+                "token": " I",
+                "logprob": -9.375165939331055,
+                "bytes": [
+                  32,
+                  73
+                ]
+              }
+            ]
+          },
+          {
+            "token": " I",
+            "logprob": -0.5865263342857361,
+            "bytes": [
+              32,
+              73
+            ],
+            "top_logprobs": [
+              {
+                "token": " I",
+                "logprob": -0.5865263342857361,
+                "bytes": [
+                  32,
+                  73
+                ]
+              },
+              {
+                "token": " I'll",
+                "logprob": -0.8365263342857361,
+                "bytes": [
+                  32,
+                  73,
+                  39,
+                  108,
+                  108
+                ]
+              }
+            ]
+          },
+          {
+            "token": "’ll",
+            "logprob": -0.8220764398574829,
+            "bytes": [
+              226,
+              128,
+              153,
+              108,
+              108
+            ],
+            "top_logprobs": [
+              {
+                "token": " can",
+                "logprob": -0.8220764398574829,
+                "bytes": [
+                  32,
+                  99,
+                  97,
+                  110
+                ]
+              },
+              {
+                "token": "’ll",
+                "logprob": -0.8220764398574829,
+                "bytes": [
+                  226,
+                  128,
+                  153,
+                  108,
+                  108
+                ]
+              }
+            ]
+          },
+          {
+            "token": " do",
+            "logprob": -0.04482409730553627,
+            "bytes": [
+              32,
+              100,
+              111
+            ],
+            "top_logprobs": [
+              {
+                "token": " do",
+                "logprob": -0.04482409730553627,
+                "bytes": [
+                  32,
+                  100,
+                  111
+                ]
+              },
+              {
+                "token": " be",
+                "logprob": -4.044824123382568,
+                "bytes": [
+                  32,
+                  98,
+                  101
+                ]
+              }
+            ]
+          },
+          {
+            "token": " my",
+            "logprob": -1.9361264946837764e-7,
+            "bytes": [
+              32,
+              109,
+              121
+            ],
+            "top_logprobs": [
+              {
+                "token": " my",
+                "logprob": -1.9361264946837764e-7,
+                "bytes": [
+                  32,
+                  109,
+                  121
+                ]
+              },
+              {
+                "token": " what",
+                "logprob": -16.5,
+                "bytes": [
+                  32,
+                  119,
+                  104,
+                  97,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " best",
+            "logprob": 0,
+            "bytes": [
+              32,
+              98,
+              101,
+              115,
+              116
+            ],
+            "top_logprobs": [
+              {
+                "token": " best",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  98,
+                  101,
+                  115,
+                  116
+                ]
+              },
+              {
+                "token": "best",
+                "logprob": -17.75,
+                "bytes": [
+                  98,
+                  101,
+                  115,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " to",
+            "logprob": 0,
+            "bytes": [
+              32,
+              116,
+              111
+            ],
+            "top_logprobs": [
+              {
+                "token": " to",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  116,
+                  111
+                ]
+              },
+              {
+                "token": " help",
+                "logprob": -19.75,
+                "bytes": [
+                  32,
+                  104,
+                  101,
+                  108,
+                  112
+                ]
+              }
+            ]
+          },
+          {
+            "token": " help",
+            "logprob": -0.07115840911865234,
+            "bytes": [
+              32,
+              104,
+              101,
+              108,
+              112
+            ],
+            "top_logprobs": [
+              {
+                "token": " help",
+                "logprob": -0.07115840911865234,
+                "bytes": [
+                  32,
+                  104,
+                  101,
+                  108,
+                  112
+                ]
+              },
+              {
+                "token": " assist",
+                "logprob": -2.8211584091186523,
+                "bytes": [
+                  32,
+                  97,
+                  115,
+                  115,
+                  105,
+                  115,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " you",
+            "logprob": -3.1753008365631104,
+            "bytes": [
+              32,
+              121,
+              111,
+              117
+            ],
+            "top_logprobs": [
+              {
+                "token": "!\n\n",
+                "logprob": -0.05030093342065811,
+                "bytes": [
+                  33,
+                  10,
+                  10
+                ]
+              },
+              {
+                "token": " you",
+                "logprob": -3.1753008365631104,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117
+                ]
+              }
+            ]
+          },
+          {
+            "token": "!\n\n",
+            "logprob": -0.08714739978313446,
+            "bytes": [
+              33,
+              10,
+              10
+            ],
+            "top_logprobs": [
+              {
+                "token": "!\n\n",
+                "logprob": -0.08714739978313446,
+                "bytes": [
+                  33,
+                  10,
+                  10
+                ]
+              },
+              {
+                "token": " out",
+                "logprob": -3.4621474742889404,
+                "bytes": [
+                  32,
+                  111,
+                  117,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": "Let",
+            "logprob": -0.057075466960668564,
+            "bytes": [
+              76,
+              101,
+              116
+            ],
+            "top_logprobs": [
+              {
+                "token": "Let",
+                "logprob": -0.057075466960668564,
+                "bytes": [
+                  76,
+                  101,
+                  116
+                ]
+              },
+              {
+                "token": "What",
+                "logprob": -3.0570755004882812,
+                "bytes": [
+                  87,
+                  104,
+                  97,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " me",
+            "logprob": -0.0000010280383548888494,
+            "bytes": [
+              32,
+              109,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " me",
+                "logprob": -0.0000010280383548888494,
+                "bytes": [
+                  32,
+                  109,
+                  101
+                ]
+              },
+              {
+                "token": "ting",
+                "logprob": -14.250000953674316,
+                "bytes": [
+                  116,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " know",
+            "logprob": 0,
+            "bytes": [
+              32,
+              107,
+              110,
+              111,
+              119
+            ],
+            "top_logprobs": [
+              {
+                "token": " know",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  107,
+                  110,
+                  111,
+                  119
+                ]
+              },
+              {
+                "token": "know",
+                "logprob": -17.875,
+                "bytes": [
+                  107,
+                  110,
+                  111,
+                  119
+                ]
+              }
+            ]
+          },
+          {
+            "token": " if",
+            "logprob": -0.4684903919696808,
+            "bytes": [
+              32,
+              105,
+              102
+            ],
+            "top_logprobs": [
+              {
+                "token": " if",
+                "logprob": -0.4684903919696808,
+                "bytes": [
+                  32,
+                  105,
+                  102
+                ]
+              },
+              {
+                "token": " what",
+                "logprob": -1.4684903621673584,
+                "bytes": [
+                  32,
+                  119,
+                  104,
+                  97,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " you",
+            "logprob": -0.16996578872203827,
+            "bytes": [
+              32,
+              121,
+              111,
+              117
+            ],
+            "top_logprobs": [
+              {
+                "token": " you",
+                "logprob": -0.16996578872203827,
+                "bytes": [
+                  32,
+                  121,
+                  111,
+                  117
+                ]
+              },
+              {
+                "token": " there's",
+                "logprob": -2.1699657440185547,
+                "bytes": [
+                  32,
+                  116,
+                  104,
+                  101,
+                  114,
+                  101,
+                  39,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": " have",
+            "logprob": -0.2718985080718994,
+            "bytes": [
+              32,
+              104,
+              97,
+              118,
+              101
+            ],
+            "top_logprobs": [
+              {
+                "token": " have",
+                "logprob": -0.2718985080718994,
+                "bytes": [
+                  32,
+                  104,
+                  97,
+                  118,
+                  101
+                ]
+              },
+              {
+                "token": " need",
+                "logprob": -1.6468985080718994,
+                "bytes": [
+                  32,
+                  110,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          },
+          {
+            "token": " a",
+            "logprob": -0.0738566443324089,
+            "bytes": [
+              32,
+              97
+            ],
+            "top_logprobs": [
+              {
+                "token": " a",
+                "logprob": -0.0738566443324089,
+                "bytes": [
+                  32,
+                  97
+                ]
+              },
+              {
+                "token": " something",
+                "logprob": -2.6988565921783447,
+                "bytes": [
+                  32,
+                  115,
+                  111,
+                  109,
+                  101,
+                  116,
+                  104,
+                  105,
+                  110,
+                  103
+                ]
+              }
+            ]
+          },
+          {
+            "token": " specific",
+            "logprob": -0.004503942560404539,
+            "bytes": [
+              32,
+              115,
+              112,
+              101,
+              99,
+              105,
+              102,
+              105,
+              99
+            ],
+            "top_logprobs": [
+              {
+                "token": " specific",
+                "logprob": -0.004503942560404539,
+                "bytes": [
+                  32,
+                  115,
+                  112,
+                  101,
+                  99,
+                  105,
+                  102,
+                  105,
+                  99
+                ]
+              },
+              {
+                "token": " particular",
+                "logprob": -5.7545037269592285,
+                "bytes": [
+                  32,
+                  112,
+                  97,
+                  114,
+                  116,
+                  105,
+                  99,
+                  117,
+                  108,
+                  97,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " context",
+            "logprob": -0.7114875912666321,
+            "bytes": [
+              32,
+              99,
+              111,
+              110,
+              116,
+              101,
+              120,
+              116
+            ],
+            "top_logprobs": [
+              {
+                "token": " area",
+                "logprob": -0.7114875912666321,
+                "bytes": [
+                  32,
+                  97,
+                  114,
+                  101,
+                  97
+                ]
+              },
+              {
+                "token": " context",
+                "logprob": -0.7114875912666321,
+                "bytes": [
+                  32,
+                  99,
+                  111,
+                  110,
+                  116,
+                  101,
+                  120,
+                  116
+                ]
+              }
+            ]
+          },
+          {
+            "token": " in",
+            "logprob": -0.11081014573574066,
+            "bytes": [
+              32,
+              105,
+              110
+            ],
+            "top_logprobs": [
+              {
+                "token": " in",
+                "logprob": -0.11081014573574066,
+                "bytes": [
+                  32,
+                  105,
+                  110
+                ]
+              },
+              {
+                "token": " or",
+                "logprob": -2.3608100414276123,
+                "bytes": [
+                  32,
+                  111,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": " mind",
+            "logprob": -0.0017032715259119868,
+            "bytes": [
+              32,
+              109,
+              105,
+              110,
+              100
+            ],
+            "top_logprobs": [
+              {
+                "token": " mind",
+                "logprob": -0.0017032715259119868,
+                "bytes": [
+                  32,
+                  109,
+                  105,
+                  110,
+                  100
+                ]
+              },
+              {
+                "token": " which",
+                "logprob": -6.376703262329102,
+                "bytes": [
+                  32,
+                  119,
+                  104,
+                  105,
+                  99,
+                  104
+                ]
+              }
+            ]
+          },
+          {
+            "token": "!",
+            "logprob": -0.09768038988113403,
+            "bytes": [
+              33
+            ],
+            "top_logprobs": [
+              {
+                "token": "!",
+                "logprob": -0.09768038988113403,
+                "bytes": [
+                  33
+                ]
+              },
+              {
+                "token": ",",
+                "logprob": -2.4726803302764893,
+                "bytes": [
+                  44
+                ]
+              }
+            ]
+          }
+        ],
+        "refusal": null
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 37,
+    "completion_tokens": 151,
+    "total_tokens": 188,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/logprobsParam/chat-completions/request.json
+++ b/payloads/snapshots/logprobsParam/chat-completions/request.json
@@ -1,0 +1,11 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is 2 + 2?"
+    }
+  ],
+  "logprobs": true,
+  "top_logprobs": 2
+}

--- a/payloads/snapshots/logprobsParam/chat-completions/response.json
+++ b/payloads/snapshots/logprobsParam/chat-completions/response.json
@@ -1,0 +1,252 @@
+{
+  "id": "chatcmpl-Cxyz1758HuQp4VqE9pstQEiG2ypxs",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "2 + 2 equals 4.",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": {
+        "content": [
+          {
+            "token": "2",
+            "logprob": -0.000010564331205387134,
+            "bytes": [
+              50
+            ],
+            "top_logprobs": [
+              {
+                "token": "2",
+                "logprob": -0.000010564331205387134,
+                "bytes": [
+                  50
+                ]
+              },
+              {
+                "token": "\\(",
+                "logprob": -11.50001049041748,
+                "bytes": [
+                  92,
+                  40
+                ]
+              }
+            ]
+          },
+          {
+            "token": " +",
+            "logprob": 0,
+            "bytes": [
+              32,
+              43
+            ],
+            "top_logprobs": [
+              {
+                "token": " +",
+                "logprob": 0,
+                "bytes": [
+                  32,
+                  43
+                ]
+              },
+              {
+                "token": " plus",
+                "logprob": -17.25,
+                "bytes": [
+                  32,
+                  112,
+                  108,
+                  117,
+                  115
+                ]
+              }
+            ]
+          },
+          {
+            "token": " ",
+            "logprob": 0,
+            "bytes": [
+              32
+            ],
+            "top_logprobs": [
+              {
+                "token": " ",
+                "logprob": 0,
+                "bytes": [
+                  32
+                ]
+              },
+              {
+                "token": "2",
+                "logprob": -25,
+                "bytes": [
+                  50
+                ]
+              }
+            ]
+          },
+          {
+            "token": "2",
+            "logprob": 0,
+            "bytes": [
+              50
+            ],
+            "top_logprobs": [
+              {
+                "token": "2",
+                "logprob": 0,
+                "bytes": [
+                  50
+                ]
+              },
+              {
+                "token": "²",
+                "logprob": -18.625,
+                "bytes": [
+                  194,
+                  178
+                ]
+              }
+            ]
+          },
+          {
+            "token": " equals",
+            "logprob": -0.008738193660974503,
+            "bytes": [
+              32,
+              101,
+              113,
+              117,
+              97,
+              108,
+              115
+            ],
+            "top_logprobs": [
+              {
+                "token": " equals",
+                "logprob": -0.008738193660974503,
+                "bytes": [
+                  32,
+                  101,
+                  113,
+                  117,
+                  97,
+                  108,
+                  115
+                ]
+              },
+              {
+                "token": " =",
+                "logprob": -4.758738040924072,
+                "bytes": [
+                  32,
+                  61
+                ]
+              }
+            ]
+          },
+          {
+            "token": " ",
+            "logprob": 0,
+            "bytes": [
+              32
+            ],
+            "top_logprobs": [
+              {
+                "token": " ",
+                "logprob": 0,
+                "bytes": [
+                  32
+                ]
+              },
+              {
+                "token": " to",
+                "logprob": -19.75,
+                "bytes": [
+                  32,
+                  116,
+                  111
+                ]
+              }
+            ]
+          },
+          {
+            "token": "4",
+            "logprob": 0,
+            "bytes": [
+              52
+            ],
+            "top_logprobs": [
+              {
+                "token": "4",
+                "logprob": 0,
+                "bytes": [
+                  52
+                ]
+              },
+              {
+                "token": " four",
+                "logprob": -18,
+                "bytes": [
+                  32,
+                  102,
+                  111,
+                  117,
+                  114
+                ]
+              }
+            ]
+          },
+          {
+            "token": ".",
+            "logprob": -3.128163257315464e-7,
+            "bytes": [
+              46
+            ],
+            "top_logprobs": [
+              {
+                "token": ".",
+                "logprob": -3.128163257315464e-7,
+                "bytes": [
+                  46
+                ]
+              },
+              {
+                "token": ".\n",
+                "logprob": -15.125,
+                "bytes": [
+                  46,
+                  10
+                ]
+              }
+            ]
+          }
+        ],
+        "refusal": null
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 15,
+    "completion_tokens": 8,
+    "total_tokens": 23,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/maxCompletionTokensParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/maxCompletionTokensParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    },
+    {
+      "role": "assistant",
+      "content": "Ok.",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "max_completion_tokens": 500
+}

--- a/payloads/snapshots/maxCompletionTokensParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/maxCompletionTokensParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz4qqhfmQWkiytZ2XiVPVz6rNG9",
+  "object": "chat.completion",
+  "created": 1768411810,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "length"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 27,
+    "completion_tokens": 500,
+    "total_tokens": 527,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 500,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/maxCompletionTokensParam/chat-completions/request.json
+++ b/payloads/snapshots/maxCompletionTokensParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    }
+  ],
+  "max_completion_tokens": 500
+}

--- a/payloads/snapshots/maxCompletionTokensParam/chat-completions/response.json
+++ b/payloads/snapshots/maxCompletionTokensParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz1PjPDVgBpITkhhchEoLBYshtB",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Ok.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 9,
+    "completion_tokens": 203,
+    "total_tokens": 212,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 192,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/metadataParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/metadataParam/chat-completions/followup-request.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    },
+    {
+      "role": "assistant",
+      "content": "ok.",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "store": true,
+  "metadata": {
+    "request_id": "req-12345",
+    "user_tier": "premium",
+    "experiment": "control"
+  }
+}

--- a/payloads/snapshots/metadataParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/metadataParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz42FB60Ol09VPK6Fjfd2uTB2pK",
+  "object": "chat.completion",
+  "created": 1768411810,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Great—what would you like to work on? If you’re not sure, here are quick options. Tell me which one fits, or describe your task and any constraints and I’ll propose a concrete plan.\n\n- Plan or organize something: define your goal, break into steps, and set a timeline.\n- Learn or explain something: a short, beginner-friendly explanation or a quick micro-lesson.\n- Create or edit: draft or polish writing, code, or a presentation outline.\n- Decide or troubleshoot: compare options, weigh pros/cons, and suggest a decision.\n\nIf you prefer, share a bit about your current goal or task and I’ll propose a 1–2 step next action.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 27,
+    "completion_tokens": 982,
+    "total_tokens": 1009,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 832,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/metadataParam/chat-completions/request.json
+++ b/payloads/snapshots/metadataParam/chat-completions/request.json
@@ -1,0 +1,15 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    }
+  ],
+  "store": true,
+  "metadata": {
+    "request_id": "req-12345",
+    "user_tier": "premium",
+    "experiment": "control"
+  }
+}

--- a/payloads/snapshots/metadataParam/chat-completions/response.json
+++ b/payloads/snapshots/metadataParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz1AsULsDUzw0hF9bDZgJB2yyNT",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "ok.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 9,
+    "completion_tokens": 267,
+    "total_tokens": 276,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 256,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/nMultipleCompletionsParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/nMultipleCompletionsParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say a word."
+    },
+    {
+      "role": "assistant",
+      "content": "Harmony.",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "n": 2
+}

--- a/payloads/snapshots/nMultipleCompletionsParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/nMultipleCompletionsParam/chat-completions/followup-response.json
@@ -1,0 +1,47 @@
+{
+  "id": "chatcmpl-Cxyz2V1I6xa8hpubB0jcenIhkAQRh",
+  "object": "chat.completion",
+  "created": 1768411808,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "It depends on what you're interested in! Here are a few suggestions:\n\n1. **Explore Harmony**: If you like the word \"harmony,\" consider listening to music that embodies it or reading about concepts of harmony in nature or relationships.\n\n2. **Creative Writing**: Write a poem or short story inspired by the word \"harmony.\"\n\n3. **Meditation**: Find a quiet space and meditate on what harmony means to you in your life right now.\n\n4. **Connect with Others**: Reach out to someone you appreciate and express your feelings, promoting harmony in your relationships.\n\n5. **Learn Something New**: Research the significance of harmony in different cultures or fields, such as music, art, or philosophy.\n\nLet me know if you'd like more specific suggestions!",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    },
+    {
+      "index": 1,
+      "message": {
+        "role": "assistant",
+        "content": "It depends on what you're interested in! Here are a few suggestions:\n\n1. **Explore Music**: If you like the word \"harmony,\" listen to some harmonious music or try playing an instrument.\n2. **Meditate or Reflect**: Spend some time reflecting on what harmony means to you and how you can create more of it in your life.\n3. **Artistic Expression**: Create something—draw, paint, or write about harmony in nature or relationships.\n4. **Learn Something New**: Research the concept of harmony in different cultures, for example in music or philosophy.\n\nWhat sounds appealing to you?",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 27,
+    "completion_tokens": 283,
+    "total_tokens": 310,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/nMultipleCompletionsParam/chat-completions/request.json
+++ b/payloads/snapshots/nMultipleCompletionsParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say a word."
+    }
+  ],
+  "n": 2
+}

--- a/payloads/snapshots/nMultipleCompletionsParam/chat-completions/response.json
+++ b/payloads/snapshots/nMultipleCompletionsParam/chat-completions/response.json
@@ -1,0 +1,47 @@
+{
+  "id": "chatcmpl-Cxyz1fHPKStkDrOnIsBMKtCWICsTD",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Harmony.",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    },
+    {
+      "index": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Serendipity.",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 11,
+    "completion_tokens": 7,
+    "total_tokens": 18,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/parallelToolCallsDisabledParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/parallelToolCallsDisabledParam/chat-completions/followup-request.json
@@ -1,0 +1,53 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Weather in NYC and LA?"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "call_5JltcXRPjXPzj6hHSutWaS2M",
+          "type": "function",
+          "function": {
+            "name": "get_weather",
+            "arguments": "{\"location\":\"New York, NY\"}"
+          }
+        }
+      ],
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_5JltcXRPjXPzj6hHSutWaS2M",
+      "content": "71 degrees"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "strict": true,
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "location"
+          ],
+          "additionalProperties": false
+        }
+      }
+    }
+  ],
+  "parallel_tool_calls": false
+}

--- a/payloads/snapshots/parallelToolCallsDisabledParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/parallelToolCallsDisabledParam/chat-completions/followup-response.json
@@ -1,0 +1,45 @@
+{
+  "id": "chatcmpl-Cxyz3uX6eSf1rICGuYSmhozRIR1K3",
+  "object": "chat.completion",
+  "created": 1768411809,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_hQu0f9O2iCJUr3abiPeeM8iq",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\":\"Los Angeles, CA\"}"
+            }
+          }
+        ],
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "tool_calls"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 160,
+    "completion_tokens": 20,
+    "total_tokens": 180,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/parallelToolCallsDisabledParam/chat-completions/request.json
+++ b/payloads/snapshots/parallelToolCallsDisabledParam/chat-completions/request.json
@@ -1,0 +1,32 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Weather in NYC and LA?"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "strict": true,
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "location"
+          ],
+          "additionalProperties": false
+        }
+      }
+    }
+  ],
+  "parallel_tool_calls": false
+}

--- a/payloads/snapshots/parallelToolCallsDisabledParam/chat-completions/response.json
+++ b/payloads/snapshots/parallelToolCallsDisabledParam/chat-completions/response.json
@@ -1,0 +1,45 @@
+{
+  "id": "chatcmpl-Cxyz1GcT40MNJCgN4AtWFSclijboj",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_5JltcXRPjXPzj6hHSutWaS2M",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\":\"New York, NY\"}"
+            }
+          }
+        ],
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "tool_calls"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 127,
+    "completion_tokens": 154,
+    "total_tokens": 281,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 128,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/predictionParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/predictionParam/chat-completions/followup-request.json
@@ -1,0 +1,23 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Update this function to add error handling:\n\nfunction divide(a, b) {\n  return a / b;\n}"
+    },
+    {
+      "role": "assistant",
+      "content": "To add error handling to the `divide` function, we can check for a few conditions:\n\n1. Ensure that `b` is not zero, as division by zero is undefined and will result in an error.\n2. Ensure that both `a` and `b` are numbers, since you might want to avoid running into type errors with non-numeric inputs.\n\nHere's the updated function with error handling:\n\n```javascript\nfunction divide(a, b) {\n  // Check if both arguments are numbers\n  if (typeof a !== 'number' || typeof b !== 'number') {\n    throw new TypeError('Both arguments must be numbers.');\n  }\n  \n  // Check for division by zero\n  if (b === 0) {\n    throw new Error('Division by zero is not allowed.');\n  }\n\n  return a / b;\n}\n```\n\n### How this works:\n- If `a` or `b` is not a number, a `TypeError` is thrown with a descriptive message.\n- If `b` is zero, a generic `Error` is thrown to indicate division by zero is not allowed.\n- Otherwise, the function performs the division and returns the result. \n\nYou can modify the error messages as per your requirements!",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "prediction": {
+    "type": "content",
+    "content": "function divide(a, b) {\n  if (b === 0) {\n    throw new Error('Cannot divide by zero');\n  }\n  return a / b;\n}"
+  }
+}

--- a/payloads/snapshots/predictionParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/predictionParam/chat-completions/followup-response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz8ey0cHKzjKSMrPqZ8mvCBGxdQ",
+  "object": "chat.completion",
+  "created": 1768411814,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Now that you have an updated version of the `divide` function with error handling, here are some steps you can take next:\n\n1. **Testing the Function**:\n   - Create some test cases to ensure the function behaves as expected in various scenarios:\n     - Valid inputs (e.g., `divide(6, 3)`)\n     - Division by zero (e.g., `divide(6, 0)`)\n     - Non-numeric inputs (e.g., `divide('a', 3)` or `divide(4, 'b')`)\n\n   Example of testing the function:\n   ```javascript\n   try {\n       console.log(divide(6, 3)); // Should return 2\n       console.log(divide(5, 0)); // Should throw Error\n   } catch (error) {\n       console.error(error.message); // Handle error\n   }\n\n   try {\n       console.log(divide('a', 3)); // Should throw TypeError\n   } catch (error) {\n       console.error(error.message); // Handle error\n   }\n   ```\n\n2. **Integrate into Larger Codebase**:\n   - If this function is part of a larger project, start integrating it where needed and ensure it’s used in appropriate places while taking care of error handling as described.\n\n3. **Documentation**:\n   - Document the function to describe its behavior, parameters, and exceptions thrown. This is especially useful for other developers who will use your function or for your future self.\n\n4. **Refactoring**:\n   - Review the function for any potential improvements or optimizations.\n   - Consider if you want to use promises or callbacks for asynchronous error handling if the context requires.\n\n5. **Create More Utility Functions**:\n   - If you find yourself needing more mathematical operations, consider creating more utility functions with similar error handling.\n\n6. **User Interface Interaction**:\n   - If you are building a UI that calls this function, implement user-friendly error messages for users (e.g., alert or display error messages in the UI instead of just logging them).\n\n7. **Code Review**:\n   - Share your code with peers for a review to get feedback and suggestions for improvement.\n\n8. **Further Learning**:\n   - Explore more advanced error handling techniques, such as custom error classes, logging errors, or using external libraries for better handling and tracking.\n\nBy following these steps, you'll not only ensure your function works correctly but also enhance your coding skills and make your code more robust and maintainable!",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 296,
+    "completion_tokens": 529,
+    "total_tokens": 825,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 16
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/predictionParam/chat-completions/request.json
+++ b/payloads/snapshots/predictionParam/chat-completions/request.json
@@ -1,0 +1,13 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Update this function to add error handling:\n\nfunction divide(a, b) {\n  return a / b;\n}"
+    }
+  ],
+  "prediction": {
+    "type": "content",
+    "content": "function divide(a, b) {\n  if (b === 0) {\n    throw new Error('Cannot divide by zero');\n  }\n  return a / b;\n}"
+  }
+}

--- a/payloads/snapshots/predictionParam/chat-completions/response.json
+++ b/payloads/snapshots/predictionParam/chat-completions/response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz1BoRIWNMsAzinL9r8NkW3d1Bp",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "To add error handling to the `divide` function, we can check for a few conditions:\n\n1. Ensure that `b` is not zero, as division by zero is undefined and will result in an error.\n2. Ensure that both `a` and `b` are numbers, since you might want to avoid running into type errors with non-numeric inputs.\n\nHere's the updated function with error handling:\n\n```javascript\nfunction divide(a, b) {\n  // Check if both arguments are numbers\n  if (typeof a !== 'number' || typeof b !== 'number') {\n    throw new TypeError('Both arguments must be numbers.');\n  }\n  \n  // Check for division by zero\n  if (b === 0) {\n    throw new Error('Division by zero is not allowed.');\n  }\n\n  return a / b;\n}\n```\n\n### How this works:\n- If `a` or `b` is not a number, a `TypeError` is thrown with a descriptive message.\n- If `b` is zero, a generic `Error` is thrown to indicate division by zero is not allowed.\n- Otherwise, the function performs the division and returns the result. \n\nYou can modify the error messages as per your requirements!",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 29,
+    "completion_tokens": 269,
+    "total_tokens": 298,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 16
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/presencePenaltyParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/presencePenaltyParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    },
+    {
+      "role": "assistant",
+      "content": "Ok.",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "presence_penalty": 0.5
+}

--- a/payloads/snapshots/presencePenaltyParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/presencePenaltyParam/chat-completions/followup-response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz3M5jtO3XEbKJVyEOAzhlap5ze",
+  "object": "chat.completion",
+  "created": 1768411809,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "It depends on what you're interested in! Here are a few options:\n\n1. **Learn Something New:** Pick a topic you've always wanted to understand better and research it.\n2. **Read a Book:** Dive into a book you've been wanting to read, whether it's fiction or non-fiction.\n3. **Exercise:** Go for a walk, do a workout, or try some yoga to stay active.\n4. **Creative Activity:** Try writing, drawing, or practicing a musical instrument.\n5. **Connect with Someone:** Reach out to a friend or family member for a chat.\n6. **Plan Your Day:** Make a to-do list or set goals for the week ahead.\n\nWhat sounds good to you?",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 26,
+    "completion_tokens": 142,
+    "total_tokens": 168,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/presencePenaltyParam/chat-completions/request.json
+++ b/payloads/snapshots/presencePenaltyParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    }
+  ],
+  "presence_penalty": 0.5
+}

--- a/payloads/snapshots/presencePenaltyParam/chat-completions/response.json
+++ b/payloads/snapshots/presencePenaltyParam/chat-completions/response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz1ngvDP9Crp8PXTrEHJFTmgESr",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Ok.",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 2,
+    "total_tokens": 12,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_c4585b5b9c"
+}

--- a/payloads/snapshots/promptCacheKeyParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/promptCacheKeyParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    },
+    {
+      "role": "assistant",
+      "content": "ok",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "prompt_cache_key": "user-123-ml-explanation"
+}

--- a/payloads/snapshots/promptCacheKeyParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/promptCacheKeyParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz5kZHw9Y0BqxBIeC6lm6F4uPLV",
+  "object": "chat.completion",
+  "created": 1768411811,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Sure—what would you like to do next? If you’re not sure, I can help with many things. Here are quick options:\n\n- Learn something: I can give you a short, actionable learning plan (e.g., Python basics, writing basics, etc.).\n- Plan a project or task: I’ll outline steps, milestones, and timeline.\n- Draft content: email, resume, cover letter, article, post, etc.\n- Code help: explain a concept, debug, or write a small script.\n- Make a decision: compare options with pros/cons and a recommendation.\n- Brainstorm ideas: topics, features, or creative ideas.\n\nTell me your goal or pick an option, and I’ll give you a concrete, step-by-step plan. If you want, I can also propose a simple 3-step plan right now for a guess at common tasks.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 26,
+    "completion_tokens": 1018,
+    "total_tokens": 1044,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 832,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/promptCacheKeyParam/chat-completions/request.json
+++ b/payloads/snapshots/promptCacheKeyParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    }
+  ],
+  "prompt_cache_key": "user-123-ml-explanation"
+}

--- a/payloads/snapshots/promptCacheKeyParam/chat-completions/response.json
+++ b/payloads/snapshots/promptCacheKeyParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz1CTb0zKrTYSA1VTuPOeKCxvzo",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "ok",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 9,
+    "completion_tokens": 266,
+    "total_tokens": 275,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 256,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/reasoningSummaryParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/reasoningSummaryParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is 2+2?"
+    },
+    {
+      "role": "assistant",
+      "content": "4\n\nIf you want a quick note: 2 + 2 equals 4 because combining two and two yields four.",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "reasoning_effort": "medium"
+}

--- a/payloads/snapshots/reasoningSummaryParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/reasoningSummaryParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz4MZzR0qgeEDEHQi5nmYkViezz",
+  "object": "chat.completion",
+  "created": 1768411810,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Happy to help. What would you like to focus on? Here are quick options you can choose from, or tell me your goal and I’ll tailor it:\n\n- Get something done now (3-step micro-plan)\n  1) Pick one important task\n  2) Work for 25 minutes (Pomodoro)\n  3) Review what you did and decide next step\n\n- Learn something new (short plan)\n  1) Pick a topic\n  2) Do a 20-minute mini-lesson or tutorial\n  3) Do one quick practice problem or summary\n\n- Boost well-being (quick routine)\n  1) 5 minutes of deep breathing\n  2) 5 minutes of light stretching or a short walk\n  3) 2-minute reflection on how you feel\n\n- Organize tasks (next actions)\n  1) List top 3 priorities\n  2) Break each into next concrete action\n  3) Schedule or set reminders\n\n- Creative / fun prompt\n  1) Try a 10-minute creative exercise (short story, sketch, idea sprint)\n  2) Share or summarize your result\n\nTell me which option fits, or share your goal (time you have, topic, constraints), and I’ll tailor a plan.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 54,
+    "completion_tokens": 1109,
+    "total_tokens": 1163,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 832,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/reasoningSummaryParam/chat-completions/request.json
+++ b/payloads/snapshots/reasoningSummaryParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is 2+2?"
+    }
+  ],
+  "reasoning_effort": "medium"
+}

--- a/payloads/snapshots/reasoningSummaryParam/chat-completions/response.json
+++ b/payloads/snapshots/reasoningSummaryParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz1VmF78ct2ffHFHffSErNbx11y",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "4\n\nIf you want a quick note: 2 + 2 equals 4 because combining two and two yields four.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 13,
+    "completion_tokens": 226,
+    "total_tokens": 239,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 192,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/safetyIdentifierParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/safetyIdentifierParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    },
+    {
+      "role": "assistant",
+      "content": "ok.",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "safety_identifier": "hashed-user-id-abc123"
+}

--- a/payloads/snapshots/safetyIdentifierParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/safetyIdentifierParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz4k9p8BKh2p1BZsGYtGqnwvR5i",
+  "object": "chat.completion",
+  "created": 1768411810,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Sure—to help you best, tell me what you want to achieve. If you’re not sure, here are quick options you can pick from (or mix):\n\n- Plan a project or task: define goal, milestones, timeline.\n- Learn something new: a focused mini-course with key topics and resources.\n- Write something: create an outline, draft, and revision steps.\n- Make a decision: list options, criteria, pros/cons, and a ranking.\n- Solve a problem: diagnose, brainstorm solutions, and pick a plan.\n- Code/tech task: gather requirements, propose architecture, and sample code.\n- Organize something: priorities, to-do list, and schedule.\n\nIf you want, we can start with a quick prompt: describe your goal in one sentence and list the top 3 outcomes you want. Any deadline or constraints?\n\nTell me which option fits, or share your goal and I’ll generate a concrete plan right away.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 27,
+    "completion_tokens": 970,
+    "total_tokens": 997,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 768,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/safetyIdentifierParam/chat-completions/request.json
+++ b/payloads/snapshots/safetyIdentifierParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    }
+  ],
+  "safety_identifier": "hashed-user-id-abc123"
+}

--- a/payloads/snapshots/safetyIdentifierParam/chat-completions/response.json
+++ b/payloads/snapshots/safetyIdentifierParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz1a28SOy0fMfBuMgzEySjh2TtV",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "ok.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 9,
+    "completion_tokens": 267,
+    "total_tokens": 276,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 256,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/seedParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/seedParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Pick a number."
+    },
+    {
+      "role": "assistant",
+      "content": "Alright! I pick the number 7.",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "seed": 12345
+}

--- a/payloads/snapshots/seedParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/seedParam/chat-completions/followup-response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz2xCn3oOXKtSf4L8qZqIwEhagg",
+  "object": "chat.completion",
+  "created": 1768411808,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "That depends on what you're interested in! Here are a few suggestions:\n\n1. **Games**: Use the number 7 in a game, like rolling a die or a number guessing game.\n2. **Creative Writing**: Write a short story or a poem that includes 7 elements (characters, settings, etc.).\n3. **Goal Setting**: Set up 7 goals you want to achieve this week or month.\n4. **Learning**: Research 7 interesting facts about a topic you enjoy.\n5. **Challenges**: Try doing 7 push-ups or drinking 7 glasses of water today.\n\nChoose whatever resonates with you!",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 34,
+    "completion_tokens": 130,
+    "total_tokens": 164,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/seedParam/chat-completions/request.json
+++ b/payloads/snapshots/seedParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Pick a number."
+    }
+  ],
+  "seed": 12345
+}

--- a/payloads/snapshots/seedParam/chat-completions/response.json
+++ b/payloads/snapshots/seedParam/chat-completions/response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz1omJMJ0mzFAdOBojRTjyABXtX",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Alright! I pick the number 7.",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 11,
+    "completion_tokens": 9,
+    "total_tokens": 20,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/serviceTierParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/serviceTierParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    },
+    {
+      "role": "assistant",
+      "content": "ok",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "service_tier": "default"
+}

--- a/payloads/snapshots/serviceTierParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/serviceTierParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz3cN6Juy8A51jtucv40x8kY76q",
+  "object": "chat.completion",
+  "created": 1768411809,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Great question. What would you like to do next? Here are a few easy options:\n\n- Plan or decide: I’ll help you define a goal, break it into steps, and make a checklist.\n- Learn or practice: Pick a topic and I’ll give a quick mini-lesson plus a short exercise.\n- Create something: I can draft an email, message, resume bullet, outline, or simple code snippet.\n- Troubleshoot: Describe a problem and I’ll guide you through debugging or solving it.\n- Quick task: I can summarize a document, brainstorm ideas, or research options.\n\nIf you want, I can propose a concrete next step right now. For example: summarize what you want to achieve in one sentence, then list the top 3 actions to get there. What would you like to do?",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 26,
+    "completion_tokens": 1134,
+    "total_tokens": 1160,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 960,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/serviceTierParam/chat-completions/request.json
+++ b/payloads/snapshots/serviceTierParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    }
+  ],
+  "service_tier": "default"
+}

--- a/payloads/snapshots/serviceTierParam/chat-completions/response.json
+++ b/payloads/snapshots/serviceTierParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz1E6faLD6QsjKj9RIUbgJh2TVA",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "ok",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 9,
+    "completion_tokens": 139,
+    "total_tokens": 148,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 128,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/stopSequencesParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/stopSequencesParam/chat-completions/followup-request.json
@@ -1,0 +1,23 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Count from 1 to 20."
+    },
+    {
+      "role": "assistant",
+      "content": "Sure! Here are the numbers from 1 to 20:\n\n1, 2, 3, 4, 5, 6, 7, 8, 9, ",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "stop": [
+    "10",
+    "ten"
+  ]
+}

--- a/payloads/snapshots/stopSequencesParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/stopSequencesParam/chat-completions/followup-response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz3hPC636DUt7hTEmVsLvyBKmkG",
+  "object": "chat.completion",
+  "created": 1768411809,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "That depends on what you want to achieve! Here are a few suggestions:\n\n1. **Learning**: If you’re interested in a specific topic, you could read a book or an article, watch a documentary, or take an online course.\n2. **Exercise**: Consider going for a walk, doing some yoga, or trying a workout routine to stay active and healthy.\n3. **Creative Pursuits**: You could try drawing, writing, or engaging in a craft project to express yourself creatively.\n4. **Organizing**: You could tidy up your living space, plan your week ahead, or set new goals for yourself.\n5. **Socializing**: Reach out to friends or family for a chat, whether in person or through a call or message.\n6. **Relaxation**: Take some time to unwind, perhaps by meditating, lis",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 69,
+    "completion_tokens": 175,
+    "total_tokens": 244,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/stopSequencesParam/chat-completions/request.json
+++ b/payloads/snapshots/stopSequencesParam/chat-completions/request.json
@@ -1,0 +1,13 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Count from 1 to 20."
+    }
+  ],
+  "stop": [
+    "10",
+    "ten"
+  ]
+}

--- a/payloads/snapshots/stopSequencesParam/chat-completions/response.json
+++ b/payloads/snapshots/stopSequencesParam/chat-completions/response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz1Ys7Ucbh2mgI90TSDVOJzoOIo",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Sure! Here are the numbers from 1 to 20:\n\n1, 2, 3, 4, 5, 6, 7, 8, 9, ",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 15,
+    "completion_tokens": 41,
+    "total_tokens": 56,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/storeDisabledParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/storeDisabledParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    },
+    {
+      "role": "assistant",
+      "content": "ok",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "store": false
+}

--- a/payloads/snapshots/storeDisabledParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/storeDisabledParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz489PgQFFZS3SRfk3gKliJ27VX",
+  "object": "chat.completion",
+  "created": 1768411810,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Sure—what would you like to focus on? Here are a few quick options, with a simple next-step plan for each. Tell me which fits, or share your own goal.\n\n1) Decide what to work on next (planning)\n- Define your goal (what you want to achieve) and deadline.\n- List 3-5 candidate tasks.\n- Pick the one with the biggest impact for the least effort.\n- Timebox the first action (e.g., 25 minutes) and start.\n\n2) Create a plan for a project\n- Write a one-paragraph goal statement and a milestone roadmap.\n- Break milestones into 2–3 concrete tasks you can do this week.\n- Identify blockers and needed resources.\n- Schedule the first task with a deadline.\n\n3) Learn something new\n- Choose a topic and a tiny task (e.g., watch a 10-minute video, then summarize in 5 bullets).\n- Set a 30-minute focused practice block.\n- Review what you learned and note one next-step task.\n\n4) Build a new habit or routine\n- Pick one micro-habit (e.g., 5-minute daily practice).\n- Attach it to an existing daily cue (after you brush your teeth, do the habit).\n- Track consistency for a week and adjust if needed.\n\n5) Solve a problem you’re facing\n- State the problem in one sentence.\n- List constraints and possible solutions.\n- Pick a feasible option and define a concrete next action with a deadline.\n\nIf you share a bit about your goal, deadline, and any constraints, I can propose a tailored next step and even draft a quick to-do. Want to try a 5-minute planning sprint now? Here’s a quick template you can fill in:\n- Goal: [what you want to achieve] by [deadline]\n- Top 1–2 next actions: [action 1], [action 2]\n- Deadline for each action: [date/time]\n- Resources needed: [list]\n- Potential obstacle and backup plan: [brief note]\n\nTell me your context and I’ll customize this.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 26,
+    "completion_tokens": 1266,
+    "total_tokens": 1292,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 832,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/storeDisabledParam/chat-completions/request.json
+++ b/payloads/snapshots/storeDisabledParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say ok."
+    }
+  ],
+  "store": false
+}

--- a/payloads/snapshots/storeDisabledParam/chat-completions/response.json
+++ b/payloads/snapshots/storeDisabledParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz1mOzA2CclcouPHmgMgxvEYJGo",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "ok",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 9,
+    "completion_tokens": 202,
+    "total_tokens": 211,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 192,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/temperatureParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/temperatureParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say hi."
+    },
+    {
+      "role": "assistant",
+      "content": "Hi! How can I assist you today?",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "temperature": 0.7
+}

--- a/payloads/snapshots/temperatureParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/temperatureParam/chat-completions/followup-response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz2QNT0SyfVxYXtOAsRSCFZNcmE",
+  "object": "chat.completion",
+  "created": 1768411808,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "That depends on what you're looking to accomplish! Here are a few suggestions based on different contexts:\n\n1. **If you're looking for something productive**: \n   - Make a to-do list for the day.\n   - Start a project you've been putting off.\n   - Organize your workspace.\n\n2. **If you want to relax**:\n   - Read a book or watch a movie.\n   - Go for a walk or do some stretching.\n   - Try a new recipe or bake something.\n\n3. **If you're seeking inspiration**:\n   - Explore a new hobby or craft.\n   - Listen to a podcast or watch a documentary.\n   - Write in a journal or brainstorm ideas.\n\n4. **If you're feeling social**:\n   - Call or message a friend or family member.\n   - Plan a get-together or virtual hangout.\n   - Join a local club or online community.\n\nLet me know if you have a specific area in mind, and I can tailor my suggestions further!",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 33,
+    "completion_tokens": 201,
+    "total_tokens": 234,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/temperatureParam/chat-completions/request.json
+++ b/payloads/snapshots/temperatureParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say hi."
+    }
+  ],
+  "temperature": 0.7
+}

--- a/payloads/snapshots/temperatureParam/chat-completions/response.json
+++ b/payloads/snapshots/temperatureParam/chat-completions/response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz1ULDZoTZJAthztgUkSGKwOXYI",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hi! How can I assist you today?",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 9,
+    "total_tokens": 19,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}

--- a/payloads/snapshots/textFormatJsonObjectParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/textFormatJsonObjectParam/chat-completions/followup-request.json
@@ -1,0 +1,22 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Return {\"status\": \"ok\"} as JSON."
+    },
+    {
+      "role": "assistant",
+      "content": "{\"status\": \"ok\"}",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "response_format": {
+    "type": "json_object"
+  }
+}

--- a/payloads/snapshots/textFormatJsonObjectParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/textFormatJsonObjectParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxz263dciGek17xz8x2NI1CYaQy8m",
+  "object": "chat.completion",
+  "created": 1768411998,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\"status\":\"ok\"}\n\n",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 38,
+    "completion_tokens": 1038,
+    "total_tokens": 1076,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 1024,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/textFormatJsonObjectParam/chat-completions/request.json
+++ b/payloads/snapshots/textFormatJsonObjectParam/chat-completions/request.json
@@ -1,0 +1,12 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Return {\"status\": \"ok\"} as JSON."
+    }
+  ],
+  "response_format": {
+    "type": "json_object"
+  }
+}

--- a/payloads/snapshots/textFormatJsonObjectParam/chat-completions/response.json
+++ b/payloads/snapshots/textFormatJsonObjectParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxz247VXi3YovUR4yPmVadGYJttEa",
+  "object": "chat.completion",
+  "created": 1768411996,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\"status\": \"ok\"}",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 16,
+    "completion_tokens": 79,
+    "total_tokens": 95,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 64,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/textFormatJsonSchemaParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/textFormatJsonSchemaParam/chat-completions/followup-request.json
@@ -1,0 +1,42 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Extract: John is 25."
+    },
+    {
+      "role": "assistant",
+      "content": "{\"name\":\"John\",\"age\":25}",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "person_info",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "age"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}

--- a/payloads/snapshots/textFormatJsonSchemaParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/textFormatJsonSchemaParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz5fjHIwudEayXvyAtBXF0VN6C7",
+  "object": "chat.completion",
+  "created": 1768411811,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\"name\":\"John\",\"age\":25}",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 75,
+    "completion_tokens": 1494,
+    "total_tokens": 1569,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 1472,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/textFormatJsonSchemaParam/chat-completions/request.json
+++ b/payloads/snapshots/textFormatJsonSchemaParam/chat-completions/request.json
@@ -1,0 +1,32 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Extract: John is 25."
+    }
+  ],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "person_info",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "age"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}

--- a/payloads/snapshots/textFormatJsonSchemaParam/chat-completions/response.json
+++ b/payloads/snapshots/textFormatJsonSchemaParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Cxyz1vZIkU5JSns422HJmKe43jffV",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\"name\":\"John\",\"age\":25}",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 46,
+    "completion_tokens": 278,
+    "total_tokens": 324,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 256,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/toolChoiceRequiredParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/toolChoiceRequiredParam/chat-completions/followup-request.json
@@ -1,0 +1,58 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Tokyo weather"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "call_s07W8Ngy6ahqt8SodRcVC0wr",
+          "type": "function",
+          "function": {
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Tokyo\"}"
+          }
+        }
+      ],
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_s07W8Ngy6ahqt8SodRcVC0wr",
+      "content": "71 degrees"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "strict": true,
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "location"
+          ],
+          "additionalProperties": false
+        }
+      }
+    }
+  ],
+  "tool_choice": {
+    "type": "function",
+    "function": {
+      "name": "get_weather"
+    }
+  }
+}

--- a/payloads/snapshots/toolChoiceRequiredParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/toolChoiceRequiredParam/chat-completions/followup-response.json
@@ -1,0 +1,45 @@
+{
+  "id": "chatcmpl-Cy0KMUODSOCErXvAmZNXU35efRFnH",
+  "object": "chat.completion",
+  "created": 1768416974,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_OEbzppBzQpIHx2w9JCsR0WzP",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\":\"Tokyo\"}"
+            }
+          }
+        ],
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "tool_calls"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 153,
+    "completion_tokens": 471,
+    "total_tokens": 624,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 448,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/toolChoiceRequiredParam/chat-completions/request.json
+++ b/payloads/snapshots/toolChoiceRequiredParam/chat-completions/request.json
@@ -1,0 +1,37 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Tokyo weather"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "strict": true,
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "location"
+          ],
+          "additionalProperties": false
+        }
+      }
+    }
+  ],
+  "tool_choice": {
+    "type": "function",
+    "function": {
+      "name": "get_weather"
+    }
+  }
+}

--- a/payloads/snapshots/toolChoiceRequiredParam/chat-completions/response-streaming.json
+++ b/payloads/snapshots/toolChoiceRequiredParam/chat-completions/response-streaming.json
@@ -1,0 +1,174 @@
+[
+  {
+    "id": "chatcmpl-Cy0KWbthpAACiQSLCQrBMfb2ewiWU",
+    "object": "chat.completion.chunk",
+    "created": 1768416984,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "role": "assistant",
+          "content": null,
+          "tool_calls": [
+            {
+              "index": 0,
+              "id": "call_FYeYzNqy7xdnaPTa08SU250n",
+              "type": "function",
+              "function": {
+                "name": "get_weather",
+                "arguments": ""
+              }
+            }
+          ],
+          "refusal": null
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "02h3EwC71P1V8"
+  },
+  {
+    "id": "chatcmpl-Cy0KWbthpAACiQSLCQrBMfb2ewiWU",
+    "object": "chat.completion.chunk",
+    "created": 1768416984,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "tool_calls": [
+            {
+              "index": 0,
+              "function": {
+                "arguments": "{\""
+              }
+            }
+          ]
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7b3agQq"
+  },
+  {
+    "id": "chatcmpl-Cy0KWbthpAACiQSLCQrBMfb2ewiWU",
+    "object": "chat.completion.chunk",
+    "created": 1768416984,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "tool_calls": [
+            {
+              "index": 0,
+              "function": {
+                "arguments": "location"
+              }
+            }
+          ]
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "lK"
+  },
+  {
+    "id": "chatcmpl-Cy0KWbthpAACiQSLCQrBMfb2ewiWU",
+    "object": "chat.completion.chunk",
+    "created": 1768416984,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "tool_calls": [
+            {
+              "index": 0,
+              "function": {
+                "arguments": "\":\""
+              }
+            }
+          ]
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rHXyQ"
+  },
+  {
+    "id": "chatcmpl-Cy0KWbthpAACiQSLCQrBMfb2ewiWU",
+    "object": "chat.completion.chunk",
+    "created": 1768416984,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "tool_calls": [
+            {
+              "index": 0,
+              "function": {
+                "arguments": "Tokyo"
+              }
+            }
+          ]
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "EzTS8"
+  },
+  {
+    "id": "chatcmpl-Cy0KWbthpAACiQSLCQrBMfb2ewiWU",
+    "object": "chat.completion.chunk",
+    "created": 1768416984,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "tool_calls": [
+            {
+              "index": 0,
+              "function": {
+                "arguments": "\"}"
+              }
+            }
+          ]
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "IzZziEX"
+  },
+  {
+    "id": "chatcmpl-Cy0KWbthpAACiQSLCQrBMfb2ewiWU",
+    "object": "chat.completion.chunk",
+    "created": 1768416984,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {},
+        "finish_reason": "tool_calls"
+      }
+    ],
+    "obfuscation": "nkmmt9UV"
+  }
+]

--- a/payloads/snapshots/toolChoiceRequiredParam/chat-completions/response.json
+++ b/payloads/snapshots/toolChoiceRequiredParam/chat-completions/response.json
@@ -1,0 +1,45 @@
+{
+  "id": "chatcmpl-Cy0KHf9D7zESrsvcKTxwAb5EyWe8a",
+  "object": "chat.completion",
+  "created": 1768416969,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_s07W8Ngy6ahqt8SodRcVC0wr",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\":\"Tokyo\"}"
+            }
+          }
+        ],
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "tool_calls"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 123,
+    "completion_tokens": 471,
+    "total_tokens": 594,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 448,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/topPParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/topPParam/chat-completions/followup-request.json
@@ -1,0 +1,20 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say hi."
+    },
+    {
+      "role": "assistant",
+      "content": "Hi! How can I assist you today?",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "top_p": 0.9
+}

--- a/payloads/snapshots/topPParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/topPParam/chat-completions/followup-response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz2B5Um0U2U5gombnBkRRFfwtAn",
+  "object": "chat.completion",
+  "created": 1768411808,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "That depends on what you’re looking to do! Here are a few suggestions:\n\n1. **Learn Something New**: Pick a topic you’re interested in and read an article or watch a video about it.\n2. **Get Creative**: Try your hand at drawing, writing, or crafting.\n3. **Exercise**: Go for a walk, do some yoga, or try a workout routine at home.\n4. **Connect with Someone**: Reach out to a friend or family member for a chat.\n5. **Plan Your Day**: Make a to-do list or set some goals for the week.\n6. **Relax**: Take a break and enjoy some downtime, whether it’s meditating, listening to music, or watching a show.\n\nLet me know if you want more specific suggestions or have a certain area in mind!",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 33,
+    "completion_tokens": 170,
+    "total_tokens": 203,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_c4585b5b9c"
+}

--- a/payloads/snapshots/topPParam/chat-completions/request.json
+++ b/payloads/snapshots/topPParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Say hi."
+    }
+  ],
+  "top_p": 0.9
+}

--- a/payloads/snapshots/topPParam/chat-completions/response.json
+++ b/payloads/snapshots/topPParam/chat-completions/response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Cxyz1jlROWuECJ5ibo918JdaekX6m",
+  "object": "chat.completion",
+  "created": 1768411807,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hi! How can I assist you today?",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 9,
+    "total_tokens": 19,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_29330a9688"
+}


### PR DESCRIPTION
  Add Chat Completions API parameter test cases to the existing `params.ts` file for bidirectional mapping coverage.

  New test coverage, got the request body from https://platform.openai.com/docs/api-reference/chat/create:

  | Category | Responses API (existing) | Chat Completions API (new) |
  | --- | --- | --- |
  | Reasoning | effort, summary | + reasoning_effort |
  | Text config | json_object, json_schema | ✓ response_format (both types) |
  | Tools | function, web_search, code_interpreter, specific choice, parallel_tool_calls | ✓ function tools, tool_choice, parallel_tool_calls |
  | Context | instructions, truncation | + system message (maps to instructions) |
  | Storage | store | ✓ store |
  | Caching | service_tier, prompt_cache_key | ✓ service_tier, prompt_cache_key |
  | Metadata | metadata, safety_identifier | ✓ metadata, safety_identifier |
  | Sampling | - | + temperature, top_p, frequency_penalty, presence_penalty, logprobs, top_logprobs |
  | Output control | - | + n (multiple completions), stop, max_completion_tokens |
  | Advanced | - | + prediction, seed, logit_bias |

cross compatability coverage report -> https://github.com/braintrustdata/lingua/actions/runs/21009331121