### PR TITLE
forward client headers for providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d10e4f991a553474232bc0a31799f6d24b034a84c0971d80d2e2f78b2e576e40"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +802,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1154,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2133,6 +2172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3533,6 +3573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3897,13 +3943,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ js-sys = "0.3"
 serde-wasm-bindgen = "0.6"
 
 # Native HTTP client (non-WASM only)
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip"] }
 
 # Python
 pyo3 = { version = "0.20", features = ["extension-module"] }

--- a/crates/braintrust-llm-router/Cargo.toml
+++ b/crates/braintrust-llm-router/Cargo.toml
@@ -24,7 +24,7 @@ rand = { workspace = true }
 lingua = { workspace = true, features = ["openai", "anthropic", "google", "bedrock"] }
 
 # HTTP client
-reqwest = { workspace = true, features = ["json", "stream"] }
+reqwest = { workspace = true, features = ["json", "stream", "gzip"] }
 hyper = { workspace = true, optional = true }
 http = { workspace = true }
 

--- a/crates/braintrust-llm-router/examples/custom_auth.rs
+++ b/crates/braintrust-llm-router/examples/custom_auth.rs
@@ -15,7 +15,8 @@
 
 use anyhow::Result;
 use braintrust_llm_router::{
-    serde_json::json, AuthConfig, OpenAIConfig, OpenAIProvider, ProviderFormat, Router,
+    serde_json::json, AuthConfig, ClientHeaders, OpenAIConfig, OpenAIProvider, ProviderFormat,
+    Router,
 };
 use bytes::Bytes;
 use serde_json::Value;
