### PR TITLE
Add Google format validation and proxy test infrastructure

### DIFF
--- a/crates/lingua/src/validation/cross_provider_tests.rs
+++ b/crates/lingua/src/validation/cross_provider_tests.rs
@@ -78,6 +78,45 @@ mod tests {
         }
     }"#;
 
+    // Google uses contents/parts structure (not messages/content)
+    #[cfg(feature = "google")]
+    const GOOGLE_REQUEST: &str = r#"{
+        "model": "gemini-2.5-flash",
+        "contents": [
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "text": "Hello"
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    #[cfg(feature = "google")]
+    const GOOGLE_RESPONSE: &str = r#"{
+        "candidates": [
+            {
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "text": "Hello!"
+                        }
+                    ]
+                },
+                "finishReason": "STOP",
+                "index": 0
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 5,
+            "candidatesTokenCount": 10,
+            "totalTokenCount": 15
+        }
+    }"#;
+
     // Bedrock uses camelCase field names (modelId, not model_id)
     // and untagged content blocks ({"text": "Hello"}, not {"type": "text", "text": "Hello"})
     #[cfg(feature = "bedrock")]
@@ -163,6 +202,18 @@ mod tests {
         }
 
         #[test]
+        #[cfg(feature = "google")]
+        fn test_google_request_fails_as_openai() {
+            assert!(validate_openai_request(GOOGLE_REQUEST).is_err());
+        }
+
+        #[test]
+        #[cfg(feature = "google")]
+        fn test_google_response_fails_as_openai() {
+            assert!(validate_openai_response(GOOGLE_RESPONSE).is_err());
+        }
+
+        #[test]
         #[cfg(feature = "bedrock")]
         fn test_bedrock_request_fails_as_openai() {
             assert!(validate_openai_request(BEDROCK_REQUEST).is_err());
@@ -211,6 +262,18 @@ mod tests {
         }
 
         #[test]
+        #[cfg(feature = "google")]
+        fn test_google_request_fails_as_anthropic() {
+            assert!(validate_anthropic_request(GOOGLE_REQUEST).is_err());
+        }
+
+        #[test]
+        #[cfg(feature = "google")]
+        fn test_google_response_fails_as_anthropic() {
+            assert!(validate_anthropic_response(GOOGLE_RESPONSE).is_err());
+        }
+
+        #[test]
         #[cfg(feature = "bedrock")]
         fn test_bedrock_request_fails_as_anthropic() {
             assert!(validate_anthropic_request(BEDROCK_REQUEST).is_err());
@@ -220,6 +283,55 @@ mod tests {
         #[cfg(feature = "bedrock")]
         fn test_bedrock_response_fails_as_anthropic() {
             assert!(validate_anthropic_response(BEDROCK_RESPONSE).is_err());
+        }
+    }
+
+    // Google validation tests
+    #[cfg(feature = "google")]
+    mod google_tests {
+        use super::*;
+        use crate::validation::google::{validate_google_request, validate_google_response};
+
+        #[test]
+        fn test_google_request_validates() {
+            assert!(validate_google_request(GOOGLE_REQUEST).is_ok());
+        }
+
+        #[test]
+        fn test_google_response_validates() {
+            assert!(validate_google_response(GOOGLE_RESPONSE).is_ok());
+        }
+
+        #[test]
+        fn test_openai_request_fails_as_google() {
+            assert!(validate_google_request(OPENAI_REQUEST).is_err());
+        }
+
+        #[test]
+        fn test_openai_response_fails_as_google() {
+            assert!(validate_google_response(OPENAI_RESPONSE).is_err());
+        }
+
+        #[test]
+        fn test_anthropic_request_fails_as_google() {
+            assert!(validate_google_request(ANTHROPIC_REQUEST).is_err());
+        }
+
+        #[test]
+        fn test_anthropic_response_fails_as_google() {
+            assert!(validate_google_response(ANTHROPIC_RESPONSE).is_err());
+        }
+
+        #[test]
+        #[cfg(feature = "bedrock")]
+        fn test_bedrock_request_fails_as_google() {
+            assert!(validate_google_request(BEDROCK_REQUEST).is_err());
+        }
+
+        #[test]
+        #[cfg(feature = "bedrock")]
+        fn test_bedrock_response_fails_as_google() {
+            assert!(validate_google_response(BEDROCK_RESPONSE).is_err());
         }
     }
 
@@ -257,6 +369,18 @@ mod tests {
         #[test]
         fn test_anthropic_response_fails_as_bedrock() {
             assert!(validate_bedrock_response(ANTHROPIC_RESPONSE).is_err());
+        }
+
+        #[test]
+        #[cfg(feature = "google")]
+        fn test_google_request_fails_as_bedrock() {
+            assert!(validate_bedrock_request(GOOGLE_REQUEST).is_err());
+        }
+
+        #[test]
+        #[cfg(feature = "google")]
+        fn test_google_response_fails_as_bedrock() {
+            assert!(validate_bedrock_response(GOOGLE_RESPONSE).is_err());
         }
     }
 }

--- a/payloads/proxy/cases.ts
+++ b/payloads/proxy/cases.ts
@@ -1,4 +1,6 @@
 import OpenAI from "openai";
+import { Type } from "@google/genai";
+import { GOOGLE_MODEL } from "../cases/models";
 import { ProxyTestCaseCollection } from "./types";
 
 const TEXT_BASE64 = "SGVsbG8gd29ybGQhCg==";
@@ -911,5 +913,110 @@ export const proxyCases: ProxyTestCaseCollection = {
       max_tokens: 1000,
     },
     expect: { status: 200 },
+  },
+
+  proxyGoogleNativeBasic: {
+    format: "google",
+    request: {
+      model: GOOGLE_MODEL,
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "Say 'hello' and nothing else." }],
+        },
+      ],
+      config: { maxOutputTokens: 50 },
+    },
+    expect: {
+      status: 200,
+      fields: {
+        "candidates[0].content.role": "model",
+      },
+    },
+  },
+
+  proxyGoogleNativeSystemInstruction: {
+    format: "google",
+    request: {
+      model: GOOGLE_MODEL,
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "What is your role?" }],
+        },
+      ],
+      systemInstruction: {
+        parts: [{ text: "You are a helpful assistant." }],
+      },
+      config: { maxOutputTokens: 100 },
+    },
+    expect: {
+      status: 200,
+      fields: {
+        "candidates[0].content.role": "model",
+      },
+    },
+  },
+
+  proxyGoogleNativeMultiTurn: {
+    format: "google",
+    request: {
+      model: GOOGLE_MODEL,
+      contents: [
+        { role: "user", parts: [{ text: "My name is Alice." }] },
+        {
+          role: "model",
+          parts: [{ text: "Hello Alice! Nice to meet you." }],
+        },
+        { role: "user", parts: [{ text: "What is my name?" }] },
+      ],
+      config: { maxOutputTokens: 50 },
+    },
+    expect: {
+      status: 200,
+      fields: {
+        "candidates[0].content.role": "model",
+      },
+    },
+  },
+
+  proxyGoogleNativeToolCall: {
+    format: "google",
+    request: {
+      model: GOOGLE_MODEL,
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "What is the weather in Paris?" }],
+        },
+      ],
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: "get_weather",
+              description: "Get the current weather for a location",
+              parameters: {
+                type: Type.OBJECT,
+                properties: {
+                  location: {
+                    type: Type.STRING,
+                    description: "City name",
+                  },
+                },
+                required: ["location"],
+              },
+            },
+          ],
+        },
+      ],
+      config: { maxOutputTokens: 200 },
+    },
+    expect: {
+      status: 200,
+      fields: {
+        "candidates[0].content.role": "model",
+      },
+    },
   },
 };

