### PR TITLE
rename openai to chatcompletions

### DIFF
--- a/crates/braintrust-llm-router/README.md
+++ b/crates/braintrust-llm-router/README.md
@@ -52,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
     }))?);
 
     // Route request - auto-extracts model, returns pre-serialized response
-    let result = router.handle(body, ProviderFormat::OpenAI, None).await?;
+    let result = router.handle(body, ProviderFormat::ChatCompletions, None).await?;
 
     match result.response {
         RouterResponse::Sync(bytes) => {
@@ -113,11 +113,11 @@ Two entry points:
 
 ```rust
 // handle() - auto-extracts model from body, detects streaming
-let result = router.handle(body, ProviderFormat::OpenAI, None).await?;
+let result = router.handle(body, ProviderFormat::ChatCompletions, None).await?;
 
 // complete() / complete_stream() - explicit model parameter
-let bytes = router.complete(body, "gpt-4", ProviderFormat::OpenAI, None).await?;
-let stream = router.complete_stream(body, "gpt-4", ProviderFormat::OpenAI, None).await?;
+let bytes = router.complete(body, "gpt-4", ProviderFormat::ChatCompletions, None).await?;
+let stream = router.complete_stream(body, "gpt-4", ProviderFormat::ChatCompletions, None).await?;
 ```
 
 ### Authentication

--- a/crates/braintrust-llm-router/examples/custom_auth.rs
+++ b/crates/braintrust-llm-router/examples/custom_auth.rs
@@ -132,7 +132,7 @@ async fn main() -> Result<()> {
         .complete(
             body,
             model,
-            ProviderFormat::OpenAI,
+            ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )
         .await?;

--- a/crates/braintrust-llm-router/examples/multi_provider.rs
+++ b/crates/braintrust-llm-router/examples/multi_provider.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
             .complete(
                 body,
                 model,
-                ProviderFormat::OpenAI,
+                ProviderFormat::ChatCompletions,
                 &ClientHeaders::default(),
             )
             .await
@@ -112,7 +112,7 @@ async fn main() -> Result<()> {
             .complete(
                 body,
                 model,
-                ProviderFormat::OpenAI,
+                ProviderFormat::ChatCompletions,
                 &ClientHeaders::default(),
             )
             .await

--- a/crates/braintrust-llm-router/examples/simple.rs
+++ b/crates/braintrust-llm-router/examples/simple.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
         .complete(
             body,
             model,
-            ProviderFormat::OpenAI,
+            ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )
         .await?;

--- a/crates/braintrust-llm-router/examples/streaming.rs
+++ b/crates/braintrust-llm-router/examples/streaming.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
         .complete_stream(
             body,
             model,
-            ProviderFormat::OpenAI,
+            ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )
         .await?;
@@ -136,7 +136,7 @@ async fn main() -> Result<()> {
             .complete_stream(
                 body,
                 model,
-                ProviderFormat::OpenAI,
+                ProviderFormat::ChatCompletions,
                 &ClientHeaders::default(),
             )
             .await?;

--- a/crates/braintrust-llm-router/src/catalog/resolver.rs
+++ b/crates/braintrust-llm-router/src/catalog/resolver.rs
@@ -45,7 +45,7 @@ impl ModelResolver {
 
 fn format_identifier(format: ProviderFormat) -> String {
     match format {
-        ProviderFormat::OpenAI => "openai",
+        ProviderFormat::ChatCompletions => "openai",
         ProviderFormat::Anthropic => "anthropic",
         ProviderFormat::Google => "google",
         ProviderFormat::Mistral => "mistral",
@@ -87,11 +87,14 @@ mod tests {
     #[test]
     fn resolve_returns_default_alias() {
         let mut catalog = ModelCatalog::empty();
-        catalog.insert("model".into(), spec("model", ProviderFormat::OpenAI));
+        catalog.insert(
+            "model".into(),
+            spec("model", ProviderFormat::ChatCompletions),
+        );
         let resolver = ModelResolver::new(Arc::new(catalog));
 
         let (_, format, alias) = resolver.resolve("model").expect("resolves");
-        assert_eq!(format, ProviderFormat::OpenAI);
+        assert_eq!(format, ProviderFormat::ChatCompletions);
         assert_eq!(alias, "openai");
     }
 

--- a/crates/braintrust-llm-router/src/error.rs
+++ b/crates/braintrust-llm-router/src/error.rs
@@ -162,13 +162,19 @@ mod tests {
         // Client errors
         assert!(TransformError::UnableToDetectFormat.is_client_error());
         assert!(TransformError::ValidationFailed {
-            target: ProviderFormat::OpenAI,
+            target: ProviderFormat::ChatCompletions,
             reason: "test".into()
         }
         .is_client_error());
         assert!(TransformError::DeserializationFailed("invalid json".into()).is_client_error());
-        assert!(TransformError::UnsupportedTargetFormat(ProviderFormat::OpenAI).is_client_error());
-        assert!(TransformError::UnsupportedSourceFormat(ProviderFormat::OpenAI).is_client_error());
+        assert!(
+            TransformError::UnsupportedTargetFormat(ProviderFormat::ChatCompletions)
+                .is_client_error()
+        );
+        assert!(
+            TransformError::UnsupportedSourceFormat(ProviderFormat::ChatCompletions)
+                .is_client_error()
+        );
 
         // Conversion errors are client errors (user sent unsupported content)
         assert!(TransformError::FromUniversalFailed("test".into()).is_client_error());
@@ -183,7 +189,7 @@ mod tests {
     fn router_error_classification() {
         // Client errors
         assert!(Error::UnknownModel("gpt-5".into()).is_client_error());
-        assert!(Error::NoProvider(ProviderFormat::OpenAI).is_client_error());
+        assert!(Error::NoProvider(ProviderFormat::ChatCompletions).is_client_error());
         assert!(Error::InvalidRequest("bad".into()).is_client_error());
         assert!(Error::Lingua(lingua::TransformError::UnableToDetectFormat).is_client_error());
 

--- a/crates/braintrust-llm-router/src/providers/azure.rs
+++ b/crates/braintrust-llm-router/src/providers/azure.rs
@@ -141,7 +141,7 @@ impl crate::providers::Provider for AzureProvider {
     }
 
     fn format(&self) -> ProviderFormat {
-        ProviderFormat::OpenAI
+        ProviderFormat::ChatCompletions
     }
 
     async fn complete(

--- a/crates/braintrust-llm-router/src/providers/openai.rs
+++ b/crates/braintrust-llm-router/src/providers/openai.rs
@@ -164,7 +164,7 @@ impl crate::providers::Provider for OpenAIProvider {
     }
 
     fn format(&self) -> ProviderFormat {
-        ProviderFormat::OpenAI
+        ProviderFormat::ChatCompletions
     }
 
     async fn complete(

--- a/crates/braintrust-llm-router/tests/router.rs
+++ b/crates/braintrust-llm-router/tests/router.rs
@@ -25,7 +25,7 @@ impl Provider for StubProvider {
     }
 
     fn format(&self) -> ProviderFormat {
-        ProviderFormat::OpenAI
+        ProviderFormat::ChatCompletions
     }
 
     async fn complete(
@@ -89,7 +89,7 @@ async fn router_routes_to_stub_provider() {
         "stub-model".into(),
         ModelSpec {
             model: "stub-model".into(),
-            format: ProviderFormat::OpenAI,
+            format: ProviderFormat::ChatCompletions,
             flavor: ModelFlavor::Chat,
             display_name: None,
             parent: None,
@@ -134,7 +134,7 @@ async fn router_routes_to_stub_provider() {
         .complete(
             body,
             model,
-            ProviderFormat::OpenAI,
+            ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )
         .await
@@ -156,7 +156,7 @@ async fn router_requires_auth_for_provider() {
         "stub-model".into(),
         ModelSpec {
             model: "stub-model".into(),
-            format: ProviderFormat::OpenAI,
+            format: ProviderFormat::ChatCompletions,
             flavor: ModelFlavor::Chat,
             display_name: None,
             parent: None,
@@ -189,7 +189,7 @@ async fn router_requires_auth_for_provider() {
         .complete(
             body,
             model,
-            ProviderFormat::OpenAI,
+            ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )
         .await
@@ -204,7 +204,7 @@ async fn router_reports_missing_provider() {
         "lonely-model".into(),
         ModelSpec {
             model: "lonely-model".into(),
-            format: ProviderFormat::OpenAI,
+            format: ProviderFormat::ChatCompletions,
             flavor: ModelFlavor::Chat,
             display_name: None,
             parent: None,
@@ -235,12 +235,15 @@ async fn router_reports_missing_provider() {
         .complete(
             body,
             model,
-            ProviderFormat::OpenAI,
+            ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )
         .await
         .expect_err("missing provider");
-    assert!(matches!(err, Error::NoProvider(ProviderFormat::OpenAI)));
+    assert!(matches!(
+        err,
+        Error::NoProvider(ProviderFormat::ChatCompletions)
+    ));
 }
 
 #[tokio::test]
@@ -264,7 +267,12 @@ async fn router_propagates_validation_errors() {
         "messages": []
     }));
     let err = router
-        .complete(body, "", ProviderFormat::OpenAI, &ClientHeaders::default())
+        .complete(
+            body,
+            "",
+            ProviderFormat::ChatCompletions,
+            &ClientHeaders::default(),
+        )
         .await
         .expect_err("validation");
     // Empty model is treated as unknown model, not invalid request
@@ -283,7 +291,7 @@ impl Provider for FailingProvider {
     }
 
     fn format(&self) -> ProviderFormat {
-        ProviderFormat::OpenAI
+        ProviderFormat::ChatCompletions
     }
 
     async fn complete(
@@ -319,7 +327,7 @@ async fn router_retries_and_propagates_terminal_error() {
         "retry-model".into(),
         ModelSpec {
             model: "retry-model".into(),
-            format: ProviderFormat::OpenAI,
+            format: ProviderFormat::ChatCompletions,
             flavor: ModelFlavor::Chat,
             display_name: None,
             parent: None,
@@ -375,7 +383,7 @@ async fn router_retries_and_propagates_terminal_error() {
         .complete(
             body,
             model,
-            ProviderFormat::OpenAI,
+            ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )
         .await

--- a/crates/coverage-report/src/types.rs
+++ b/crates/coverage-report/src/types.rs
@@ -111,7 +111,7 @@ pub fn parse_provider(name: &str) -> Result<ProviderFormat, String> {
     match name.to_lowercase().as_str() {
         "responses" | "response" | "openai-responses" => Ok(ProviderFormat::Responses),
         "chat-completions" | "chatcompletions" | "completions" | "openai" => {
-            Ok(ProviderFormat::OpenAI)
+            Ok(ProviderFormat::ChatCompletions)
         }
         "anthropic" => Ok(ProviderFormat::Anthropic),
         "google" | "gemini" => Ok(ProviderFormat::Google),

--- a/crates/coverage-report/tests/cross_provider_test.rs
+++ b/crates/coverage-report/tests/cross_provider_test.rs
@@ -15,7 +15,7 @@ use lingua::processing::adapters::adapters;
 /// this is temporary as we make incremental progress.
 const REQUIRED_PROVIDERS: &[ProviderFormat] = &[
     ProviderFormat::Responses,
-    ProviderFormat::OpenAI, // ChatCompletions
+    ProviderFormat::ChatCompletions, // ChatCompletions
     ProviderFormat::Anthropic,
 ];
 

--- a/crates/lingua/src/capabilities/format.rs
+++ b/crates/lingua/src/capabilities/format.rs
@@ -19,7 +19,8 @@ use ts_rs::TS;
 #[serde(rename_all = "lowercase")]
 pub enum ProviderFormat {
     /// OpenAI Chat Completions API format (also used by OpenAI-compatible providers)
-    OpenAI,
+    #[serde(rename = "openai", alias = "chat-completions")]
+    ChatCompletions,
     /// Anthropic Messages API format
     Anthropic,
     /// Google AI / Gemini GenerateContent API format
@@ -46,7 +47,7 @@ impl ProviderFormat {
 impl std::fmt::Display for ProviderFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            ProviderFormat::OpenAI => "openai",
+            ProviderFormat::ChatCompletions => "openai",
             ProviderFormat::Anthropic => "anthropic",
             ProviderFormat::Google => "google",
             ProviderFormat::Mistral => "mistral",
@@ -63,7 +64,7 @@ impl std::str::FromStr for ProviderFormat {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "openai" => Ok(ProviderFormat::OpenAI),
+            "openai" | "chat-completions" => Ok(ProviderFormat::ChatCompletions),
             "anthropic" => Ok(ProviderFormat::Anthropic),
             "google" => Ok(ProviderFormat::Google),
             "mistral" => Ok(ProviderFormat::Mistral),
@@ -82,7 +83,11 @@ mod tests {
     fn test_from_str() {
         assert_eq!(
             "openai".parse::<ProviderFormat>().unwrap(),
-            ProviderFormat::OpenAI
+            ProviderFormat::ChatCompletions
+        );
+        assert_eq!(
+            "chat-completions".parse::<ProviderFormat>().unwrap(),
+            ProviderFormat::ChatCompletions
         );
         assert_eq!(
             "ANTHROPIC".parse::<ProviderFormat>().unwrap(),

--- a/crates/lingua/src/processing/adapters.rs
+++ b/crates/lingua/src/processing/adapters.rs
@@ -244,8 +244,8 @@ mod tests {
     #[cfg(feature = "openai")]
     #[test]
     fn test_adapter_caching_is_stable() {
-        let a1 = adapter_for_format(ProviderFormat::OpenAI).unwrap();
-        let a2 = adapter_for_format(ProviderFormat::OpenAI).unwrap();
+        let a1 = adapter_for_format(ProviderFormat::ChatCompletions).unwrap();
+        let a2 = adapter_for_format(ProviderFormat::ChatCompletions).unwrap();
         assert!(std::ptr::eq(a1, a2));
     }
 }

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -503,7 +503,7 @@ fn detect_adapter(
 
 /// Check if a request needs forced translation even when source == target format.
 fn needs_forced_translation(payload: &Value, model: Option<&str>, target: ProviderFormat) -> bool {
-    if target != ProviderFormat::OpenAI {
+    if target != ProviderFormat::ChatCompletions {
         return false;
     }
 
@@ -587,7 +587,7 @@ mod tests {
         let input = to_bytes(&payload);
         let input_ptr = input.as_ptr();
 
-        let result = transform_request(input, ProviderFormat::OpenAI, None).unwrap();
+        let result = transform_request(input, ProviderFormat::ChatCompletions, None).unwrap();
 
         // Should be passthrough
         assert!(result.is_passthrough());
@@ -610,7 +610,10 @@ mod tests {
 
         // Should be transformed
         assert!(!result.is_passthrough());
-        assert_eq!(result.source_format(), Some(ProviderFormat::OpenAI));
+        assert_eq!(
+            result.source_format(),
+            Some(ProviderFormat::ChatCompletions)
+        );
 
         // Parse output and verify
         let output_bytes = result.into_bytes();
@@ -642,7 +645,7 @@ mod tests {
     fn test_transform_request_invalid_json() {
         let input = Bytes::from("not valid json");
 
-        let result = transform_request(input, ProviderFormat::OpenAI, None);
+        let result = transform_request(input, ProviderFormat::ChatCompletions, None);
 
         assert!(result.is_err());
         assert!(matches!(
@@ -671,7 +674,10 @@ mod tests {
         let result = transform_response(input, ProviderFormat::Anthropic).unwrap();
 
         assert!(!result.is_passthrough());
-        assert_eq!(result.source_format(), Some(ProviderFormat::OpenAI));
+        assert_eq!(
+            result.source_format(),
+            Some(ProviderFormat::ChatCompletions)
+        );
 
         // Verify output is valid JSON
         let output_bytes = result.into_bytes();
@@ -695,7 +701,7 @@ mod tests {
         let input = to_bytes(&payload);
         let input_ptr = input.as_ptr();
 
-        let result = transform_response(input, ProviderFormat::OpenAI).unwrap();
+        let result = transform_response(input, ProviderFormat::ChatCompletions).unwrap();
 
         // Should be passthrough with same bytes
         assert!(result.is_passthrough());
@@ -716,7 +722,7 @@ mod tests {
         });
         let input = to_bytes(&payload);
 
-        let result = transform_request(input, ProviderFormat::OpenAI, None).unwrap();
+        let result = transform_request(input, ProviderFormat::ChatCompletions, None).unwrap();
 
         // Should NOT passthrough - reasoning models need max_completion_tokens
         assert!(
@@ -748,7 +754,7 @@ mod tests {
         });
         let input = to_bytes(&payload);
 
-        let result = transform_request(input, ProviderFormat::OpenAI, None).unwrap();
+        let result = transform_request(input, ProviderFormat::ChatCompletions, None).unwrap();
 
         // Should passthrough - gpt-4o is not a reasoning model
         assert!(

--- a/crates/lingua/src/universal/reasoning.rs
+++ b/crates/lingua/src/universal/reasoning.rs
@@ -308,7 +308,9 @@ impl ReasoningConfig {
         max_tokens: Option<i64>,
     ) -> Result<Option<Value>, TransformError> {
         match provider {
-            ProviderFormat::OpenAI => Ok(to_openai_chat(self, max_tokens).map(Value::String)),
+            ProviderFormat::ChatCompletions => {
+                Ok(to_openai_chat(self, max_tokens).map(Value::String))
+            }
             ProviderFormat::Responses => Ok(to_openai_responses(self, max_tokens)),
             ProviderFormat::Anthropic => Ok(to_anthropic(self, max_tokens)),
             ProviderFormat::Converse => Ok(to_anthropic(self, max_tokens)), // Bedrock uses same format as Anthropic
@@ -542,7 +544,7 @@ mod tests {
         };
 
         let effort = config
-            .to_provider(ProviderFormat::OpenAI, Some(4096))
+            .to_provider(ProviderFormat::ChatCompletions, Some(4096))
             .unwrap()
             .unwrap();
         assert_eq!(effort.as_str().unwrap(), "medium"); // 2048/4096 = 0.5 → medium

--- a/crates/lingua/src/universal/tool_choice.rs
+++ b/crates/lingua/src/universal/tool_choice.rs
@@ -43,7 +43,7 @@ impl<'a> TryFrom<(ProviderFormat, &'a Value)> for ToolChoiceConfig {
 
     fn try_from((provider, value): (ProviderFormat, &'a Value)) -> Result<Self, Self::Error> {
         match provider {
-            ProviderFormat::OpenAI => from_openai_chat(value),
+            ProviderFormat::ChatCompletions => from_openai_chat(value),
             ProviderFormat::Responses => from_openai_responses(value),
             ProviderFormat::Anthropic => from_anthropic(value),
             _ => Ok(Self::default()),
@@ -72,7 +72,7 @@ impl ToolChoiceConfig {
         parallel_tool_calls: Option<bool>,
     ) -> Result<Option<Value>, TransformError> {
         match provider {
-            ProviderFormat::OpenAI => Ok(to_openai_chat(self)),
+            ProviderFormat::ChatCompletions => Ok(to_openai_chat(self)),
             ProviderFormat::Responses => Ok(to_openai_responses(self)),
             ProviderFormat::Anthropic => Ok(to_anthropic(self, parallel_tool_calls)),
             _ => Ok(None),
@@ -299,7 +299,9 @@ mod tests {
     #[test]
     fn test_from_openai_chat_string() {
         let value = json!("auto");
-        let config: ToolChoiceConfig = (ProviderFormat::OpenAI, &value).try_into().unwrap();
+        let config: ToolChoiceConfig = (ProviderFormat::ChatCompletions, &value)
+            .try_into()
+            .unwrap();
         assert_eq!(config.mode, Some(ToolChoiceMode::Auto));
         assert_eq!(config.tool_name, None);
     }
@@ -310,7 +312,9 @@ mod tests {
             "type": "function",
             "function": { "name": "get_weather" }
         });
-        let config: ToolChoiceConfig = (ProviderFormat::OpenAI, &value).try_into().unwrap();
+        let config: ToolChoiceConfig = (ProviderFormat::ChatCompletions, &value)
+            .try_into()
+            .unwrap();
         assert_eq!(config.mode, Some(ToolChoiceMode::Tool));
         assert_eq!(config.tool_name, Some("get_weather".into()));
     }
@@ -344,7 +348,7 @@ mod tests {
             ..Default::default()
         };
         let value = config
-            .to_provider(ProviderFormat::OpenAI, None)
+            .to_provider(ProviderFormat::ChatCompletions, None)
             .unwrap()
             .unwrap();
         assert_eq!(value, json!("auto"));
@@ -358,7 +362,7 @@ mod tests {
             ..Default::default()
         };
         let value = config
-            .to_provider(ProviderFormat::OpenAI, None)
+            .to_provider(ProviderFormat::ChatCompletions, None)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -404,9 +408,11 @@ mod tests {
             "type": "function",
             "function": { "name": "get_weather" }
         });
-        let config: ToolChoiceConfig = (ProviderFormat::OpenAI, &original).try_into().unwrap();
+        let config: ToolChoiceConfig = (ProviderFormat::ChatCompletions, &original)
+            .try_into()
+            .unwrap();
         let back = config
-            .to_provider(ProviderFormat::OpenAI, None)
+            .to_provider(ProviderFormat::ChatCompletions, None)
             .unwrap()
             .unwrap();
         assert_eq!(original, back);
@@ -416,7 +422,9 @@ mod tests {
     fn test_cross_provider_openai_to_anthropic() {
         // OpenAI required → Anthropic any
         let openai_value = json!("required");
-        let config: ToolChoiceConfig = (ProviderFormat::OpenAI, &openai_value).try_into().unwrap();
+        let config: ToolChoiceConfig = (ProviderFormat::ChatCompletions, &openai_value)
+            .try_into()
+            .unwrap();
         let anthropic_value = config
             .to_provider(ProviderFormat::Anthropic, None)
             .unwrap()
@@ -428,7 +436,8 @@ mod tests {
     fn test_invalid_string_mode_errors() {
         // Unrecognized string mode should error
         let value = json!("invalid_mode");
-        let result: Result<ToolChoiceConfig, _> = (ProviderFormat::OpenAI, &value).try_into();
+        let result: Result<ToolChoiceConfig, _> =
+            (ProviderFormat::ChatCompletions, &value).try_into();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("invalid_mode"));
     }


### PR DESCRIPTION
This PR renames ProviderFormat::OpenAI to ProviderFormat::ChatCompletions.



ask from slack https://braintrustdata.slack.com/archives/C09MDUXLRN1/p1770363224384649