### PR TITLE
Force translation for openai reasoning models

### DIFF
--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -511,9 +511,9 @@ fn needs_forced_translation(payload: &Value, model: Option<&str>, target: Provid
     {
         // If the model doesn't support max_tokens, we need to force translation
         let request_model = payload.get("model").and_then(Value::as_str).or(model);
-        return request_model
+        request_model
             .map(|m| !model_supports_max_tokens(m))
-            .unwrap_or(false);
+            .unwrap_or(false)
     }
 
     #[cfg(not(feature = "openai"))]

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -16,6 +16,8 @@ use bytes::Bytes;
 use crate::capabilities::ProviderFormat;
 use crate::error::ConvertError;
 use crate::processing::adapters::{adapter_for_format, adapters, ProviderAdapter};
+#[cfg(feature = "openai")]
+use crate::providers::openai::is_reasoning_model_name;
 use crate::serde_json::Value;
 use crate::universal::{UniversalResponse, UniversalStreamChunk};
 use thiserror::Error;
@@ -223,7 +225,9 @@ pub fn transform_request(
 
     let source_adapter = detect_adapter(&payload, DetectKind::Request)?;
 
-    if source_adapter.format() == target_format {
+    if source_adapter.format() == target_format
+        && !needs_forced_translation(&payload, model, target_format)
+    {
         return Ok(TransformResult::PassThrough(input));
     }
 
@@ -497,6 +501,23 @@ fn detect_adapter(
         .ok_or(TransformError::UnableToDetectFormat)
 }
 
+/// Check if a request needs forced translation even when source == target format.
+/// Reasoning models (gpt-5.*, o1-*, etc.) require `max_completion_tokens` instead of `max_tokens`.
+fn needs_forced_translation(payload: &Value, model: Option<&str>, target: ProviderFormat) -> bool {
+    if target != ProviderFormat::OpenAI {
+        return false;
+    }
+
+    #[cfg(feature = "openai")]
+    {
+        let request_model = payload.get("model").and_then(Value::as_str).or(model);
+        return request_model.map(is_reasoning_model_name).unwrap_or(false);
+    }
+
+    #[cfg(not(feature = "openai"))]
+    false
+}
+
 /// Sanitize a payload for a target format by parsing and re-serializing.
 ///
 /// This strips unknown fields that strict providers (like Anthropic) would reject.
@@ -679,5 +700,60 @@ mod tests {
         // Should be passthrough with same bytes
         assert!(result.is_passthrough());
         assert_eq!(result.into_bytes().as_ptr(), input_ptr);
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
+    fn test_reasoning_model_forces_translation() {
+        // Reasoning models (gpt-5.*, o1-*, o3-*) require max_completion_tokens
+        // Even for OpenAI → OpenAI, we must translate to convert max_tokens → max_completion_tokens
+        // Note: Include an OpenAI-only field (seed) to ensure detection as OpenAI format
+        let payload = json!({
+            "model": "gpt-5.1-mini",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 1000,
+            "seed": 42
+        });
+        let input = to_bytes(&payload);
+
+        let result = transform_request(input, ProviderFormat::OpenAI, None).unwrap();
+
+        // Should NOT passthrough - reasoning models need max_completion_tokens
+        assert!(
+            !result.is_passthrough(),
+            "Reasoning models should force translation"
+        );
+
+        let output: Value = crate::serde_json::from_slice(result.as_bytes()).unwrap();
+        assert!(
+            output.get("max_completion_tokens").is_some(),
+            "Should have max_completion_tokens"
+        );
+        assert!(
+            output.get("max_tokens").is_none(),
+            "Should not have max_tokens"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
+    fn test_non_reasoning_model_still_passthroughs() {
+        // Non-reasoning models should still passthrough for efficiency
+        // Note: Include an OpenAI-only field (seed) to ensure detection as OpenAI format
+        let payload = json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 1000,
+            "seed": 42
+        });
+        let input = to_bytes(&payload);
+
+        let result = transform_request(input, ProviderFormat::OpenAI, None).unwrap();
+
+        // Should passthrough - gpt-4o is not a reasoning model
+        assert!(
+            result.is_passthrough(),
+            "Non-reasoning models should passthrough"
+        );
     }
 }

--- a/crates/lingua/src/providers/openai/capabilities.rs
+++ b/crates/lingua/src/providers/openai/capabilities.rs
@@ -108,6 +108,10 @@ const REASONING_MODEL_PREFIXES: &[&str] = &["o1", "o2", "o3", "o4", "gpt-5"];
 /// Legacy o1 models that need special handling.
 const LEGACY_O1_MODELS: &[&str] = &["o1-preview", "o1-mini", "o1-preview-2024-09-12"];
 
+/// Model prefixes that do NOT support the `max_tokens` parameter.
+/// These models require `max_completion_tokens` instead.
+const MODELS_WITHOUT_MAX_TOKENS_SUPPORT: &[&str] = &["o1", "o3", "o4", "gpt-5"];
+
 fn supports_native_structured_output(model: &str, target: TargetProvider) -> bool {
     STRUCTURED_OUTPUT_PREFIXES
         .iter()
@@ -115,11 +119,7 @@ fn supports_native_structured_output(model: &str, target: TargetProvider) -> boo
         || matches!(target, TargetProvider::Fireworks)
 }
 
-/// Check if a model name indicates a reasoning model that requires special handling.
-///
-/// Reasoning models (o1, o2, o3, o4, gpt-5) require `max_completion_tokens` instead
-/// of `max_tokens`, so passthrough must be disabled to ensure proper conversion.
-pub fn is_reasoning_model_name(model: &str) -> bool {
+fn is_reasoning_model_name(model: &str) -> bool {
     let lower = model.to_ascii_lowercase();
     REASONING_MODEL_PREFIXES
         .iter()
@@ -128,4 +128,13 @@ pub fn is_reasoning_model_name(model: &str) -> bool {
 
 fn is_legacy_o1_model(model: &str) -> bool {
     LEGACY_O1_MODELS.contains(&model)
+}
+
+/// Check if a model supports the `max_tokens` parameter.
+/// Returns false for models that require `max_completion_tokens` instead.
+pub fn model_supports_max_tokens(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    !MODELS_WITHOUT_MAX_TOKENS_SUPPORT
+        .iter()
+        .any(|prefix| lower.starts_with(prefix))
 }

--- a/crates/lingua/src/providers/openai/capabilities.rs
+++ b/crates/lingua/src/providers/openai/capabilities.rs
@@ -115,7 +115,11 @@ fn supports_native_structured_output(model: &str, target: TargetProvider) -> boo
         || matches!(target, TargetProvider::Fireworks)
 }
 
-fn is_reasoning_model_name(model: &str) -> bool {
+/// Check if a model name indicates a reasoning model that requires special handling.
+///
+/// Reasoning models (o1, o2, o3, o4, gpt-5) require `max_completion_tokens` instead
+/// of `max_tokens`, so passthrough must be disabled to ensure proper conversion.
+pub fn is_reasoning_model_name(model: &str) -> bool {
     let lower = model.to_ascii_lowercase();
     REASONING_MODEL_PREFIXES
         .iter()

--- a/crates/lingua/src/providers/openai/mod.rs
+++ b/crates/lingua/src/providers/openai/mod.rs
@@ -28,7 +28,7 @@ pub mod test_chat_completions;
 pub use detect::{try_parse_openai, try_parse_responses, DetectionError};
 
 // Re-export capability functions
-pub use capabilities::is_reasoning_model_name;
+pub use capabilities::model_supports_max_tokens;
 
 // Re-export conversion functions and extension types
 pub use convert::{

--- a/crates/lingua/src/providers/openai/mod.rs
+++ b/crates/lingua/src/providers/openai/mod.rs
@@ -27,6 +27,9 @@ pub mod test_chat_completions;
 // Re-export detection functions
 pub use detect::{try_parse_openai, try_parse_responses, DetectionError};
 
+// Re-export capability functions
+pub use capabilities::is_reasoning_model_name;
+
 // Re-export conversion functions and extension types
 pub use convert::{
     universal_to_responses_input, ChatCompletionRequestMessageExt, ChatCompletionResponseMessageExt,


### PR DESCRIPTION
chat completions can have `max_tokens` as a parameter for the API but it isn't accepted for certain models, see error:
```
  "error": {
    "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
    "type": "invalid_request_error",
    "param": "max_tokens",
    "code": "unsupported_parameter"
  }
}

Caused by:
    HTTP 400 Bad Request: {
      "error": {
        "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
        "type": "invalid_request_error",
        "param": "max_tokens",
        "code": "unsupported_parameter"
      }
```
all models associated with chat completions api accept `max_completion_tokens` which is why when we transform back from universal, we always insert `max_completion_tokens` ->  https://github.com/braintrustdata/lingua/blob/main/crates/lingua/src/providers/openai/adapter.rs#L209


This PR adds forcing translation automatically for these reasoning models that don't support `max_tokens`