--- a/payloads/proxy/types.ts
+++ b/payloads/proxy/types.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { type GoogleGenerateContentRequest } from "../cases/types";
 
 export interface ProxyTestExpectation {
   status?: number;
@@ -18,6 +19,11 @@ export type ProxyTestCase =
   | {
       format: "responses";
       request: OpenAI.Responses.ResponseCreateParams;
+      expect: ProxyTestExpectation;
+    }
+  | {
+      format: "google";
+      request: GoogleGenerateContentRequest & { model: string };
       expect: ProxyTestExpectation;
     };
 

--- a/payloads/scripts/providers/google-proxy.ts
+++ b/payloads/scripts/providers/google-proxy.ts
@@ -1,0 +1,143 @@
+import { CaptureResult, ExecuteOptions, ProviderExecutor } from "../types";
+import {
+  allTestCases,
+  getCaseNames,
+  getCaseForProvider,
+  hasExpectation,
+  GoogleGenerateContentRequest,
+} from "../../cases";
+
+type GoogleProxyRequest = GoogleGenerateContentRequest & { model: string };
+type GoogleProxyResponse = Record<string, unknown>;
+
+// Google cases for proxy validation - extracted from unified cases.
+// Skips cases with expectations (those are validated, not captured).
+export const googleProxyCases: Record<string, GoogleProxyRequest> = {};
+
+getCaseNames(allTestCases).forEach((caseName) => {
+  if (hasExpectation(allTestCases, caseName)) {
+    return;
+  }
+  const caseData = getCaseForProvider(allTestCases, caseName, "google");
+  if (caseData) {
+    // The proxy requires a model field in the body for routing
+    googleProxyCases[caseName] = {
+      ...caseData,
+      model: "gemini-2.5-flash",
+    };
+  }
+});
+
+export async function executeGoogleProxy(
+  _caseName: string,
+  payload: GoogleProxyRequest,
+  options?: ExecuteOptions
+): Promise<
+  CaptureResult<GoogleProxyRequest, GoogleProxyResponse, GoogleProxyResponse>
+> {
+  const { stream, baseURL, apiKey } = options ?? {};
+  const result: CaptureResult<
+    GoogleProxyRequest,
+    GoogleProxyResponse,
+    GoogleProxyResponse
+  > = { request: payload };
+
+  if (!baseURL) {
+    result.error =
+      "Google proxy executor requires a baseURL (proxy URL) to send requests to";
+    return result;
+  }
+
+  // Build the request body: translate google executor format to native Gemini API format.
+  // The cases use `config` (matching the @google/genai SDK), but the native API
+  // uses `generationConfig` at the top level.
+  const body: Record<string, unknown> = {
+    model: payload.model,
+    contents: payload.contents,
+  };
+  if (payload.systemInstruction) {
+    body.systemInstruction = payload.systemInstruction;
+  }
+  if (payload.tools) {
+    body.tools = payload.tools;
+  }
+  if (payload.config) {
+    body.generationConfig = payload.config;
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+
+    if (stream !== true) {
+      const response = await fetch(`${baseURL}/v1/generateContent`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        result.error = `HTTP ${response.status}: ${await response.text()}`;
+        return result;
+      }
+
+      result.response =
+        (await response.json()) as unknown as GoogleProxyResponse;
+    }
+
+    if (stream !== false) {
+      const streamResponse = await fetch(
+        `${baseURL}/v1/streamGenerateContent`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+        }
+      );
+
+      if (!streamResponse.ok) {
+        result.error = `HTTP ${streamResponse.status}: ${await streamResponse.text()}`;
+        return result;
+      }
+
+      const streamText = await streamResponse.text();
+      const chunks: GoogleProxyResponse[] = [];
+      for (const line of streamText.split("\n")) {
+        if (line.startsWith("data: ") && !line.startsWith("data: [DONE]")) {
+          try {
+            chunks.push(
+              JSON.parse(line.slice(6)) as unknown as GoogleProxyResponse
+            );
+          } catch {
+            // skip non-JSON lines
+          }
+        }
+      }
+      result.streamingResponse = chunks;
+    }
+  } catch (error) {
+    result.error = String(error);
+  }
+
+  return result;
+}
+
+export const googleProxyExecutor: ProviderExecutor<
+  GoogleProxyRequest,
+  GoogleProxyResponse,
+  GoogleProxyResponse
+> = {
+  name: "google",
+  cases: googleProxyCases,
+  execute: executeGoogleProxy,
+  ignoredFields: [
+    "responseId",
+    "modelVersion",
+    "candidates.*.content.parts.*.text",
+    "usageMetadata",
+  ],
+};


### PR DESCRIPTION
## Summary

- Implement real Google request/response validation in `validation/google.rs` using the generated pbjson serde implementations (the previous stubs returned errors claiming protobuf types lacked serde support -- they do now)
- Add Google to cross-provider validation tests with full cross-format discrimination (Google payloads validate as Google, fail as OpenAI/Anthropic/Bedrock and vice versa)
- Register Google in the payloads format registry so the snapshot validation pipeline can test native Gemini endpoints through the gateway proxy
- Add a proxy-aware Google executor (`google-proxy.ts`) that uses raw `fetch` to hit `/v1/generateContent` and `/v1/streamGenerateContent` (since the Google SDK doesn't support `baseURL` override)
- Add 4 native Gemini proxy test cases: basic, system instruction, multi-turn, tool call

## Test plan

- [x] `cargo test -p lingua validation` -- 32 validation tests pass (up from 14)
- [x] `cargo clippy --all-targets` -- clean
- [x] `npx tsc --noEmit` in `payloads/` -- TypeScript compiles cleanly
- [x] Gateway tests still pass (`cargo test` in gateway/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)