@@ -127,7 +128,14 @@ async fn main() -> Result<()> {
 
     println!("   Sending authenticated request to GPT-4...");
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let bytes = router.complete(body, model, ProviderFormat::OpenAI).await?;
+    let bytes = router
+        .complete(
+            body,
+            model,
+            ProviderFormat::OpenAI,
+            &ClientHeaders::default(),
+        )
+        .await?;
     let response: Value = serde_json::from_slice(&bytes)?;
 
     if let Some(text) = extract_assistant_text(&response) {

--- a/crates/braintrust-llm-router/examples/multi_provider.rs
+++ b/crates/braintrust-llm-router/examples/multi_provider.rs
@@ -10,8 +10,8 @@
 
 use anyhow::Result;
 use braintrust_llm_router::{
-    serde_json::json, AnthropicConfig, AnthropicProvider, AuthConfig, OpenAIConfig, OpenAIProvider,
-    ProviderFormat, Router,
+    serde_json::json, AnthropicConfig, AnthropicProvider, AuthConfig, ClientHeaders, OpenAIConfig,
+    OpenAIProvider, ProviderFormat, Router,
 };
 use bytes::Bytes;
 use serde_json::Value;
@@ -77,7 +77,15 @@ async fn main() -> Result<()> {
         });
 
         let body = Bytes::from(serde_json::to_vec(&payload)?);
-        match router.complete(body, model, ProviderFormat::OpenAI).await {
+        match router
+            .complete(
+                body,
+                model,
+                ProviderFormat::OpenAI,
+                &ClientHeaders::default(),
+            )
+            .await
+        {
             Ok(bytes) => {
                 if let Ok(response) = serde_json::from_slice::<Value>(&bytes) {
                     if let Some(text) = extract_assistant_text(&response) {
@@ -100,7 +108,15 @@ async fn main() -> Result<()> {
         });
 
         let body = Bytes::from(serde_json::to_vec(&payload)?);
-        match router.complete(body, model, ProviderFormat::OpenAI).await {
+        match router
+            .complete(
+                body,
+                model,
+                ProviderFormat::OpenAI,
+                &ClientHeaders::default(),
+            )
+            .await
+        {
             Ok(bytes) => {
                 if let Ok(response) = serde_json::from_slice::<Value>(&bytes) {
                     if let Some(text) = extract_assistant_text(&response) {

--- a/crates/braintrust-llm-router/examples/simple.rs
+++ b/crates/braintrust-llm-router/examples/simple.rs
@@ -7,7 +7,7 @@
 
 use anyhow::Result;
 use braintrust_llm_router::{
-    serde_json::json, OpenAIConfig, OpenAIProvider, ProviderFormat, Router,
+    serde_json::json, ClientHeaders, OpenAIConfig, OpenAIProvider, ProviderFormat, Router,
 };
 use bytes::Bytes;
 use serde_json::Value;
@@ -53,7 +53,14 @@ async fn main() -> Result<()> {
 
     // Convert payload to bytes and send request
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let bytes = router.complete(body, model, ProviderFormat::OpenAI).await?;
+    let bytes = router
+        .complete(
+            body,
+            model,
+            ProviderFormat::OpenAI,
+            &ClientHeaders::default(),
+        )
+        .await?;
     let response: Value = serde_json::from_slice(&bytes)?;
 
     println!("📝 Response:\n");

--- a/crates/braintrust-llm-router/examples/streaming.rs
+++ b/crates/braintrust-llm-router/examples/streaming.rs
@@ -7,8 +7,8 @@
 
 use anyhow::Result;
 use braintrust_llm_router::{
-    serde_json::json, AnthropicConfig, AnthropicProvider, AuthConfig, ProviderFormat,
-    ResponseStream, Router,
+    serde_json::json, AnthropicConfig, AnthropicProvider, AuthConfig, ClientHeaders,
+    ProviderFormat, ResponseStream, Router,
 };
 use bytes::Bytes;
 use futures::StreamExt;
@@ -54,7 +54,12 @@ async fn main() -> Result<()> {
 
     let body = Bytes::from(serde_json::to_vec(&payload)?);
     let mut stream = router
-        .complete_stream(body, model, ProviderFormat::OpenAI)
+        .complete_stream(
+            body,
+            model,
+            ProviderFormat::OpenAI,
+            &ClientHeaders::default(),
+        )
         .await?;
 
     // Process the stream
@@ -128,7 +133,12 @@ async fn main() -> Result<()> {
         });
         let body = Bytes::from(serde_json::to_vec(&payload)?);
         let stream = router
-            .complete_stream(body, model, ProviderFormat::OpenAI)
+            .complete_stream(
+                body,
+                model,
+                ProviderFormat::OpenAI,
+                &ClientHeaders::default(),
+            )
             .await?;
         streams.push((model.to_string(), stream));
     }

--- a/crates/braintrust-llm-router/src/lib.rs
+++ b/crates/braintrust-llm-router/src/lib.rs
@@ -25,9 +25,9 @@ pub use lingua::ProviderFormat;
 pub use lingua::{FinishReason, UniversalStreamChoice, UniversalStreamChunk};
 pub use providers::{
     is_openai_compatible, openai_compatible_endpoint, AnthropicConfig, AnthropicProvider,
-    AzureConfig, AzureProvider, BedrockConfig, BedrockProvider, GoogleConfig, GoogleProvider,
-    MistralConfig, MistralProvider, OpenAICompatibleEndpoint, OpenAIConfig, OpenAIProvider,
-    OpenAIResponsesProvider, Provider, VertexConfig, VertexProvider,
+    AzureConfig, AzureProvider, BedrockConfig, BedrockProvider, ClientHeaders, GoogleConfig,
+    GoogleProvider, MistralConfig, MistralProvider, OpenAICompatibleEndpoint, OpenAIConfig,
+    OpenAIProvider, OpenAIResponsesProvider, Provider, VertexConfig, VertexProvider,
 };
 pub use retry::{RetryPolicy, RetryStrategy};
 pub use router::{create_provider, extract_request_hints, RequestHints, Router, RouterBuilder};

--- a/crates/braintrust-llm-router/src/providers/azure.rs
+++ b/crates/braintrust-llm-router/src/providers/azure.rs
@@ -3,13 +3,14 @@ use std::time::Duration;
 use async_trait::async_trait;
 use bytes::Bytes;
 use lingua::serde_json::Value;
-use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
+use reqwest::header::HeaderMap;
 use reqwest::{Client, StatusCode, Url};
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{default_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
+use crate::providers::ClientHeaders;
 use crate::streaming::{single_bytes_stream, sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
 
@@ -143,7 +144,13 @@ impl crate::providers::Provider for AzureProvider {
         ProviderFormat::OpenAI
     }
 
-    async fn complete(&self, payload: Bytes, auth: &AuthConfig, spec: &ModelSpec) -> Result<Bytes> {
+    async fn complete(
+        &self,
+        payload: Bytes,
+        auth: &AuthConfig,
+        spec: &ModelSpec,
+        client_headers: &ClientHeaders,
+    ) -> Result<Bytes> {
         let url = self.chat_url(&spec.model)?;
 
         #[cfg(feature = "tracing")]
@@ -154,8 +161,7 @@ impl crate::providers::Provider for AzureProvider {
             "sending request to Azure"
         );
 
-        let mut headers = HeaderMap::new();
-        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
@@ -201,9 +207,10 @@ impl crate::providers::Provider for AzureProvider {
         payload: Bytes,
         auth: &AuthConfig,
         spec: &ModelSpec,
+        client_headers: &ClientHeaders,
     ) -> Result<RawResponseStream> {
         if !spec.supports_streaming {
-            let response = self.complete(payload, auth, spec).await?;
+            let response = self.complete(payload, auth, spec, client_headers).await?;
             return Ok(single_bytes_stream(response));
         }
 
@@ -219,8 +226,7 @@ impl crate::providers::Provider for AzureProvider {
             "sending streaming request to Azure"
         );
 
-        let mut headers = HeaderMap::new();
-        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self

--- a/crates/braintrust-llm-router/src/providers/mod.rs
+++ b/crates/braintrust-llm-router/src/providers/mod.rs
@@ -21,6 +21,8 @@ pub use vertex::{VertexConfig, VertexProvider};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::auth::AuthConfig;
@@ -28,6 +30,89 @@ use crate::catalog::ModelSpec;
 use crate::error::Result;
 use crate::streaming::RawResponseStream;
 use lingua::ProviderFormat;
+
+/// Header prefixes blocked from forwarding to upstream LLM providers.
+pub const BLOCKED_HEADER_PREFIXES: &[&str] = &["x-amzn", "x-bt", "sec-"];
+
+/// Exact header names blocked from forwarding to upstream LLM providers
+/// from https://github.com/braintrustdata/braintrust-proxy/blob/e992f51734c71e689ea0090f9e0a6759c9a593a4/packages/proxy/src/proxy.ts#L247
+pub const BLOCKED_HEADERS: &[&str] = &[
+    "authorization",
+    "api-key",
+    "x-api-key",
+    "x-auth-token",
+    "content-length",
+    "origin",
+    "priority",
+    "referer",
+    "user-agent",
+    "cache-control",
+    // Block accept-encoding so reqwest handles compression internally.
+    // If client's Accept-Encoding is forwarded, reqwest skips auto-decompression.
+    "accept-encoding",
+];
+
+#[derive(Debug, Clone, Default)]
+pub struct ClientHeaders {
+    inner: HashMap<String, String>,
+}
+
+impl ClientHeaders {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn is_blocked(name: &str) -> bool {
+        let name = name.to_lowercase();
+        BLOCKED_HEADER_PREFIXES
+            .iter()
+            .any(|prefix| name.starts_with(prefix))
+            || BLOCKED_HEADERS.iter().any(|&blocked| name == blocked)
+    }
+
+    pub fn insert_if_allowed(&mut self, name: impl Into<String>, value: impl Into<String>) {
+        let name = name.into();
+        if !Self::is_blocked(&name) {
+            self.inner.insert(name.to_lowercase(), value.into());
+        }
+    }
+
+    pub fn apply(&self, headers: &mut HeaderMap) {
+        for (name, value) in &self.inner {
+            if name == "host" {
+                // Don't forward client Host; reqwest sets it from the upstream URL.
+                continue;
+            }
+            if let (Ok(header_name), Ok(header_value)) = (
+                HeaderName::from_bytes(name.as_bytes()),
+                HeaderValue::from_str(value),
+            ) {
+                headers.insert(header_name, header_value);
+            }
+        }
+    }
+
+    pub(crate) fn to_json_headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        self.apply(&mut headers);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers
+    }
+}
+
+// NOTE: This FromIterator impl exists to support collecting forwarded client
+// headers from `(String, String)` pairs at crate boundaries. We use pairs instead
+// of `http::HeaderMap` because different workspace crates depend on different
+// major versions of the `http` crate, making `HeaderMap` incompatible.
+impl FromIterator<(String, String)> for ClientHeaders {
+    fn from_iter<T: IntoIterator<Item = (String, String)>>(iter: T) -> Self {
+        let mut client_headers = ClientHeaders::new();
+        for (name, value) in iter {
+            client_headers.insert_if_allowed(name, value);
+        }
+        client_headers
+    }
+}
 
 /// Provider trait for LLM API backends.
 ///
@@ -55,7 +140,14 @@ pub trait Provider: Send + Sync {
     /// * `payload` - Pre-transformed bytes payload ready to send to the provider
     /// * `auth` - Authentication configuration
     /// * `spec` - Model specification
-    async fn complete(&self, payload: Bytes, auth: &AuthConfig, spec: &ModelSpec) -> Result<Bytes>;
+    /// * `client_headers` - Client headers to forward to the upstream provider
+    async fn complete(
+        &self,
+        payload: Bytes,
+        auth: &AuthConfig,
+        spec: &ModelSpec,
+        client_headers: &ClientHeaders,
+    ) -> Result<Bytes>;
 
     /// Execute a streaming completion request.
     ///
@@ -67,15 +159,25 @@ pub trait Provider: Send + Sync {
     /// * `payload` - Pre-transformed bytes payload ready to send to the provider
     /// * `auth` - Authentication configuration
     /// * `spec` - Model specification
+    /// * `client_headers` - Client headers to forward to the upstream provider
     async fn complete_stream(
         &self,
         payload: Bytes,
         auth: &AuthConfig,
         spec: &ModelSpec,
+        client_headers: &ClientHeaders,
     ) -> Result<RawResponseStream>;
 
     /// Check if the provider is reachable.
     async fn health_check(&self, auth: &AuthConfig) -> Result<()>;
+
+    /// Build HTTP headers for a request.
+    ///
+    /// Default implementation returns JSON content-type headers.
+    /// Override for provider-specific headers (e.g., OpenAI-Organization).
+    fn build_headers(&self, client_headers: &ClientHeaders) -> HeaderMap {
+        client_headers.to_json_headers()
+    }
 }
 
 impl dyn Provider {

--- a/crates/braintrust-llm-router/tests/client_headers.rs
+++ b/crates/braintrust-llm-router/tests/client_headers.rs
@@ -1,0 +1,37 @@
+use braintrust_llm_router::ClientHeaders;
+use http::HeaderMap;
+
+fn apply_headers(cases: &[(&str, &str, bool)]) -> HeaderMap {
+    let header_pairs = cases
+        .iter()
+        .map(|(name, value, _)| (name.to_string(), value.to_string()))
+        .collect::<Vec<_>>();
+    let client_headers: ClientHeaders = header_pairs.into_iter().collect();
+    let mut headers = HeaderMap::new();
+    client_headers.apply(&mut headers);
+    headers
+}
+
+#[test]
+fn client_headers_filter_and_host_behavior() {
+    let cases = [
+        ("x-amzn-trace-id", "1", false),
+        ("x-bt-project-id", "1", false),
+        ("sec-fetch-mode", "cors", false),
+        ("content-length", "123", false),
+        ("origin", "https://example.com", false),
+        ("priority", "u=1", false),
+        ("referer", "https://example.com", false),
+        ("user-agent", "test", false),
+        ("cache-control", "no-cache", false),
+        ("host", "api.example.com", false),
+        ("anthropic-beta", "tools-2024-05-16", true),
+        ("accept", "application/json", true),
+        ("x-custom-header", "1", true),
+    ];
+
+    let headers = apply_headers(&cases);
+    for (name, _value, expected) in cases {
+        assert_eq!(headers.contains_key(name), expected, "header {name}");
+    }
+}


### PR DESCRIPTION
This PR forwards client headers into lingua with proxy-style filtering and dedupe JSON header setup; filtering similar to proxy.ts -> https://github.com/braintrustdata/braintrust-proxy/blob/main/packages/proxy/src/proxy.ts#L247