### PR TITLE
mistral provider: Strip some unsupported openai fields

### DIFF
--- a/crates/braintrust-llm-router/src/providers/mistral.rs
+++ b/crates/braintrust-llm-router/src/providers/mistral.rs
@@ -11,6 +11,7 @@ use crate::client::{default_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::ClientHeaders;
 use crate::streaming::{single_bytes_stream, sse_stream, RawResponseStream};
+use lingua::serde_json::Value;
 use lingua::ProviderFormat;
 
 #[derive(Debug, Clone)]
@@ -85,6 +86,30 @@ fn extract_retry_after(status: StatusCode) -> Option<Duration> {
     }
 }
 
+/// Sanitize a payload for Mistral's API by removing unsupported fields and
+/// converting OpenAI-only parameter names to their Mistral equivalents.
+///
+/// Mistral's API does not support:
+/// - `max_completion_tokens` (use `max_tokens` instead)
+/// - `stream_options` (extra_forbidden)
+fn sanitize_payload(payload: Bytes) -> Bytes {
+    let Ok(mut body) = lingua::serde_json::from_slice::<Value>(&payload) else {
+        return payload;
+    };
+    let Some(obj) = body.as_object_mut() else {
+        return payload;
+    };
+
+    if let Some(v) = obj.remove("max_completion_tokens") {
+        obj.entry("max_tokens").or_insert(v);
+    }
+    obj.remove("stream_options");
+
+    lingua::serde_json::to_vec(obj)
+        .map(Bytes::from)
+        .unwrap_or(payload)
+}
+
 #[async_trait]
 impl crate::providers::Provider for MistralProvider {
     fn id(&self) -> &'static str {
@@ -92,7 +117,7 @@ impl crate::providers::Provider for MistralProvider {
     }
 
     fn provider_formats(&self) -> Vec<ProviderFormat> {
-        vec![ProviderFormat::Mistral]
+        vec![ProviderFormat::ChatCompletions]
     }
 
     async fn complete(
@@ -103,6 +128,7 @@ impl crate::providers::Provider for MistralProvider {
         _format: ProviderFormat,
         client_headers: &ClientHeaders,
     ) -> Result<Bytes> {
+        let payload = sanitize_payload(payload);
         let url = self.chat_url()?;
 
         #[cfg(feature = "tracing")]
@@ -162,6 +188,7 @@ impl crate::providers::Provider for MistralProvider {
         format: ProviderFormat,
         client_headers: &ClientHeaders,
     ) -> Result<RawResponseStream> {
+        let payload = sanitize_payload(payload);
         if !spec.supports_streaming {
             let response = self
                 .complete(payload, auth, spec, format, client_headers)

--- a/crates/lingua/src/providers/openai/capabilities.rs
+++ b/crates/lingua/src/providers/openai/capabilities.rs
@@ -23,6 +23,8 @@ const MODEL_TRANSFORM_RULES: &[(&str, &[ModelTransform])] = &[
     ("o3", &[StripTemperature, ForceMaxCompletionTokens]),
     ("o4", &[StripTemperature, ForceMaxCompletionTokens]),
     ("gpt-5", &[StripTemperature, ForceMaxCompletionTokens]),
+    // TODO: would be nice if we could apply these rules by provider instead of model name, and
+    // apply these to all Mistral models
     ("mistral", &[ForceMaxTokens]),
     ("magistral", &[ForceMaxTokens]),
     ("codestral", &[ForceMaxTokens]),
@@ -223,5 +225,37 @@ mod tests {
             !obj.contains_key("max_completion_tokens"),
             "should not convert max_output_tokens"
         );
+    }
+
+    #[test]
+    fn test_force_max_tokens() {
+        for model in [
+            "mistral",
+            "magistral",
+            "codestral",
+            "pixstral",
+            "devstral",
+            "voxstral",
+        ] {
+            let mut obj = json!({
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_completion_tokens": 100
+            })
+            .as_object()
+            .unwrap()
+            .clone();
+            apply_model_transforms(model, &mut obj);
+            assert!(
+                obj.contains_key("max_tokens"),
+                "{} should add max_tokens",
+                model
+            );
+            assert!(
+                !obj.contains_key("max_completion_tokens"),
+                "{} should remove max_completion_tokens",
+                model
+            );
+        }
     }
 }

--- a/crates/lingua/src/providers/openai/capabilities.rs
+++ b/crates/lingua/src/providers/openai/capabilities.rs
@@ -10,6 +10,8 @@ pub enum ModelTransform {
     StripTemperature,
     /// Convert max_tokens to max_completion_tokens
     ForceMaxCompletionTokens,
+    /// Convert max_completion_tokens to max_tokens
+    ForceMaxTokens,
 }
 
 use ModelTransform::*;
@@ -21,6 +23,12 @@ const MODEL_TRANSFORM_RULES: &[(&str, &[ModelTransform])] = &[
     ("o3", &[StripTemperature, ForceMaxCompletionTokens]),
     ("o4", &[StripTemperature, ForceMaxCompletionTokens]),
     ("gpt-5", &[StripTemperature, ForceMaxCompletionTokens]),
+    ("mistral", &[ForceMaxTokens]),
+    ("magistral", &[ForceMaxTokens]),
+    ("codestral", &[ForceMaxTokens]),
+    ("pixstral", &[ForceMaxTokens]),
+    ("devstral", &[ForceMaxTokens]),
+    ("voxstral", &[ForceMaxTokens]),
 ];
 
 /// Get the transforms required for a model.
@@ -55,6 +63,12 @@ pub fn apply_model_transforms(model: &str, obj: &mut Map<String, Value>) {
                 // (Chat Completions API) max_tokens is deprecated - convert to max_completion_tokens.
                 if let Some(max_tokens) = obj.remove("max_tokens") {
                     obj.entry("max_completion_tokens").or_insert(max_tokens);
+                }
+            }
+            ForceMaxTokens => {
+                // Mistral does not support max_completion_tokens yet, use max_tokens instead
+                if let Some(max_tokens) = obj.remove("max_completion_tokens") {
+                    obj.entry("max_tokens").or_insert(max_tokens);
                 }
             }
         }


### PR DESCRIPTION
Update the mistral provider to use max_tokens instead of max_completion_tokens,
since mistral only supports the older format.