### PR TITLE
Add proxy validation tool

### DIFF
--- a/payloads/README.md
+++ b/payloads/README.md
@@ -2,6 +2,18 @@
 
 Scripts to capture OpenAI and Anthropic API payloads with TypeScript type safety.
 
+## Table of contents
+
+- [Purpose](#purpose)
+- [Installation](#installation)
+- [Environment variables](#environment-variables)
+- [Capture usage](#usage)
+- [Validation tool](#validation-tool)
+- [Output structure](#output-structure)
+- [Example payloads](#example-payloads)
+- [Type checking](#type-checking)
+- [Extending](#extending)
+
 ## Purpose
 
 This package provides scripts to systematically capture real API requests and responses from OpenAI and Anthropic, using their official TypeScript types to ensure payload validity. This creates a repository of real-world test cases for AI API compatibility testing.
@@ -81,7 +93,61 @@ const anthropicRequest = {
 } satisfies Anthropic.MessageCreateParams;
 ```
 
-## Output Structure
+## Validation tool
+
+Validate any LLM proxy by comparing responses to captured snapshots.
+
+### Basic usage
+
+```bash
+# Validate chat-completions format through a proxy
+pnpm validate --proxy-url http://localhost:8080
+
+# Use Braintrust API key
+pnpm validate --proxy-url http://localhost:8080 --api-key $BRAINTRUST_API_KEY
+```
+
+### Testing different models
+
+The `--models` flag lets you test the same format with different provider models:
+
+```bash
+# Test with both OpenAI and Anthropic models through chat-completions format
+pnpm validate --proxy-url http://localhost:8080 --models openai,anthropic
+
+# Test specific model
+pnpm validate --proxy-url http://localhost:8080 --models anthropic
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--proxy-url <url>` | Proxy URL (required) |
+| `--api-key <key>` | API key for gateway |
+| `--format <formats>` | Formats to test: `chat-completions`, `responses`, `anthropic` |
+| `--models <models>` | Model providers: `openai`, `anthropic`, `google`, `bedrock` |
+| `--cases <cases>` | Specific cases to run |
+| `--all` | Run all cases (including slow ones) |
+| `--verbose` | Show full diff details |
+
+### Example output
+
+```
+Validating proxy at http://localhost:8080...
+
+chat-completions
+  ✓ simpleRequest [gpt-5-nano] (4124ms)
+  ✓ simpleRequest [claude-sonnet-4-20250514] (11033ms)
+  ✓ toolCallRequest [gpt-5-nano] (7344ms)
+  ✓ reasoningRequest [gpt-5-nano] (26859ms)
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Summary: 4 passed, 0 failed
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## Output structure
 
 Payloads are saved to `snapshots/` directory with the following naming:
 

--- a/payloads/package.json
+++ b/payloads/package.json
@@ -5,11 +5,14 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "capture": "tsx scripts/capture.ts",
+    "validate": "tsx scripts/validate.ts",
     "prune": "tsx scripts/prune.ts",
     "lint": "eslint \"./**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"./**/*.{ts,tsx}\" --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.63.0",
@@ -25,6 +28,7 @@
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.4.1",
     "tsx": "^4.19.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^3.0.0"
   }
 }

--- a/payloads/scripts/capture.ts
+++ b/payloads/scripts/capture.ts
@@ -199,7 +199,7 @@ async function main() {
       const result = await case_.executor.execute(
         case_.caseName,
         case_.payload,
-        options.stream
+        { stream: options.stream }
       );
 
       const savedFiles = saveAllFiles(

--- a/payloads/scripts/providers/bedrock.ts
+++ b/payloads/scripts/providers/bedrock.ts
@@ -6,7 +6,7 @@ import {
   type ConverseStreamOutput,
   type Message,
 } from "@aws-sdk/client-bedrock-runtime";
-import { CaptureResult, ProviderExecutor } from "../types";
+import { CaptureResult, ExecuteOptions, ProviderExecutor } from "../types";
 import {
   allTestCases,
   getCaseNames,
@@ -65,10 +65,12 @@ type ParallelBedrockResult =
 export async function executeBedrock(
   caseName: string,
   payload: BedrockConverseRequest,
-  stream?: boolean
+  options?: ExecuteOptions
 ): Promise<
   CaptureResult<BedrockConverseRequest, ConverseResponse, ConverseStreamOutput>
 > {
+  const { stream } = options ?? {};
+  // Note: Bedrock SDK uses AWS credentials, so baseURL/apiKey are ignored
   const client = createBedrockClient();
   const result: CaptureResult<
     BedrockConverseRequest,

--- a/payloads/scripts/providers/google.ts
+++ b/payloads/scripts/providers/google.ts
@@ -1,6 +1,6 @@
 import { GoogleGenAI } from "@google/genai";
 import type { GenerateContentResponse, Content } from "@google/genai";
-import { CaptureResult, ProviderExecutor } from "../types";
+import { CaptureResult, ExecuteOptions, ProviderExecutor } from "../types";
 import {
   allTestCases,
   getCaseNames,
@@ -33,7 +33,7 @@ type ParallelGoogleResult =
 export async function executeGoogle(
   caseName: string,
   payload: GoogleGenerateContentRequest,
-  stream?: boolean
+  options?: ExecuteOptions
 ): Promise<
   CaptureResult<
     GoogleGenerateContentRequest,
@@ -41,7 +41,11 @@ export async function executeGoogle(
     GenerateContentResponse
   >
 > {
-  const client = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
+  const { stream, apiKey } = options ?? {};
+  // Note: Google SDK doesn't support baseURL override, so we ignore it here
+  const client = new GoogleGenAI({
+    apiKey: apiKey ?? process.env.GOOGLE_API_KEY,
+  });
   const result: CaptureResult<
     GoogleGenerateContentRequest,
     GenerateContentResponse,

--- a/payloads/scripts/providers/openai-responses.ts
+++ b/payloads/scripts/providers/openai-responses.ts
@@ -1,5 +1,5 @@
 import OpenAI from "openai";
-import { CaptureResult, ProviderExecutor } from "../types";
+import { CaptureResult, ExecuteOptions, ProviderExecutor } from "../types";
 import { allTestCases, getCaseNames, getCaseForProvider } from "../../cases";
 import {
   ResponseInputItem,
@@ -33,7 +33,7 @@ type ParallelResponseResult =
 export async function executeOpenAIResponses(
   caseName: string,
   payload: OpenAI.Responses.ResponseCreateParams,
-  stream?: boolean
+  options?: ExecuteOptions
 ): Promise<
   CaptureResult<
     OpenAI.Responses.ResponseCreateParams,
@@ -41,7 +41,11 @@ export async function executeOpenAIResponses(
     unknown
   >
 > {
-  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const { stream, baseURL, apiKey } = options ?? {};
+  const client = new OpenAI({
+    apiKey: apiKey ?? process.env.OPENAI_API_KEY,
+    baseURL: baseURL ? `${baseURL}/v1` : undefined,
+  });
   const result: CaptureResult<
     OpenAI.Responses.ResponseCreateParams,
     OpenAI.Responses.Response,
@@ -233,4 +237,11 @@ export const openaiResponsesExecutor: ProviderExecutor<
   name: "responses",
   cases: openaiResponsesCases,
   execute: executeOpenAIResponses,
+  ignoredFields: [
+    "id",
+    "created_at",
+    "output.*.content.*.text",
+    "output_text",
+    "usage",
+  ],
 };

--- a/payloads/scripts/providers/openai.ts
+++ b/payloads/scripts/providers/openai.ts
@@ -1,5 +1,5 @@
 import OpenAI from "openai";
-import { CaptureResult, ProviderExecutor } from "../types";
+import { CaptureResult, ExecuteOptions, ProviderExecutor } from "../types";
 import { allTestCases, getCaseNames, getCaseForProvider } from "../../cases";
 
 // Define specific types for OpenAI
@@ -35,9 +35,13 @@ type ParallelOpenAIResult =
 export async function executeOpenAI(
   caseName: string,
   payload: OpenAIRequest,
-  stream?: boolean
+  options?: ExecuteOptions
 ): Promise<CaptureResult<OpenAIRequest, OpenAIResponse, OpenAIStreamChunk>> {
-  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const { stream, baseURL, apiKey } = options ?? {};
+  const client = new OpenAI({
+    apiKey: apiKey ?? process.env.OPENAI_API_KEY,
+    baseURL: baseURL ? `${baseURL}/v1` : undefined,
+  });
   const result: CaptureResult<
     OpenAIRequest,
     OpenAIResponse,
@@ -204,4 +208,18 @@ export const openaiExecutor: ProviderExecutor<
   name: "chat-completions",
   cases: openaiCases,
   execute: executeOpenAI,
+  ignoredFields: [
+    "id",
+    "created",
+    "model",
+    "service_tier",
+    "system_fingerprint",
+    "choices.*.message.content",
+    "choices.*.message.tool_calls.*.id",
+    "choices.*.delta.content",
+    "choices.*.delta.tool_calls.*.id",
+    "choices.*.finish_reason",
+    "usage",
+    "obfuscation",
+  ],
 };

--- a/payloads/scripts/types.ts
+++ b/payloads/scripts/types.ts
@@ -19,6 +19,12 @@ export interface ProviderCase<TPayload = unknown> {
   payload: TPayload;
 }
 
+export interface ExecuteOptions {
+  stream?: boolean;
+  baseURL?: string; // Proxy URL (e.g., "http://localhost:8080")
+  apiKey?: string; // API key override (e.g., BRAINTRUST_API_KEY)
+}
+
 export interface ProviderExecutor<
   TRequest = unknown,
   TResponse = unknown,
@@ -29,6 +35,8 @@ export interface ProviderExecutor<
   execute: (
     caseName: string,
     payload: TRequest,
-    stream?: boolean
+    options?: ExecuteOptions
   ) => Promise<CaptureResult<TRequest, TResponse, TStreamChunk>>;
+  // Fields to ignore when comparing responses (e.g., 'id', 'created', 'content')
+  ignoredFields?: string[];
 }

--- a/payloads/scripts/validate.ts
+++ b/payloads/scripts/validate.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env tsx
+
+// CLI wrapper for the validation library
+
+import {
+  runValidation,
+  getAvailableFormats,
+  ValidationResult,
+} from "./validation";
+import { createStreamingPrinter } from "./validation/reporter";
+
+interface CLIOptions {
+  proxyUrl?: string;
+  apiKey?: string;
+  formats?: string[];
+  cases?: string[];
+  providers?: string[];
+  all: boolean;
+  verbose: boolean;
+  stream: boolean;
+  help: boolean;
+}
+
+function parseArguments(): CLIOptions {
+  const args = process.argv.slice(2);
+  const options: CLIOptions = {
+    all: false,
+    verbose: false,
+    stream: false,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    switch (arg) {
+      case "--proxy-url":
+        if (i + 1 < args.length) {
+          options.proxyUrl = args[i + 1];
+          i++;
+        }
+        break;
+      case "--api-key":
+        if (i + 1 < args.length) {
+          options.apiKey = args[i + 1];
+          i++;
+        }
+        break;
+      case "--format":
+        if (i + 1 < args.length) {
+          options.formats = args[i + 1].split(",");
+          i++;
+        }
+        break;
+      case "--cases":
+        if (i + 1 < args.length) {
+          options.cases = args[i + 1].split(",");
+          i++;
+        }
+        break;
+      case "--provider":
+        if (i + 1 < args.length) {
+          options.providers = args[i + 1].split(",");
+          i++;
+        }
+        break;
+      case "--all":
+      case "-a":
+        options.all = true;
+        break;
+      case "--verbose":
+      case "-v":
+        options.verbose = true;
+        break;
+      case "--stream":
+      case "-s":
+        options.stream = true;
+        break;
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      default:
+        if (arg.startsWith("--")) {
+          console.error(`Unknown option: ${arg}`);
+          process.exit(1);
+        }
+    }
+  }
+
+  return options;
+}
+
+function printHelp(): void {
+  const formats = getAvailableFormats();
+
+  console.log(`
+Usage: ./scripts/validate.ts --proxy-url <url> [options]
+
+Validate an LLM proxy by comparing responses to captured snapshots.
+
+Required:
+  --proxy-url <url>      Proxy URL (e.g., http://localhost:8080)
+
+Options:
+  --api-key <key>        API key to use (default: provider-specific env vars)
+                         Use $BRAINTRUST_API_KEY for Braintrust gateway
+  --format <formats>     Comma-separated formats to test (default: chat-completions)
+                         Available: ${formats.join(", ")}
+  --provider <providers> Comma-separated providers to test (default: uses snapshot model)
+                         Available: openai, anthropic
+  --cases <cases>        Comma-separated case names to test (default: all)
+  --verbose, -v          Show full diff details
+  --stream, -s           Test streaming responses instead of non-streaming
+  --help, -h             Show this help message
+
+Examples:
+  # Validate chat-completions format through local gateway
+  ./scripts/validate.ts --proxy-url http://localhost:8080
+
+  # Validate with Braintrust API key
+  ./scripts/validate.ts --proxy-url http://localhost:8080 --api-key $BRAINTRUST_API_KEY
+
+  # Validate chat-completions format with both OpenAI and Anthropic providers
+  ./scripts/validate.ts --proxy-url http://localhost:8080 --provider openai,anthropic
+
+  # Validate multiple formats
+  ./scripts/validate.ts --proxy-url http://localhost:8080 --format chat-completions,anthropic
+
+  # Validate specific cases
+  ./scripts/validate.ts --proxy-url http://localhost:8080 --cases simpleRequest,toolCallRequest
+
+Environment Variables:
+  BRAINTRUST_API_KEY     API key for Braintrust gateway
+  OPENAI_API_KEY         API key for OpenAI (if not using --api-key)
+  ANTHROPIC_API_KEY      API key for Anthropic (if not using --api-key)
+`);
+}
+
+async function main(): Promise<void> {
+  const options = parseArguments();
+
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!options.proxyUrl) {
+    console.error("Error: --proxy-url is required\n");
+    printHelp();
+    process.exit(1);
+  }
+
+  // Use BRAINTRUST_API_KEY if available and no --api-key specified
+  const apiKey = options.apiKey ?? process.env.BRAINTRUST_API_KEY;
+
+  // Create streaming printer for real-time output
+  const printer = createStreamingPrinter({
+    verbose: options.verbose,
+    proxyUrl: options.proxyUrl,
+  });
+
+  // Collect results while printing them as they complete
+  const results: ValidationResult[] = [];
+
+  await runValidation({
+    proxyUrl: options.proxyUrl,
+    apiKey,
+    formats: options.formats,
+    cases: options.cases,
+    providers: options.providers,
+    all: options.all,
+    stream: options.stream,
+    onResult: (result) => {
+      results.push(result);
+      printer.printResult(result);
+    },
+  });
+
+  printer.printSummary(results);
+
+  // Exit with error code if any tests failed
+  const failed = results.filter((r) => !r.success).length;
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/payloads/scripts/validation/diff-utils.test.ts
+++ b/payloads/scripts/validation/diff-utils.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "vitest";
+import { compareResponses, formatDiff, DiffEntry } from "./diff-utils";
+
+describe("compareResponses", () => {
+  describe("matching objects", () => {
+    it("returns match for identical primitive values", () => {
+      const result = compareResponses(42, 42);
+      expect(result.match).toBe(true);
+      expect(result.diffs).toEqual([]);
+    });
+
+    it("returns match for identical strings", () => {
+      const result = compareResponses("hello", "hello");
+      expect(result.match).toBe(true);
+      expect(result.diffs).toEqual([]);
+    });
+
+    it("returns match for identical objects", () => {
+      const obj = { id: "123", name: "test", nested: { value: 42 } };
+      const result = compareResponses(obj, obj);
+      expect(result.match).toBe(true);
+      expect(result.diffs).toEqual([]);
+    });
+
+    it("returns match for identical arrays", () => {
+      const arr = [1, 2, { a: "b" }];
+      const result = compareResponses(arr, arr);
+      expect(result.match).toBe(true);
+      expect(result.diffs).toEqual([]);
+    });
+  });
+
+  describe("different values", () => {
+    it("detects different primitive values", () => {
+      const result = compareResponses(42, 43);
+      expect(result.match).toBe(false);
+      expect(result.diffs).toHaveLength(1);
+      expect(result.diffs[0]).toEqual({ path: "", expected: 42, actual: 43 });
+    });
+
+    it("detects different string values", () => {
+      const result = compareResponses("hello", "world");
+      expect(result.match).toBe(false);
+      expect(result.diffs).toHaveLength(1);
+    });
+
+    it("detects different nested values", () => {
+      const expected = { nested: { value: 42 } };
+      const actual = { nested: { value: 43 } };
+      const result = compareResponses(expected, actual);
+      expect(result.match).toBe(false);
+      expect(result.diffs).toHaveLength(1);
+      expect(result.diffs[0].path).toBe("nested.value");
+    });
+  });
+
+  describe("missing fields", () => {
+    it("detects missing field in actual", () => {
+      const expected = { id: "123", name: "test" };
+      const actual = { id: "123" };
+      const result = compareResponses(expected, actual);
+      expect(result.match).toBe(false);
+      expect(result.diffs).toHaveLength(1);
+      expect(result.diffs[0].path).toBe("name (missing)");
+    });
+
+    it("detects extra field in actual", () => {
+      const expected = { id: "123" };
+      const actual = { id: "123", extra: "value" };
+      const result = compareResponses(expected, actual);
+      expect(result.match).toBe(false);
+      expect(result.diffs).toHaveLength(1);
+      expect(result.diffs[0].path).toBe("extra");
+      expect(result.diffs[0].expected).toBe(undefined);
+      expect(result.diffs[0].actual).toBe("value");
+    });
+  });
+
+  describe("type mismatches", () => {
+    it("detects type mismatch between number and string", () => {
+      const result = compareResponses(42, "42");
+      expect(result.match).toBe(false);
+      expect(result.diffs).toHaveLength(1);
+    });
+
+    it("detects difference between object and array (treated as objects)", () => {
+      // Arrays are objects in JS, so deepCompare compares their keys
+      // { a: 1 } has key "a", [1] has key "0" - both report as missing from the other
+      const result = compareResponses({ a: 1 }, [1]);
+      expect(result.match).toBe(false);
+      expect(result.diffs.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("detects type mismatch between null and value", () => {
+      const result = compareResponses(null, "value");
+      expect(result.match).toBe(false);
+      expect(result.diffs).toHaveLength(1);
+    });
+  });
+
+  describe("array handling", () => {
+    it("detects different array lengths within objects", () => {
+      // Note: Top-level arrays auto-ignore "length" for streaming support
+      // So we test array length detection within an object
+      const expected = { items: [1, 2, 3] };
+      const actual = { items: [1, 2] };
+      const result = compareResponses(expected, actual);
+      expect(result.match).toBe(false);
+      expect(result.diffs.some((d) => d.path === "items.length")).toBe(true);
+    });
+
+    it("ignores length for top-level arrays (streaming support)", () => {
+      // Top-level arrays auto-ignore length since streaming chunk counts vary
+      const expected = [1, 2, 3];
+      const actual = [1, 2];
+      const result = compareResponses(expected, actual);
+      expect(result.match).toBe(true);
+    });
+
+    it("detects different array elements", () => {
+      const result = compareResponses([1, 2, 3], [1, 5, 3]);
+      expect(result.match).toBe(false);
+      expect(result.diffs.some((d) => d.path === "1")).toBe(true);
+    });
+
+    it("handles nested arrays", () => {
+      const expected = { items: [{ id: 1 }, { id: 2 }] };
+      const actual = { items: [{ id: 1 }, { id: 3 }] };
+      const result = compareResponses(expected, actual);
+      expect(result.match).toBe(false);
+      expect(result.diffs[0].path).toBe("items.1.id");
+    });
+  });
+
+  describe("ignored fields", () => {
+    it("ignores exact field match", () => {
+      const expected = { id: "123", name: "test" };
+      const actual = { id: "456", name: "test" };
+      const result = compareResponses(expected, actual, ["id"]);
+      expect(result.match).toBe(true);
+    });
+
+    it("ignores nested field with dot notation", () => {
+      const expected = { data: { timestamp: 100, value: "a" } };
+      const actual = { data: { timestamp: 200, value: "a" } };
+      const result = compareResponses(expected, actual, ["data.timestamp"]);
+      expect(result.match).toBe(true);
+    });
+
+    it("ignores field with wildcard in array", () => {
+      const expected = {
+        choices: [
+          { index: 0, message: { content: "hello" } },
+          { index: 1, message: { content: "world" } },
+        ],
+      };
+      const actual = {
+        choices: [
+          { index: 0, message: { content: "different" } },
+          { index: 1, message: { content: "values" } },
+        ],
+      };
+      const result = compareResponses(expected, actual, [
+        "choices.*.message.content",
+      ]);
+      expect(result.match).toBe(true);
+    });
+
+    it("still detects non-ignored differences with wildcards", () => {
+      const expected = {
+        choices: [
+          { index: 0, message: { content: "hello" } },
+          { index: 1, message: { content: "world" } },
+        ],
+      };
+      const actual = {
+        choices: [
+          { index: 5, message: { content: "different" } },
+          { index: 1, message: { content: "values" } },
+        ],
+      };
+      const result = compareResponses(expected, actual, [
+        "choices.*.message.content",
+      ]);
+      expect(result.match).toBe(false);
+      expect(result.diffs[0].path).toBe("choices.0.index");
+    });
+
+    it("ignores multiple fields", () => {
+      const expected = { id: "123", timestamp: 100, value: "a" };
+      const actual = { id: "456", timestamp: 200, value: "a" };
+      const result = compareResponses(expected, actual, ["id", "timestamp"]);
+      expect(result.match).toBe(true);
+    });
+  });
+
+  describe("array (streaming) response handling", () => {
+    it("auto-prefixes ignore patterns with *. for array responses", () => {
+      const expected = [
+        { id: "1", content: "chunk1" },
+        { id: "2", content: "chunk2" },
+      ];
+      const actual = [
+        { id: "different1", content: "chunk1" },
+        { id: "different2", content: "chunk2" },
+      ];
+      const result = compareResponses(expected, actual, ["id"]);
+      expect(result.match).toBe(true);
+    });
+
+    it("ignores array length for streaming responses", () => {
+      const expected = [{ id: "1" }, { id: "2" }];
+      const actual = [{ id: "different1" }, { id: "different2" }, { id: "3" }];
+      const result = compareResponses(expected, actual, ["id"]);
+      expect(result.match).toBe(true);
+    });
+  });
+});
+
+describe("formatDiff", () => {
+  it("formats primitive diff", () => {
+    const diff: DiffEntry = { path: "value", expected: 42, actual: 43 };
+    expect(formatDiff(diff)).toBe("value: 42 → 43");
+  });
+
+  it("formats string diff", () => {
+    const diff: DiffEntry = {
+      path: "name",
+      expected: "hello",
+      actual: "world",
+    };
+    expect(formatDiff(diff)).toBe("name: hello → world");
+  });
+
+  it("formats object diff", () => {
+    const diff: DiffEntry = {
+      path: "data",
+      expected: { a: 1 },
+      actual: { a: 2 },
+    };
+    expect(formatDiff(diff)).toBe('data: {"a":1} → {"a":2}');
+  });
+
+  it("formats array diff", () => {
+    const diff: DiffEntry = {
+      path: "items",
+      expected: [1, 2],
+      actual: [1, 2, 3],
+    };
+    expect(formatDiff(diff)).toBe("items: [1,2] → [1,2,3]");
+  });
+
+  it("formats nested path diff", () => {
+    const diff: DiffEntry = {
+      path: "choices.0.message.content",
+      expected: "hello",
+      actual: "world",
+    };
+    expect(formatDiff(diff)).toBe("choices.0.message.content: hello → world");
+  });
+
+  it("formats missing field diff", () => {
+    const diff: DiffEntry = {
+      path: "field (missing)",
+      expected: "(exists)",
+      actual: "(missing)",
+    };
+    expect(formatDiff(diff)).toBe("field (missing): (exists) → (missing)");
+  });
+});

--- a/payloads/scripts/validation/diff-utils.ts
+++ b/payloads/scripts/validation/diff-utils.ts
@@ -1,0 +1,202 @@
+// JSON comparison utilities with field ignore support
+
+export interface DiffEntry {
+  path: string;
+  expected: unknown;
+  actual: unknown;
+}
+
+export interface DiffResult {
+  match: boolean;
+  diffs: DiffEntry[];
+}
+
+/**
+ * Check if a path matches an ignore pattern.
+ * Supports:
+ * - Exact matches: "id", "usage"
+ * - Dot notation: "choices.0.message.content"
+ * - Wildcards: "choices.*.message.content" (matches any array index)
+ */
+function matchesIgnorePattern(path: string, pattern: string): boolean {
+  // Convert pattern to regex
+  // - Escape dots
+  // - Replace * with regex pattern for array indices or object keys
+  const regexPattern = pattern
+    .split(".")
+    .map((part) => {
+      if (part === "*") {
+        return "[^.]+"; // Match any segment (array index or key)
+      }
+      return part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // Escape special chars
+    })
+    .join("\\.");
+
+  const regex = new RegExp(`^${regexPattern}$`);
+  return regex.test(path);
+}
+
+/**
+ * Check if a path should be ignored based on the ignore patterns.
+ */
+function shouldIgnore(path: string, ignoredFields: string[]): boolean {
+  return ignoredFields.some((pattern) => matchesIgnorePattern(path, pattern));
+}
+
+/**
+ * Deep compare two values, tracking the path and collecting differences.
+ * When a field is ignored, we still verify the key exists - just ignore the value.
+ */
+function deepCompare(
+  expected: unknown,
+  actual: unknown,
+  path: string,
+  ignoredFields: string[],
+  diffs: DiffEntry[]
+): void {
+  const isIgnored = shouldIgnore(path, ignoredFields);
+
+  // Handle null/undefined - even for ignored fields, check presence
+  if (expected === null || expected === undefined) {
+    if (actual !== null && actual !== undefined) {
+      // Only report if NOT ignored (ignored means we don't care about value differences)
+      if (!isIgnored) {
+        diffs.push({ path, expected, actual });
+      }
+    }
+    return;
+  }
+  if (actual === null || actual === undefined) {
+    // Key exists in expected but missing in actual
+    // Skip if this field is ignored (we don't care about its presence)
+    if (!isIgnored) {
+      diffs.push({
+        path: `${path} (missing)`,
+        expected: "(exists)",
+        actual: "(missing)",
+      });
+    }
+    return;
+  }
+
+  // If this path is ignored, we've verified both have the key - stop here
+  if (isIgnored) {
+    return;
+  }
+
+  // Handle different types
+  const expectedType = typeof expected;
+  const actualType = typeof actual;
+
+  if (expectedType !== actualType) {
+    diffs.push({ path, expected, actual });
+    return;
+  }
+
+  // Handle arrays
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual)) {
+      diffs.push({ path, expected, actual });
+      return;
+    }
+
+    // Compare array lengths
+    const lengthPath = path ? `${path}.length` : "length";
+    const ignoringLength = shouldIgnore(lengthPath, ignoredFields);
+    if (expected.length !== actual.length && !ignoringLength) {
+      diffs.push({
+        path: lengthPath,
+        expected: expected.length,
+        actual: actual.length,
+      });
+    }
+
+    // Compare each element
+    // When ignoring length (e.g., streaming), only compare elements that exist in both
+    const compareLen = ignoringLength
+      ? Math.min(expected.length, actual.length)
+      : Math.max(expected.length, actual.length);
+    for (let i = 0; i < compareLen; i++) {
+      const elemPath = path ? `${path}.${i}` : String(i);
+      deepCompare(expected[i], actual[i], elemPath, ignoredFields, diffs);
+    }
+    return;
+  }
+
+  // Handle objects
+  if (expectedType === "object") {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Type narrowing already confirmed this is an object
+    const expectedObj = expected as Record<string, unknown>;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Type narrowing already confirmed this is an object
+    const actualObj = actual as Record<string, unknown>;
+
+    // Get all keys from both objects
+    const allKeys = new Set([
+      ...Object.keys(expectedObj),
+      ...Object.keys(actualObj),
+    ]);
+
+    for (const key of allKeys) {
+      const keyPath = path ? `${path}.${key}` : key;
+      deepCompare(
+        expectedObj[key],
+        actualObj[key],
+        keyPath,
+        ignoredFields,
+        diffs
+      );
+    }
+    return;
+  }
+
+  // Handle primitives
+  if (expected !== actual) {
+    diffs.push({ path, expected, actual });
+  }
+}
+
+/**
+ * Compare two JSON objects and return differences, ignoring specified fields.
+ *
+ * @param expected - The expected/baseline response
+ * @param actual - The actual response from the proxy
+ * @param ignoredFields - Fields to ignore (supports wildcards like "choices.*.message.content")
+ * @returns DiffResult with match status and list of differences
+ */
+export function compareResponses(
+  expected: unknown,
+  actual: unknown,
+  ignoredFields: string[] = []
+): DiffResult {
+  // Transform patterns for array (streaming) responses
+  // "id" → "*.id" to match "0.id", "1.id", etc.
+  // "choices.*.delta.content" → "*.choices.*.delta.content"
+  // Also ignore "length" since streaming chunk count is variable
+  const effectiveIgnoredFields = Array.isArray(expected)
+    ? [...ignoredFields.map((pattern) => `*.${pattern}`), "length"]
+    : ignoredFields;
+
+  const diffs: DiffEntry[] = [];
+  deepCompare(expected, actual, "", effectiveIgnoredFields, diffs);
+
+  return {
+    match: diffs.length === 0,
+    diffs,
+  };
+}
+
+/**
+ * Format a diff entry for display.
+ */
+export function formatDiff(diff: DiffEntry): string {
+  const expectedStr =
+    typeof diff.expected === "object"
+      ? JSON.stringify(diff.expected)
+      : String(diff.expected);
+  const actualStr =
+    typeof diff.actual === "object"
+      ? JSON.stringify(diff.actual)
+      : String(diff.actual);
+
+  return `${diff.path}: ${expectedStr} → ${actualStr}`;
+}

--- a/payloads/scripts/validation/index.ts
+++ b/payloads/scripts/validation/index.ts
@@ -1,0 +1,328 @@
+// Core validation library - runValidation()
+
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { compareResponses, DiffResult } from "./diff-utils";
+
+// Import executors
+import { openaiExecutor } from "../providers/openai";
+import { openaiResponsesExecutor } from "../providers/openai-responses";
+import { anthropicExecutor } from "../providers/anthropic";
+
+// Import test cases from code
+import { simpleCases, getCaseNames, getCaseForProvider } from "../../cases";
+import {
+  OPENAI_CHAT_COMPLETIONS_MODEL,
+  ANTHROPIC_MODEL,
+  GOOGLE_MODEL,
+  BEDROCK_MODEL,
+} from "../../cases/models";
+
+// Simplified executor interface for the registry (relaxes generic constraints)
+interface ExecutorEntry {
+  name: string;
+  cases: Record<string, unknown>;
+  execute: (
+    caseName: string,
+    payload: unknown,
+    options?: { stream?: boolean; baseURL?: string; apiKey?: string }
+  ) => Promise<{
+    request: unknown;
+    response?: unknown;
+    streamingResponse?: unknown[];
+    error?: string;
+  }>;
+  ignoredFields?: string[];
+}
+
+// Format registry - maps format names to executors
+// Type assertions are necessary for heterogeneous executor types in the registry
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+const formatRegistry: Record<string, ExecutorEntry> = {
+  "chat-completions": openaiExecutor as ExecutorEntry,
+  responses: openaiResponsesExecutor as ExecutorEntry,
+  anthropic: anthropicExecutor as ExecutorEntry,
+};
+/* eslint-enable @typescript-eslint/consistent-type-assertions */
+
+export interface ValidationOptions {
+  proxyUrl: string;
+  apiKey?: string; // API key to use (e.g., BRAINTRUST_API_KEY)
+  formats?: string[]; // default: ['chat-completions']
+  cases?: string[]; // default: DEFAULT_CASES (use `all: true` for all)
+  providers?: string[]; // provider aliases to test (default: uses snapshot model)
+  all?: boolean; // run all cases including slow ones
+  stream?: boolean; // default: false (non-streaming only)
+  onResult?: (result: ValidationResult) => void; // callback for streaming results
+}
+
+export interface ValidationResult {
+  format: string;
+  caseName: string;
+  model: string; // model that was tested
+  success: boolean;
+  durationMs: number;
+  diff?: DiffResult; // only if success=false due to diff
+  error?: string; // only if request failed
+}
+
+/**
+ * Get the snapshots directory path.
+ */
+function getSnapshotsDir(): string {
+  return join(__dirname, "..", "..", "snapshots");
+}
+
+/**
+ * Load a snapshot file (request.json or response.json).
+ */
+function loadSnapshotFile<T>(
+  caseName: string,
+  format: string,
+  filename: string
+): T | null {
+  const filepath = join(getSnapshotsDir(), caseName, format, filename);
+  if (!existsSync(filepath)) {
+    return null;
+  }
+  const content = readFileSync(filepath, "utf-8");
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- JSON.parse returns unknown, caller provides expected type
+  return JSON.parse(content) as T;
+}
+
+// Default cases to run (fast + representative)
+const DEFAULT_CASES = ["simpleRequest", "toolCallRequest", "reasoningRequest"];
+
+// Provider registry - maps provider aliases to actual model names (uses canonical models.ts)
+const PROVIDER_REGISTRY: Record<string, string> = {
+  openai: OPENAI_CHAT_COMPLETIONS_MODEL,
+  anthropic: ANTHROPIC_MODEL,
+  google: GOOGLE_MODEL,
+  bedrock: BEDROCK_MODEL,
+};
+
+/**
+ * Get all available cases for a format from the cases definitions.
+ */
+function getAvailableCases(format: string): string[] {
+  return getCaseNames(simpleCases).filter(
+    (caseName) =>
+      getCaseForProvider(
+        simpleCases,
+        caseName,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- format is a string key
+        format as
+          | "chat-completions"
+          | "responses"
+          | "anthropic"
+          | "google"
+          | "bedrock"
+      ) !== undefined
+  );
+}
+
+/**
+ * Get executor for a format.
+ */
+function getExecutorForFormat(format: string): ExecutorEntry | null {
+  return formatRegistry[format] ?? null;
+}
+
+/**
+ * Get list of available formats.
+ */
+export function getAvailableFormats(): string[] {
+  return Object.keys(formatRegistry);
+}
+
+/**
+ * Get list of available provider aliases.
+ */
+export function getAvailableProviders(): string[] {
+  return Object.keys(PROVIDER_REGISTRY);
+}
+
+/**
+ * Run validation against a proxy, comparing responses to snapshots.
+ *
+ * @param options - Validation options
+ * @returns Array of validation results
+ */
+export async function runValidation(
+  options: ValidationOptions
+): Promise<ValidationResult[]> {
+  const results: ValidationResult[] = [];
+  const formats = options.formats ?? ["chat-completions"];
+  // "default" means use the snapshot's model as-is
+  const providersToTest = options.providers ?? ["default"];
+
+  for (const format of formats) {
+    const executor = getExecutorForFormat(format);
+    if (!executor) {
+      console.error(`Unknown format: ${format}`);
+      continue;
+    }
+
+    // Get cases to run
+    const availableCases = getAvailableCases(format);
+    let caseNames: string[];
+    if (options.cases) {
+      // User specified explicit cases
+      caseNames = options.cases.filter((c) => availableCases.includes(c));
+    } else if (options.all) {
+      // Run all available cases
+      caseNames = availableCases;
+    } else {
+      // Use default cases (filtered to available)
+      caseNames = DEFAULT_CASES.filter((c) => availableCases.includes(c));
+    }
+
+    if (caseNames.length === 0) {
+      console.warn(`No cases found for format: ${format}`);
+      continue;
+    }
+
+    // Run all (case, provider) combinations in parallel
+    const testCombinations: Array<{ caseName: string; providerAlias: string }> =
+      [];
+    for (const caseName of caseNames) {
+      for (const providerAlias of providersToTest) {
+        testCombinations.push({ caseName, providerAlias });
+      }
+    }
+
+    const caseResults = await Promise.all(
+      testCombinations.map(
+        async ({ caseName, providerAlias }): Promise<ValidationResult> => {
+          const start = Date.now();
+
+          // Resolve model name from provider alias
+          const modelName =
+            providerAlias === "default"
+              ? "default"
+              : (PROVIDER_REGISTRY[providerAlias] ?? providerAlias);
+
+          try {
+            // Get request from cases definitions (single source of truth)
+            const caseRequest = getCaseForProvider(
+              simpleCases,
+              caseName,
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- format is a string key
+              format as
+                | "chat-completions"
+                | "responses"
+                | "anthropic"
+                | "google"
+                | "bedrock"
+            );
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Need to type the request for model override
+            let request = caseRequest as Record<string, unknown> | null;
+            // Load expected response from snapshots for comparison
+            const snapshotFilename = options.stream
+              ? "response-streaming.json"
+              : "response.json";
+            const expectedResponse = loadSnapshotFile(
+              caseName,
+              format,
+              snapshotFilename
+            );
+
+            if (!request) {
+              const result: ValidationResult = {
+                format,
+                caseName,
+                model: modelName,
+                success: false,
+                durationMs: Date.now() - start,
+                error: `Case ${caseName} not found for format ${format}`,
+              };
+              options.onResult?.(result);
+              return result;
+            }
+
+            if (!expectedResponse) {
+              const result: ValidationResult = {
+                format,
+                caseName,
+                model: modelName,
+                success: false,
+                durationMs: Date.now() - start,
+                error: `Missing ${snapshotFilename} for ${caseName}/${format}`,
+              };
+              options.onResult?.(result);
+              return result;
+            }
+
+            // Override model if not using default
+            if (
+              providerAlias !== "default" &&
+              PROVIDER_REGISTRY[providerAlias]
+            ) {
+              request = { ...request, model: PROVIDER_REGISTRY[providerAlias] };
+            }
+
+            // Execute through proxy
+            const actual = await executor.execute(caseName, request, {
+              stream: options.stream,
+              baseURL: options.proxyUrl,
+              apiKey: options.apiKey,
+            });
+
+            if (actual.error) {
+              const result: ValidationResult = {
+                format,
+                caseName,
+                model: modelName,
+                success: false,
+                durationMs: Date.now() - start,
+                error: actual.error,
+              };
+              options.onResult?.(result);
+              return result;
+            }
+
+            // Compare response (use streamingResponse array when streaming)
+            const actualResponse = options.stream
+              ? actual.streamingResponse
+              : actual.response;
+            const diff = compareResponses(
+              expectedResponse,
+              actualResponse,
+              executor.ignoredFields ?? []
+            );
+
+            const result: ValidationResult = {
+              format,
+              caseName,
+              model: modelName,
+              success: diff.match,
+              durationMs: Date.now() - start,
+              diff: diff.match ? undefined : diff,
+            };
+            options.onResult?.(result);
+            return result;
+          } catch (error) {
+            const result: ValidationResult = {
+              format,
+              caseName,
+              model: modelName,
+              success: false,
+              durationMs: Date.now() - start,
+              error: String(error),
+            };
+            options.onResult?.(result);
+            return result;
+          }
+        }
+      )
+    );
+
+    results.push(...caseResults);
+  }
+
+  return results;
+}
+
+// Re-export types for convenience
+export type { DiffResult, DiffEntry } from "./diff-utils";
+export { compareResponses, formatDiff } from "./diff-utils";

--- a/payloads/scripts/validation/reporter.ts
+++ b/payloads/scripts/validation/reporter.ts
@@ -1,0 +1,112 @@
+// Console output formatting for validation results
+
+import { ValidationResult } from "./index";
+import { formatDiff } from "./diff-utils";
+
+// ANSI color codes
+const colors = {
+  reset: "\x1b[0m",
+  green: "\x1b[32m",
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+};
+
+interface PrinterOptions {
+  verbose?: boolean;
+  proxyUrl: string;
+}
+
+/**
+ * Create a streaming printer that prints results as they complete.
+ */
+export function createStreamingPrinter(options: PrinterOptions) {
+  const { verbose, proxyUrl } = options;
+  let currentFormat: string | null = null;
+  let headerPrinted = false;
+
+  return {
+    printResult(result: ValidationResult): void {
+      // Print header on first result
+      if (!headerPrinted) {
+        console.log(
+          `\nValidating proxy at ${colors.cyan}${proxyUrl}${colors.reset}...\n`
+        );
+        headerPrinted = true;
+      }
+
+      // Print format header when format changes
+      if (result.format !== currentFormat) {
+        if (currentFormat !== null) {
+          console.log(); // Blank line between formats
+        }
+        console.log(`${colors.bold}${result.format}${colors.reset}`);
+        currentFormat = result.format;
+      }
+
+      // Print result
+      const icon = result.success
+        ? `${colors.green}✓${colors.reset}`
+        : `${colors.red}✗${colors.reset}`;
+      const duration = `${colors.dim}(${result.durationMs}ms)${colors.reset}`;
+      const modelLabel =
+        result.model !== "default"
+          ? ` ${colors.cyan}[${result.model}]${colors.reset}`
+          : "";
+
+      if (result.success) {
+        console.log(`  ${icon} ${result.caseName}${modelLabel} ${duration}`);
+      } else if (result.error) {
+        console.log(`  ${icon} ${result.caseName}${modelLabel} ${duration}`);
+        console.log(`    ${colors.red}Error: ${result.error}${colors.reset}`);
+      } else if (result.diff) {
+        console.log(`  ${icon} ${result.caseName}${modelLabel} ${duration}`);
+        console.log(`    ${colors.yellow}Differences found:${colors.reset}`);
+
+        const diffsToShow = verbose
+          ? result.diff.diffs
+          : result.diff.diffs.slice(0, 5);
+        for (const diff of diffsToShow) {
+          console.log(`      ${colors.dim}${formatDiff(diff)}${colors.reset}`);
+        }
+
+        if (!verbose && result.diff.diffs.length > 5) {
+          console.log(
+            `      ${colors.dim}... and ${result.diff.diffs.length - 5} more differences${colors.reset}`
+          );
+        }
+      }
+    },
+
+    printSummary(results: ValidationResult[]): void {
+      const passed = results.filter((r) => r.success).length;
+      const failed = results.length - passed;
+      const totalDuration = results.reduce((sum, r) => sum + r.durationMs, 0);
+
+      console.log(); // Blank line before summary
+      console.log("━".repeat(50));
+      console.log(
+        `${colors.bold}Summary:${colors.reset} ${colors.green}${passed} passed${colors.reset}, ${failed > 0 ? colors.red : colors.dim}${failed} failed${colors.reset}`
+      );
+      console.log(`${colors.dim}Total time: ${totalDuration}ms${colors.reset}`);
+      console.log("━".repeat(50));
+    },
+  };
+}
+
+/**
+ * Print a validation report to the console (batch mode).
+ * @deprecated Use createStreamingPrinter for streaming output
+ */
+export function printReport(
+  results: ValidationResult[],
+  options: PrinterOptions
+): void {
+  const printer = createStreamingPrinter(options);
+  for (const result of results) {
+    printer.printResult(result);
+  }
+  printer.printSummary(results);
+}

--- a/payloads/vitest.config.ts
+++ b/payloads/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["scripts/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.1)
 
 packages:
 
@@ -1184,6 +1187,12 @@ packages:
   '@swc/wasm@1.15.7':
     resolution: {integrity: sha512-m1Cslgkp7gFIUB2ZiIUHMoUskwxOAi9uaf27inoKb7Oc8MkMjt+eNTeSyeGckkwRtMQiybKYTGGnA5imxSsedQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1255,17 +1264,46 @@ packages:
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/runner@1.6.1':
     resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
   '@vitest/snapshot@1.6.1':
     resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
   '@vitest/spy@1.6.1':
     resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1317,6 +1355,10 @@ packages:
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1356,12 +1398,20 @@ packages:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -1409,6 +1459,10 @@ packages:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1447,6 +1501,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -1517,6 +1574,10 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1759,6 +1820,9 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -1890,6 +1954,10 @@ packages:
 
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2050,6 +2118,9 @@ packages:
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   strnum@2.1.2:
     resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
@@ -2086,8 +2157,20 @@ packages:
     resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
     engines: {node: '>=14.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tree-kill@1.2.2:
@@ -2168,6 +2251,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-plugin-top-level-await@1.6.0:
     resolution: {integrity: sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww==}
     peerDependencies:
@@ -2222,6 +2310,34 @@ packages:
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -3453,6 +3569,13 @@ snapshots:
 
   '@swc/wasm@1.15.7': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.1':
@@ -3559,11 +3682,37 @@ snapshots:
       '@vitest/utils': 1.6.1
       chai: 4.5.0
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@22.19.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.1)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/runner@1.6.1':
     dependencies:
       '@vitest/utils': 1.6.1
       p-limit: 5.0.0
       pathe: 1.1.2
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
 
   '@vitest/snapshot@1.6.1':
     dependencies:
@@ -3571,9 +3720,19 @@ snapshots:
       pathe: 1.1.2
       pretty-format: 29.7.0
 
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@1.6.1':
     dependencies:
       tinyspy: 2.2.1
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -3581,6 +3740,12 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -3618,6 +3783,8 @@ snapshots:
   argparse@2.0.1: {}
 
   assertion-error@1.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
 
@@ -3657,6 +3824,14 @@ snapshots:
       pathval: 1.1.1
       type-detect: 4.1.0
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -3665,6 +3840,8 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -3700,6 +3877,8 @@ snapshots:
     dependencies:
       type-detect: 4.1.0
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   diff-sequences@29.6.3: {}
@@ -3732,6 +3911,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -3908,6 +4089,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -4158,6 +4341,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   magic-string@0.30.21:
@@ -4270,6 +4455,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@1.1.1: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -4412,6 +4599,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   strnum@2.1.2: {}
 
   sucrase@3.35.1:
@@ -4449,7 +4640,13 @@ snapshots:
 
   tinypool@0.8.4: {}
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
   tinyspy@2.2.1: {}
+
+  tinyspy@4.0.4: {}
 
   tree-kill@1.2.2: {}
 
@@ -4537,6 +4734,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@3.2.4(@types/node@22.19.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.21(@types/node@22.19.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-plugin-top-level-await@1.6.0(rollup@4.53.3)(vite@5.4.21(@types/node@22.19.1)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.53.3)
@@ -4588,6 +4803,44 @@ snapshots:
     transitivePeerDependencies:
       - less
       - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@3.2.4(@types/node@22.19.1):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@22.19.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@22.19.1)
+      vite-node: 3.2.4(@types/node@22.19.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
       - sass
       - sass-embedded
       - stylus


### PR DESCRIPTION
### TL;DR

Added a validation tool to compare LLM proxy responses against captured snapshots, ensuring API compatibility.

### Testing - ran manually:

```bash
pnpm validate --proxy-url http://localhost:8080 --models openai,anthropic,google

> @braintrust/payload-capture@0.1.0 validate /Users/kenjiang/Development/braintrust/lingua/payloads
> tsx scripts/validate.ts --proxy-url http://localhost:8080 --models openai,anthropic,google


Validating proxy at http://localhost:8080...

chat-completions
  ✗ toolCallRequest [gemini-2.5-flash] (379ms)
    Error: Error: 400 Invalid JSON payload received. Unknown name "function" at 'tools[0]': Cannot find field.
Invalid JSON payload received. Unknown name "type" at 'tools[0]': Cannot find field.
  ✗ toolCallRequest [claude-sonnet-4-20250514] (388ms)
    Error: Error: 400 tool_choice: Input should be a valid dictionary or object to extract fields from
  ✓ simpleRequest [gpt-5-nano] (7024ms)
  ✓ simpleRequest [gemini-2.5-flash] (7442ms)
  ✓ simpleRequest [claude-sonnet-4-20250514] (8436ms)
  ✓ toolCallRequest [gpt-5-nano] (10404ms)
  ✓ reasoningRequest [claude-sonnet-4-20250514] (13769ms)
  ✓ reasoningRequest [gemini-2.5-flash] (13920ms)
  ✓ reasoningRequest [gpt-5-nano] (26758ms)

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Summary: 7 passed, 2 failed
Total time: 88520ms
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ELIFECYCLE  Command failed with exit code 1.```
```

### Why make this change?

This validation tool enables systematic testing of LLM proxies and gateways against known-good responses. It helps ensure that proxies maintain API compatibility with original providers.