### PR TITLE
Add event_type to StreamChunk for SSE event line preservation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lingua-wasm typescript python test test-payloads capture capture-transforms clean help generate-types generate-all-providers install-hooks install-wasm-tools setup
+.PHONY: all lingua-wasm typescript python test test-payloads capture capture-transforms clean help generate-types generate-all-providers install-hooks install-wasm-tools setup precommit
 
 all: typescript python ## Build all bindings
 
@@ -111,5 +111,10 @@ install-dependencies: ## Install dependencies
 	./scripts/setup.sh
 
 setup: install-dependencies install-hooks ## Setup the project
+
+precommit: ## Run formatting, linting, and tests for Rust code
+	cargo fmt --all -- --check
+	cargo clippy --all-targets --all-features -- -D warnings
+	cargo test
 
 .DEFAULT_GOAL := all

--- a/crates/braintrust-llm-router/examples/streaming.rs
+++ b/crates/braintrust-llm-router/examples/streaming.rs
@@ -74,9 +74,9 @@ async fn main() -> Result<()> {
 
     while let Some(chunk_result) = stream.next().await {
         match chunk_result {
-            Ok(bytes) => {
+            Ok(stream_chunk) => {
                 // Parse bytes to Value
-                let chunk: Value = match serde_json::from_slice(&bytes) {
+                let chunk: Value = match serde_json::from_slice(&stream_chunk.data) {
                     Ok(v) => v,
                     Err(_) => continue,
                 };
@@ -155,8 +155,8 @@ async fn main() -> Result<()> {
         let mut response = String::new();
         while let Some(chunk_result) = stream.next().await {
             match chunk_result {
-                Ok(bytes) => {
-                    if let Ok(chunk) = serde_json::from_slice::<Value>(&bytes) {
+                Ok(stream_chunk) => {
+                    if let Ok(chunk) = serde_json::from_slice::<Value>(&stream_chunk.data) {
                         if let Some(text) = extract_chunk_text(&chunk) {
                             response.push_str(&text);
                         }

--- a/crates/braintrust-llm-router/src/lib.rs
+++ b/crates/braintrust-llm-router/src/lib.rs
@@ -29,7 +29,7 @@ pub use providers::{
 };
 pub use retry::{RetryPolicy, RetryStrategy};
 pub use router::{create_provider, extract_request_hints, RequestHints, Router, RouterBuilder};
-pub use streaming::{RawResponseStream, ResponseStream};
+pub use streaming::{RawResponseStream, ResponseStream, StreamChunk};
 
 // Provider trait requirement (for custom provider implementations)
 pub use lingua::{UniversalResponse, UniversalUsage};

--- a/crates/braintrust-llm-router/src/streaming.rs
+++ b/crates/braintrust-llm-router/src/streaming.rs
@@ -71,9 +71,10 @@ pub fn transform_stream(raw: RawResponseStream, output_format: ProviderFormat) -
 
                     // Transform with lingua (bytes-based)
                     match lingua::transform_stream_chunk(data.clone(), output_format) {
-                        Ok(TransformResult::PassThrough(pass_bytes)) => {
-                            Some(Ok(StreamChunk { data: pass_bytes, event_type }))
-                        }
+                        Ok(TransformResult::PassThrough(pass_bytes)) => Some(Ok(StreamChunk {
+                            data: pass_bytes,
+                            event_type,
+                        })),
                         Ok(TransformResult::Transformed {
                             bytes: out_bytes, ..
                         }) => {
@@ -81,7 +82,10 @@ pub fn transform_stream(raw: RawResponseStream, output_format: ProviderFormat) -
                             if out_bytes.as_ref() == b"{}" {
                                 None
                             } else {
-                                Some(Ok(StreamChunk { data: out_bytes, event_type }))
+                                Some(Ok(StreamChunk {
+                                    data: out_bytes,
+                                    event_type,
+                                }))
                             }
                         }
                         Err(lingua::TransformError::UnableToDetectFormat) => {
@@ -290,7 +294,7 @@ where
 
                     if event_type.as_deref() == Some("chunk") {
                         if let Some(decoded_chunk) = decode_bedrock_chunk_payload(payload) {
-                            return Poll::Ready(Some(Ok(decoded_chunk)));
+                            return Poll::Ready(Some(Ok(StreamChunk::data(decoded_chunk))));
                         }
                     }
 

--- a/crates/lingua/src/processing/adapters.rs
+++ b/crates/lingua/src/processing/adapters.rs
@@ -202,15 +202,15 @@ static ADAPTERS: LazyLock<Vec<Box<dyn ProviderAdapter>>> = LazyLock::new(|| {
     list.push(Box::new(crate::providers::bedrock::BedrockAdapter));
 
     #[cfg(feature = "anthropic")]
+    list.push(Box::new(crate::providers::anthropic::AnthropicAdapter));
+
+    #[cfg(feature = "anthropic")]
     list.push(Box::new(
         crate::providers::bedrock_anthropic::BedrockAnthropicAdapter::new(),
     ));
 
     #[cfg(feature = "google")]
     list.push(Box::new(crate::providers::google::GoogleAdapter));
-
-    #[cfg(feature = "anthropic")]
-    list.push(Box::new(crate::providers::anthropic::AnthropicAdapter));
 
     #[cfg(feature = "openai")]
     list.push(Box::new(crate::providers::openai::OpenAIAdapter));

--- a/crates/lingua/src/providers/bedrock_anthropic/adapter.rs
+++ b/crates/lingua/src/providers/bedrock_anthropic/adapter.rs
@@ -114,8 +114,8 @@ impl ProviderAdapter for BedrockAnthropicAdapter {
         self.inner.response_from_universal(resp)
     }
 
-    fn detect_stream_response(&self, payload: &Value) -> bool {
-        self.inner.detect_stream_response(payload)
+    fn detect_stream_response(&self, _payload: &Value) -> bool {
+        false
     }
 
     fn stream_to_universal(


### PR DESCRIPTION
The Anthropic SDK requires SSE `event:` lines to dispatch streaming events. Embed the event type from upstream SSE parsing into StreamChunk so downstream consumers can emit it without re-parsing JSON.

Also moves bedrock parsing lower so it doesn't interpret anthropic payloads as bedrock andthropic