### PR TITLE
Refactor Vertex Anthropic to use adapter pattern

### DIFF
--- a/crates/braintrust-llm-router/src/catalog/resolver.rs
+++ b/crates/braintrust-llm-router/src/catalog/resolver.rs
@@ -37,6 +37,10 @@ impl ModelResolver {
             && lingua::is_bedrock_anthropic_model(model)
         {
             ProviderFormat::BedrockAnthropic
+        } else if spec.format == ProviderFormat::Anthropic
+            && lingua::is_vertex_anthropic_model(model)
+        {
+            ProviderFormat::VertexAnthropic
         } else {
             spec.format
         };
@@ -56,6 +60,7 @@ fn format_identifier(format: ProviderFormat) -> String {
         ProviderFormat::ChatCompletions => "openai",
         ProviderFormat::Anthropic => "anthropic",
         ProviderFormat::BedrockAnthropic => "bedrock",
+        ProviderFormat::VertexAnthropic => "vertex",
         ProviderFormat::Google => "google",
         ProviderFormat::Mistral => "mistral",
         ProviderFormat::Converse => "bedrock",
@@ -182,7 +187,7 @@ mod tests {
         let resolver = ModelResolver::new(Arc::new(catalog));
 
         let (_, format, alias) = resolver.resolve(model).expect("resolves");
-        assert_eq!(format, ProviderFormat::Anthropic);
+        assert_eq!(format, ProviderFormat::VertexAnthropic);
         assert_eq!(alias, "vertex");
     }
 }

--- a/crates/braintrust-llm-router/src/catalog/resolver.rs
+++ b/crates/braintrust-llm-router/src/catalog/resolver.rs
@@ -41,7 +41,7 @@ impl ModelResolver {
             spec.format
         };
         let provider_alias = self.aliases.get(model).cloned().unwrap_or_else(|| {
-            if format == ProviderFormat::Google && lingua::is_vertex_model(model) {
+            if lingua::is_vertex_model(model) {
                 "vertex".to_string()
             } else {
                 format_identifier(format)
@@ -172,5 +172,17 @@ mod tests {
         let (_, format, alias) = resolver.resolve(model).expect("resolves");
         assert_eq!(format, ProviderFormat::Google);
         assert_eq!(alias, "google");
+    }
+
+    #[test]
+    fn resolve_vertex_anthropic_model_routes_to_vertex() {
+        let model = "publishers/anthropic/models/claude-haiku-4-5";
+        let mut catalog = ModelCatalog::empty();
+        catalog.insert(model.into(), spec(model, ProviderFormat::Anthropic));
+        let resolver = ModelResolver::new(Arc::new(catalog));
+
+        let (_, format, alias) = resolver.resolve(model).expect("resolves");
+        assert_eq!(format, ProviderFormat::Anthropic);
+        assert_eq!(alias, "vertex");
     }
 }

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -536,14 +536,8 @@ mod tests {
             .build()
             .expect("router builds");
 
-        assert_eq!(
-            router.provider_alias(vertex_model).unwrap(),
-            "vertex"
-        );
-        assert_eq!(
-            router.provider_alias(google_model).unwrap(),
-            "google"
-        );
+        assert_eq!(router.provider_alias(vertex_model).unwrap(), "vertex");
+        assert_eq!(router.provider_alias(google_model).unwrap(), "google");
     }
 
     #[test]
@@ -566,9 +560,6 @@ mod tests {
             .build()
             .expect("router builds");
 
-        assert_eq!(
-            router.provider_alias(vertex_model).unwrap(),
-            "google"
-        );
+        assert_eq!(router.provider_alias(vertex_model).unwrap(), "google");
     }
 }

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -250,21 +250,17 @@ impl Router {
             );
             self.formats.get(&catalog_format).cloned().unwrap_or(alias)
         };
-        let provider = self
-            .providers
-            .get(&alias)
-            .cloned()
-            .ok_or_else(|| {
-                #[cfg(feature = "tracing")]
-                tracing::warn!(
-                    model,
-                    alias = %alias,
-                    format = ?catalog_format,
-                    registered = ?registered,
-                    "no provider found for resolved alias"
-                );
-                Error::NoProvider(catalog_format)
-            })?;
+        let provider = self.providers.get(&alias).cloned().ok_or_else(|| {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                model,
+                alias = %alias,
+                format = ?catalog_format,
+                registered = ?registered,
+                "no provider found for resolved alias"
+            );
+            Error::NoProvider(catalog_format)
+        })?;
         let format = if output_format != catalog_format
             && provider.provider_formats().contains(&output_format)
         {

--- a/crates/coverage-report/src/expected.rs
+++ b/crates/coverage-report/src/expected.rs
@@ -112,7 +112,10 @@ fn get_expected_differences(category: TestCategory) -> &'static ExpectedDifferen
 /// Bedrock Anthropic delegates all conversion to `AnthropicAdapter`, so it
 /// shares every known limitation with "Anthropic".
 fn inherits_from(provider: &str, parent: &str) -> bool {
-    matches!((provider, parent), ("Bedrock Anthropic", "Anthropic"))
+    matches!(
+        (provider, parent),
+        ("Bedrock Anthropic", "Anthropic") | ("Vertex Anthropic", "Anthropic")
+    )
 }
 
 /// Helper function for source/target matching with wildcard support.

--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -121,6 +121,14 @@
     },
     {
       "source": "*",
+      "target": "Vertex Anthropic",
+      "fields": [
+        { "pattern": "model", "reason": "Vertex Anthropic rawPredict body omits model (selected by URL path)" },
+        { "pattern": "params.stream", "reason": "Vertex Anthropic uses endpoint-based streaming" }
+      ]
+    },
+    {
+      "source": "*",
       "target": "Google",
       "fields": [
         { "pattern": "params.stream", "reason": "Google uses endpoint-based streaming" },

--- a/crates/coverage-report/src/runner.rs
+++ b/crates/coverage-report/src/runner.rs
@@ -80,6 +80,7 @@ pub fn test_request_transformation(
         ProviderFormat::Google => Some("gemini-1.5-pro"),
         ProviderFormat::Converse => Some("anthropic.claude-3-sonnet"),
         ProviderFormat::BedrockAnthropic => Some("us.anthropic.claude-haiku-4-5-20251001-v1:0"),
+        ProviderFormat::VertexAnthropic => Some("publishers/anthropic/models/claude-haiku-4-5"),
         _ => None,
     };
 

--- a/crates/coverage-report/src/types.rs
+++ b/crates/coverage-report/src/types.rs
@@ -117,6 +117,7 @@ pub fn parse_provider(name: &str) -> Result<ProviderFormat, String> {
         "google" | "gemini" => Ok(ProviderFormat::Google),
         "bedrock" | "converse" => Ok(ProviderFormat::Converse),
         "bedrock-anthropic" => Ok(ProviderFormat::BedrockAnthropic),
+        "vertex-anthropic" => Ok(ProviderFormat::VertexAnthropic),
         _ => Err(format!("Unknown provider: {}", name)),
     }
 }

--- a/crates/coverage-report/tests/cross_provider_test.rs
+++ b/crates/coverage-report/tests/cross_provider_test.rs
@@ -19,6 +19,7 @@ const REQUIRED_PROVIDERS: &[ProviderFormat] = &[
     ProviderFormat::Anthropic,
     ProviderFormat::BedrockAnthropic,
     ProviderFormat::Google,
+    ProviderFormat::VertexAnthropic,
 ];
 
 #[test]

--- a/crates/lingua/src/capabilities/format.rs
+++ b/crates/lingua/src/capabilities/format.rs
@@ -35,6 +35,10 @@ pub enum ProviderFormat {
     #[serde(skip_serializing, skip_deserializing)]
     #[ts(skip)]
     BedrockAnthropic,
+    /// Internal-only format for Vertex AI Anthropic rawPredict envelope handling.
+    #[serde(skip_serializing, skip_deserializing)]
+    #[ts(skip)]
+    VertexAnthropic,
     /// Unknown or undetectable format
     #[default]
     #[serde(other)]
@@ -58,6 +62,7 @@ impl std::fmt::Display for ProviderFormat {
             ProviderFormat::Converse => "converse",
             ProviderFormat::Responses => "responses",
             ProviderFormat::BedrockAnthropic => "bedrock_anthropic",
+            ProviderFormat::VertexAnthropic => "vertex_anthropic",
             ProviderFormat::Unknown => "unknown",
         };
         write!(f, "{}", s)

--- a/crates/lingua/src/lib.rs
+++ b/crates/lingua/src/lib.rs
@@ -47,3 +47,7 @@ pub use universal::{
 // Re-export bedrock-anthropic model utilities for router integration
 #[cfg(feature = "anthropic")]
 pub use providers::bedrock_anthropic::{is_bedrock_anthropic_model, is_bedrock_anthropic_target};
+
+// Re-export vertex model utilities for router integration
+#[cfg(feature = "google")]
+pub use providers::google::is_vertex_model;

--- a/crates/lingua/src/lib.rs
+++ b/crates/lingua/src/lib.rs
@@ -51,3 +51,7 @@ pub use providers::bedrock_anthropic::{is_bedrock_anthropic_model, is_bedrock_an
 // Re-export vertex model utilities for router integration
 #[cfg(feature = "google")]
 pub use providers::google::is_vertex_model;
+
+// Re-export vertex-anthropic model utilities for router integration
+#[cfg(feature = "anthropic")]
+pub use providers::vertex_anthropic::{is_vertex_anthropic_model, is_vertex_anthropic_target};

--- a/crates/lingua/src/processing/adapters.rs
+++ b/crates/lingua/src/processing/adapters.rs
@@ -209,6 +209,11 @@ static ADAPTERS: LazyLock<Vec<Box<dyn ProviderAdapter>>> = LazyLock::new(|| {
         crate::providers::bedrock_anthropic::BedrockAnthropicAdapter::new(),
     ));
 
+    #[cfg(feature = "anthropic")]
+    list.push(Box::new(
+        crate::providers::vertex_anthropic::VertexAnthropicAdapter::new(),
+    ));
+
     #[cfg(feature = "google")]
     list.push(Box::new(crate::providers::google::GoogleAdapter));
 

--- a/crates/lingua/src/providers/google/mod.rs
+++ b/crates/lingua/src/providers/google/mod.rs
@@ -31,3 +31,11 @@ pub use generated::{
 
 // Type aliases for convenience
 pub type SafetySettings = Vec<SafetySetting>;
+
+/// Returns true if the model ID represents a Vertex AI model.
+///
+/// Vertex models use the `publishers/` prefix
+/// (e.g. `publishers/google/models/gemini-2.5-flash-preview-04-17`).
+pub fn is_vertex_model(model: &str) -> bool {
+    model.starts_with("publishers/")
+}

--- a/crates/lingua/src/providers/mod.rs
+++ b/crates/lingua/src/providers/mod.rs
@@ -11,6 +11,9 @@ pub mod bedrock;
 #[cfg(feature = "anthropic")]
 pub mod bedrock_anthropic;
 
+#[cfg(feature = "anthropic")]
+pub mod vertex_anthropic;
+
 #[cfg(feature = "google")]
 pub mod google;
 

--- a/crates/lingua/src/providers/vertex_anthropic/adapter.rs
+++ b/crates/lingua/src/providers/vertex_anthropic/adapter.rs
@@ -1,0 +1,203 @@
+use crate::capabilities::ProviderFormat;
+use crate::processing::adapters::ProviderAdapter;
+use crate::processing::transform::TransformError;
+use crate::providers::anthropic::AnthropicAdapter;
+use crate::serde_json::Value;
+use crate::universal::{UniversalRequest, UniversalResponse, UniversalStreamChunk};
+use serde::Deserialize;
+
+const VERTEX_ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
+
+#[derive(Deserialize)]
+struct VertexDetectHint {
+    #[serde(default)]
+    anthropic_version: Option<String>,
+    #[serde(default)]
+    model: Option<Value>,
+    #[serde(default)]
+    messages: Option<Value>,
+}
+
+/// Adapter for Vertex AI's Anthropic rawPredict body format.
+///
+/// For Vertex AI rawPredict endpoints, the model is selected by URL path
+/// and the request body contains Anthropic fields with `anthropic_version`
+/// set to the Vertex-specific version string.
+pub struct VertexAnthropicAdapter {
+    inner: AnthropicAdapter,
+}
+
+impl VertexAnthropicAdapter {
+    pub fn new() -> Self {
+        Self {
+            inner: AnthropicAdapter,
+        }
+    }
+
+    fn is_raw_vertex_body(payload: &Value) -> bool {
+        let Ok(hint) = crate::serde_json::from_value::<VertexDetectHint>(payload.clone()) else {
+            return false;
+        };
+        if hint.model.is_some() {
+            return false;
+        }
+        let has_vertex_version = hint
+            .anthropic_version
+            .as_deref()
+            .is_some_and(|v| v.contains("vertex"));
+        hint.messages.is_some() && has_vertex_version
+    }
+
+    fn convert_to_vertex_body(mut payload: Value) -> Value {
+        if let Some(obj) = payload.as_object_mut() {
+            obj.remove("model");
+            obj.remove("stream");
+            obj.remove("stream_options");
+            obj.insert(
+                "anthropic_version".into(),
+                Value::String(VERTEX_ANTHROPIC_VERSION.into()),
+            );
+        }
+        payload
+    }
+}
+
+impl Default for VertexAnthropicAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProviderAdapter for VertexAnthropicAdapter {
+    fn format(&self) -> ProviderFormat {
+        ProviderFormat::VertexAnthropic
+    }
+
+    fn directory_name(&self) -> &'static str {
+        "vertex-anthropic"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Vertex Anthropic"
+    }
+
+    fn detect_request(&self, payload: &Value) -> bool {
+        if !Self::is_raw_vertex_body(payload) {
+            return false;
+        }
+        self.inner.request_to_universal(payload.clone()).is_ok()
+    }
+
+    fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
+        if !Self::is_raw_vertex_body(&payload) {
+            return Err(TransformError::ToUniversalFailed(
+                "Invalid Vertex Anthropic request format".to_string(),
+            ));
+        }
+        self.inner.request_to_universal(payload)
+    }
+
+    fn request_from_universal(&self, req: &UniversalRequest) -> Result<Value, TransformError> {
+        let mut request = req.clone();
+        request.params.stream = None;
+        let anthropic_payload = self.inner.request_from_universal(&request)?;
+        Ok(Self::convert_to_vertex_body(anthropic_payload))
+    }
+
+    fn apply_defaults(&self, req: &mut UniversalRequest) {
+        self.inner.apply_defaults(req);
+    }
+
+    fn detect_response(&self, payload: &Value) -> bool {
+        self.inner.detect_response(payload)
+    }
+
+    fn response_to_universal(&self, payload: Value) -> Result<UniversalResponse, TransformError> {
+        self.inner.response_to_universal(payload)
+    }
+
+    fn response_from_universal(&self, resp: &UniversalResponse) -> Result<Value, TransformError> {
+        self.inner.response_from_universal(resp)
+    }
+
+    fn detect_stream_response(&self, payload: &Value) -> bool {
+        self.inner.detect_stream_response(payload)
+    }
+
+    fn stream_to_universal(
+        &self,
+        payload: Value,
+    ) -> Result<Option<UniversalStreamChunk>, TransformError> {
+        self.inner.stream_to_universal(payload)
+    }
+
+    fn stream_from_universal(&self, chunk: &UniversalStreamChunk) -> Result<Value, TransformError> {
+        self.inner.stream_from_universal(chunk)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::processing::adapters::ProviderAdapter;
+    use crate::serde_json::{json, Map};
+
+    #[test]
+    fn detect_request_accepts_raw_vertex_body() {
+        let adapter = VertexAnthropicAdapter::new();
+
+        let valid = json!({
+            "anthropic_version": "vertex-2023-10-16",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(adapter.detect_request(&valid));
+
+        let with_model = json!({
+            "model": "claude-3-sonnet",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(!adapter.detect_request(&with_model));
+
+        let bedrock_version = json!({
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        assert!(!adapter.detect_request(&bedrock_version));
+    }
+
+    #[test]
+    fn request_to_universal_parses_flat_body() {
+        let adapter = VertexAnthropicAdapter::new();
+        let raw = json!({
+            "anthropic_version": "vertex-2023-10-16",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        let universal = adapter.request_to_universal(raw).unwrap();
+        assert_eq!(universal.model, None);
+    }
+
+    #[test]
+    fn request_roundtrip_emits_flat_vertex_body() {
+        let adapter = VertexAnthropicAdapter::new();
+        let input = json!({
+            "anthropic_version": "vertex-2023-10-16",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let mut universal = adapter.request_to_universal(input).unwrap();
+        universal.model = Some("publishers/anthropic/models/claude-haiku-4-5".to_string());
+        let transformed = adapter.request_from_universal(&universal).unwrap();
+
+        let obj: Map<String, Value> = crate::serde_json::from_value(transformed).unwrap();
+        assert!(!obj.contains_key("model"));
+        assert!(!obj.contains_key("stream"));
+        assert_eq!(obj["anthropic_version"], "vertex-2023-10-16");
+        assert!(obj.contains_key("messages"));
+        assert!(obj.contains_key("max_tokens"));
+    }
+}

--- a/crates/lingua/src/providers/vertex_anthropic/mod.rs
+++ b/crates/lingua/src/providers/vertex_anthropic/mod.rs
@@ -1,0 +1,26 @@
+#[cfg(feature = "anthropic")]
+pub mod adapter;
+
+#[cfg(feature = "anthropic")]
+pub use adapter::VertexAnthropicAdapter;
+
+/// Returns true if the model ID represents a Vertex AI-hosted Anthropic model.
+///
+/// These models have IDs starting with `publishers/anthropic/`
+/// (e.g. `publishers/anthropic/models/claude-haiku-4-5`).
+pub fn is_vertex_anthropic_model(model: &str) -> bool {
+    model.starts_with("publishers/anthropic/")
+}
+
+/// Returns true if the given format + model combination targets a Vertex
+/// Anthropic rawPredict endpoint.
+pub fn is_vertex_anthropic_target(
+    format: crate::capabilities::ProviderFormat,
+    model: Option<&str>,
+) -> bool {
+    matches!(
+        format,
+        crate::capabilities::ProviderFormat::Anthropic
+            | crate::capabilities::ProviderFormat::VertexAnthropic
+    ) && model.is_some_and(is_vertex_anthropic_model)
+}

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -114,6 +114,7 @@ impl FinishReason {
                 "end_turn" | "stop_sequence",
                 ProviderFormat::Anthropic
                 | ProviderFormat::BedrockAnthropic
+                | ProviderFormat::VertexAnthropic
                 | ProviderFormat::Converse,
             ) => Self::Stop,
             ("STOP", ProviderFormat::Google) => Self::Stop,
@@ -125,6 +126,7 @@ impl FinishReason {
                 "max_tokens",
                 ProviderFormat::Anthropic
                 | ProviderFormat::BedrockAnthropic
+                | ProviderFormat::VertexAnthropic
                 | ProviderFormat::Converse,
             ) => Self::Length,
             ("MAX_TOKENS", ProviderFormat::Google) => Self::Length,
@@ -136,6 +138,7 @@ impl FinishReason {
                 "tool_use",
                 ProviderFormat::Anthropic
                 | ProviderFormat::BedrockAnthropic
+                | ProviderFormat::VertexAnthropic
                 | ProviderFormat::Converse,
             ) => Self::ToolCalls,
             ("TOOL_CALLS", ProviderFormat::Google) => Self::ToolCalls,
@@ -167,6 +170,7 @@ impl FinishReason {
                 Self::Stop,
                 ProviderFormat::Anthropic
                 | ProviderFormat::BedrockAnthropic
+                | ProviderFormat::VertexAnthropic
                 | ProviderFormat::Converse,
             ) => "end_turn",
             (Self::Stop, ProviderFormat::Google) => "STOP",
@@ -187,6 +191,7 @@ impl FinishReason {
                 Self::Length,
                 ProviderFormat::Anthropic
                 | ProviderFormat::BedrockAnthropic
+                | ProviderFormat::VertexAnthropic
                 | ProviderFormat::Converse,
             ) => "max_tokens",
 
@@ -195,6 +200,7 @@ impl FinishReason {
                 Self::ToolCalls,
                 ProviderFormat::Anthropic
                 | ProviderFormat::BedrockAnthropic
+                | ProviderFormat::VertexAnthropic
                 | ProviderFormat::Converse,
             ) => "tool_use",
             (Self::ToolCalls, ProviderFormat::Google) => "STOP",
@@ -213,6 +219,7 @@ impl FinishReason {
                 ProviderFormat::ChatCompletions
                 | ProviderFormat::Anthropic
                 | ProviderFormat::BedrockAnthropic
+                | ProviderFormat::VertexAnthropic
                 | ProviderFormat::Mistral
                 | ProviderFormat::Unknown,
             ) => "content_filter",
@@ -267,7 +274,9 @@ impl UniversalUsage {
                     .and_then(Value::as_i64)
                     .filter(|&v| v > 0),
             },
-            ProviderFormat::Anthropic | ProviderFormat::BedrockAnthropic => Self {
+            ProviderFormat::Anthropic
+            | ProviderFormat::BedrockAnthropic
+            | ProviderFormat::VertexAnthropic => Self {
                 prompt_tokens: usage.get("input_tokens").and_then(Value::as_i64),
                 completion_tokens: usage.get("output_tokens").and_then(Value::as_i64),
                 prompt_cached_tokens: usage.get("cache_read_input_tokens").and_then(Value::as_i64),
@@ -355,7 +364,9 @@ impl UniversalUsage {
 
                 Value::Object(map)
             }
-            ProviderFormat::Anthropic | ProviderFormat::BedrockAnthropic => {
+            ProviderFormat::Anthropic
+            | ProviderFormat::BedrockAnthropic
+            | ProviderFormat::VertexAnthropic => {
                 let mut map = serde_json::Map::new();
                 if let Some(p) = self.prompt_tokens {
                     map.insert("input_tokens".into(), serde_json::json!(p));

--- a/payloads/cases/advanced.ts
+++ b/payloads/cases/advanced.ts
@@ -6,6 +6,7 @@ import {
   ANTHROPIC_MODEL,
   BEDROCK_MODEL,
   BEDROCK_ANTHROPIC_MODEL,
+  VERTEX_ANTHROPIC_MODEL,
 } from "./models";
 
 const IMAGE_BASE64 =
@@ -398,6 +399,36 @@ export const advancedCases: TestCaseCollection = {
 
     "bedrock-anthropic": {
       model: BEDROCK_ANTHROPIC_MODEL,
+      max_tokens: 20_000,
+      messages: [
+        {
+          role: "user",
+          content: "What's the weather like in San Francisco?",
+        },
+      ],
+      tools: [
+        {
+          name: "get_weather",
+          description: "Get the current weather for a location",
+          input_schema: {
+            type: "object",
+            properties: {
+              location: {
+                type: "string",
+                description: "The city and state, e.g. San Francisco, CA",
+              },
+            },
+            required: ["location"],
+          },
+        },
+      ],
+      tool_choice: {
+        type: "auto",
+      },
+    },
+
+    "vertex-anthropic": {
+      model: VERTEX_ANTHROPIC_MODEL,
       max_tokens: 20_000,
       messages: [
         {

--- a/payloads/cases/models.ts
+++ b/payloads/cases/models.ts
@@ -12,3 +12,5 @@ export const GOOGLE_IMAGE_MODEL = "gemini-2.5-flash-image";
 export const BEDROCK_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 export const BEDROCK_ANTHROPIC_MODEL =
   "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+export const VERTEX_ANTHROPIC_MODEL =
+  "publishers/anthropic/models/claude-haiku-4-5";

--- a/payloads/cases/simple.ts
+++ b/payloads/cases/simple.ts
@@ -6,6 +6,7 @@ import {
   ANTHROPIC_MODEL,
   BEDROCK_MODEL,
   BEDROCK_ANTHROPIC_MODEL,
+  VERTEX_ANTHROPIC_MODEL,
 } from "./models";
 
 // Simple test cases - basic functionality testing
@@ -66,6 +67,17 @@ export const simpleCases: TestCaseCollection = {
 
     "bedrock-anthropic": {
       model: BEDROCK_ANTHROPIC_MODEL,
+      max_tokens: 20_000,
+      messages: [
+        {
+          role: "user",
+          content: "What is the capital of France?",
+        },
+      ],
+    },
+
+    "vertex-anthropic": {
+      model: VERTEX_ANTHROPIC_MODEL,
       max_tokens: 20_000,
       messages: [
         {
@@ -149,6 +161,18 @@ export const simpleCases: TestCaseCollection = {
         },
       ],
     },
+
+    "vertex-anthropic": {
+      model: VERTEX_ANTHROPIC_MODEL,
+      max_tokens: 20_000,
+      messages: [
+        {
+          role: "user",
+          content:
+            "Solve this step by step: If a train travels 60 mph for 2 hours, then 80 mph for 1 hour, what's the average speed?",
+        },
+      ],
+    },
   },
 
   reasoningRequestTruncated: {
@@ -223,6 +247,18 @@ export const simpleCases: TestCaseCollection = {
 
     "bedrock-anthropic": {
       model: BEDROCK_ANTHROPIC_MODEL,
+      max_tokens: 100,
+      messages: [
+        {
+          role: "user",
+          content:
+            "Solve this step by step: If a train travels 60 mph for 2 hours, then 80 mph for 1 hour, what's the average speed?",
+        },
+      ],
+    },
+
+    "vertex-anthropic": {
+      model: VERTEX_ANTHROPIC_MODEL,
       max_tokens: 100,
       messages: [
         {
@@ -382,6 +418,33 @@ export const simpleCases: TestCaseCollection = {
 
     "bedrock-anthropic": {
       model: BEDROCK_ANTHROPIC_MODEL,
+      max_tokens: 20_000,
+      messages: [
+        {
+          role: "user",
+          content: "What's the weather like in San Francisco?",
+        },
+      ],
+      tools: [
+        {
+          name: "get_weather",
+          description: "Get the current weather for a location",
+          input_schema: {
+            type: "object",
+            properties: {
+              location: {
+                type: "string",
+                description: "The city and state, e.g. San Francisco, CA",
+              },
+            },
+            required: ["location"],
+          },
+        },
+      ],
+    },
+
+    "vertex-anthropic": {
+      model: VERTEX_ANTHROPIC_MODEL,
       max_tokens: 20_000,
       messages: [
         {

--- a/payloads/cases/types.ts
+++ b/payloads/cases/types.ts
@@ -46,6 +46,7 @@ export interface TestCase {
   google: GoogleGenerateContentRequest | null;
   bedrock: BedrockConverseRequest | null;
   "bedrock-anthropic"?: AnthropicMessageCreateParams | null;
+  "vertex-anthropic"?: AnthropicMessageCreateParams | null;
   // Optional expectations for proxy compatibility tests
   expect?: TestExpectation;
 }
@@ -65,4 +66,5 @@ export const PROVIDER_TYPES = [
   "google",
   "bedrock",
   "bedrock-anthropic",
+  "vertex-anthropic",
 ] as const;

--- a/payloads/scripts/capture.ts
+++ b/payloads/scripts/capture.ts
@@ -13,6 +13,7 @@ import { anthropicExecutor } from "./providers/anthropic";
 import { googleExecutor } from "./providers/google";
 import { bedrockExecutor } from "./providers/bedrock";
 import { bedrockAnthropicExecutor } from "./providers/bedrock-anthropic";
+import { vertexAnthropicExecutor } from "./providers/vertex-anthropic";
 import { type ProviderExecutor } from "./types";
 
 // Update provider names to be more descriptive
@@ -23,6 +24,7 @@ const allProviders = [
   googleExecutor,
   bedrockExecutor,
   bedrockAnthropicExecutor,
+  vertexAnthropicExecutor,
 ] as const;
 
 interface CaptureOptions {
@@ -263,9 +265,10 @@ async function main() {
   await captureProviderSnapshots(allCases, options);
 
   console.log(`\n--- Transform captures ---`);
+  const forceTransforms = options.force && !options.providers;
   const transformResult = await captureTransforms(
     options.filter,
-    options.force
+    forceTransforms
   );
 
   if (transformResult.captured > 0) {

--- a/payloads/scripts/providers/vertex-anthropic.ts
+++ b/payloads/scripts/providers/vertex-anthropic.ts
@@ -1,0 +1,499 @@
+import { readFileSync } from "fs";
+import { resolve, isAbsolute } from "path";
+import { createSign } from "crypto";
+import Anthropic from "@anthropic-ai/sdk";
+import { CaptureResult, ExecuteOptions, ProviderExecutor } from "../types";
+import {
+  allTestCases,
+  getCaseNames,
+  getCaseForProvider,
+  hasExpectation,
+  type AnthropicMessageCreateParams,
+} from "../../cases";
+
+const VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16";
+
+export const vertexAnthropicCases: Record<
+  string,
+  AnthropicMessageCreateParams
+> = {};
+
+getCaseNames(allTestCases).forEach((caseName) => {
+  if (hasExpectation(allTestCases, caseName)) {
+    return;
+  }
+  const caseData = getCaseForProvider(
+    allTestCases,
+    caseName,
+    "vertex-anthropic"
+  );
+  if (caseData) {
+    vertexAnthropicCases[caseName] = caseData;
+  }
+});
+
+interface ServiceAccountKey {
+  client_email: string;
+  private_key: string;
+  token_uri: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseAccessTokenResponse(value: unknown): {
+  access_token: string;
+  expires_in: number;
+} {
+  if (!isRecord(value)) {
+    throw new Error("Invalid access token response: expected object");
+  }
+  const accessToken = value.access_token;
+  const expiresIn = value.expires_in;
+  if (typeof accessToken !== "string") {
+    throw new Error(
+      "Invalid access token response: access_token must be string"
+    );
+  }
+  if (typeof expiresIn !== "number") {
+    throw new Error("Invalid access token response: expires_in must be number");
+  }
+  return { access_token: accessToken, expires_in: expiresIn };
+}
+
+function parseAnthropicMessageResponse(
+  value: unknown
+): Anthropic.Messages.Message {
+  if (!isRecord(value)) {
+    throw new Error("Invalid Anthropic response: expected object");
+  }
+  const id = value.id;
+  const type = value.type;
+  const role = value.role;
+  const model = value.model;
+  const content = value.content;
+  const stopReason = value.stop_reason;
+  const stopSequence = value.stop_sequence;
+  const usage = value.usage;
+
+  if (typeof id !== "string") {
+    throw new Error("Invalid Anthropic response: id must be string");
+  }
+  if (type !== "message") {
+    throw new Error("Invalid Anthropic response: type must be 'message'");
+  }
+  if (role !== "assistant") {
+    throw new Error("Invalid Anthropic response: role must be 'assistant'");
+  }
+  if (typeof model !== "string") {
+    throw new Error("Invalid Anthropic response: model must be string");
+  }
+  if (!Array.isArray(content)) {
+    throw new Error("Invalid Anthropic response: content must be array");
+  }
+  if (stopReason !== null && typeof stopReason !== "string") {
+    throw new Error(
+      "Invalid Anthropic response: stop_reason must be string or null"
+    );
+  }
+  if (stopSequence !== null && typeof stopSequence !== "string") {
+    throw new Error(
+      "Invalid Anthropic response: stop_sequence must be string or null"
+    );
+  }
+  if (!isRecord(usage)) {
+    throw new Error("Invalid Anthropic response: usage must be object");
+  }
+  const inputTokens = usage.input_tokens;
+  const outputTokens = usage.output_tokens;
+  if (typeof inputTokens !== "number") {
+    throw new Error(
+      "Invalid Anthropic response: usage.input_tokens must be number"
+    );
+  }
+  if (typeof outputTokens !== "number") {
+    throw new Error(
+      "Invalid Anthropic response: usage.output_tokens must be number"
+    );
+  }
+
+  if (!isAnthropicMessage(value)) {
+    throw new Error(
+      "Invalid Anthropic response: does not match Anthropic message type"
+    );
+  }
+  return value;
+}
+
+function isAnthropicMessage(
+  value: unknown
+): value is Anthropic.Messages.Message {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    typeof value.id === "string" &&
+    value.type === "message" &&
+    value.role === "assistant" &&
+    Array.isArray(value.content) &&
+    typeof value.model === "string" &&
+    (value.stop_reason === null || typeof value.stop_reason === "string") &&
+    (value.stop_sequence === null || typeof value.stop_sequence === "string") &&
+    isRecord(value.usage) &&
+    typeof value.usage.input_tokens === "number" &&
+    typeof value.usage.output_tokens === "number"
+  );
+}
+
+function loadServiceAccountKey(): ServiceAccountKey {
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!credPath) {
+    throw new Error(
+      "GOOGLE_APPLICATION_CREDENTIALS environment variable is required"
+    );
+  }
+  const resolvedPath = isAbsolute(credPath)
+    ? credPath
+    : resolve(process.cwd(), credPath);
+  const raw = readFileSync(resolvedPath, "utf-8");
+  return JSON.parse(raw);
+}
+
+function createSignedJwt(key: ServiceAccountKey): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT" })
+  ).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      iss: key.client_email,
+      sub: key.client_email,
+      aud: key.token_uri,
+      iat: now,
+      exp: now + 3600,
+      scope: "https://www.googleapis.com/auth/cloud-platform",
+    })
+  ).toString("base64url");
+
+  const signInput = `${header}.${payload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signInput);
+  const signature = signer.sign(key.private_key, "base64url");
+
+  return `${signInput}.${signature}`;
+}
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+async function getAccessToken(): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt - 60_000) {
+    return cachedToken.token;
+  }
+
+  const key = loadServiceAccountKey();
+  const jwt = createSignedJwt(key);
+
+  const response = await fetch(key.token_uri, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: jwt,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to get access token: ${response.status} ${text}`);
+  }
+
+  const json: unknown = await response.json();
+  const data = parseAccessTokenResponse(json);
+  cachedToken = {
+    token: data.access_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+  };
+  return cachedToken.token;
+}
+
+type VertexAnthropicBody = Omit<
+  AnthropicMessageCreateParams,
+  "model" | "stream"
+> & { anthropic_version: string };
+
+function buildVertexBody(payload: AnthropicMessageCreateParams): {
+  model: string;
+  body: string;
+  bodyObj: VertexAnthropicBody;
+} {
+  const { model, stream: _stream, ...rest } = payload;
+  const bodyObj: VertexAnthropicBody = {
+    anthropic_version: VERTEX_ANTHROPIC_VERSION,
+    ...rest,
+  };
+  return { model, body: JSON.stringify(bodyObj), bodyObj };
+}
+
+function buildUrl(model: string, stream: boolean): string {
+  const project = process.env.VERTEX_PROJECT;
+  if (!project) {
+    throw new Error("VERTEX_PROJECT environment variable is required");
+  }
+  const location = process.env.VERTEX_LOCATION ?? "us-east5";
+  const method = stream ? "streamRawPredict" : "rawPredict";
+  return `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/${model}:${method}`;
+}
+
+type ParallelResult =
+  | { type: "response"; data: Anthropic.Messages.Message }
+  | { type: "streamingResponse"; data: Array<unknown> };
+
+async function fetchVertex(
+  url: string,
+  body: string,
+  token: string
+): Promise<Response> {
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body,
+  });
+}
+
+function parseStreamChunks(text: string): unknown[] {
+  const chunks: unknown[] = [];
+  const lines = text.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Vertex streamRawPredict returns SSE format: "data: {...}"
+    if (trimmed.startsWith("data: ")) {
+      const data = trimmed.slice(6).trim();
+      if (data) {
+        chunks.push(JSON.parse(data));
+      }
+      continue;
+    }
+
+    // Also handle raw NDJSON (one JSON object per line)
+    if (trimmed.startsWith("{")) {
+      chunks.push(JSON.parse(trimmed));
+    }
+  }
+  return chunks;
+}
+
+export async function executeVertexAnthropic(
+  _caseName: string,
+  payload: AnthropicMessageCreateParams | VertexAnthropicBody,
+  options?: ExecuteOptions
+): Promise<
+  CaptureResult<
+    AnthropicMessageCreateParams | VertexAnthropicBody,
+    Anthropic.Messages.Message,
+    unknown
+  >
+> {
+  if (!("model" in payload)) {
+    throw new Error(
+      "vertex-anthropic executor expects input format, not wire format"
+    );
+  }
+  const { stream } = options ?? {};
+  const token = await getAccessToken();
+  const { model, body, bodyObj } = buildVertexBody(payload);
+  const result: CaptureResult<
+    AnthropicMessageCreateParams | VertexAnthropicBody,
+    Anthropic.Messages.Message,
+    unknown
+  > = { request: bodyObj };
+
+  try {
+    const promises: Promise<ParallelResult>[] = [];
+
+    if (stream !== true) {
+      const url = buildUrl(model, false);
+      promises.push(
+        fetchVertex(url, body, token).then(async (response) => {
+          if (!response.ok) {
+            const text = await response.text();
+            throw new Error(
+              `Vertex rawPredict failed: ${response.status} ${text}`
+            );
+          }
+          const json: unknown = await response.json();
+          const data = parseAnthropicMessageResponse(json);
+          return { type: "response", data };
+        })
+      );
+    }
+
+    if (stream !== false) {
+      const url = buildUrl(model, true);
+      promises.push(
+        fetchVertex(url, body, token).then(async (response) => {
+          if (!response.ok) {
+            const text = await response.text();
+            throw new Error(
+              `Vertex streamRawPredict failed: ${response.status} ${text}`
+            );
+          }
+          const text = await response.text();
+          const chunks = parseStreamChunks(text);
+          return { type: "streamingResponse", data: chunks };
+        })
+      );
+    }
+
+    const initialResults = await Promise.all(promises);
+
+    for (const result_ of initialResults) {
+      if (result_.type === "response") {
+        result.response = result_.data;
+      } else if (result_.type === "streamingResponse") {
+        result.streamingResponse = result_.data;
+      }
+    }
+
+    // Follow-up conversation
+    if (
+      result.response &&
+      typeof result.response === "object" &&
+      result.response !== null &&
+      "content" in result.response &&
+      Array.isArray(result.response.content)
+    ) {
+      const assistantMessage: Anthropic.MessageParam = {
+        role: "assistant",
+        content: result.response.content,
+      };
+
+      const followUpMessages: Anthropic.MessageParam[] = [
+        ...payload.messages,
+        assistantMessage,
+      ];
+
+      const assistantContent = Array.isArray(assistantMessage.content)
+        ? assistantMessage.content
+        : [assistantMessage.content];
+
+      let hasToolCalls = false;
+      for (const contentBlock of assistantContent) {
+        if (
+          typeof contentBlock === "object" &&
+          contentBlock !== null &&
+          "type" in contentBlock &&
+          contentBlock.type === "tool_use" &&
+          "id" in contentBlock &&
+          typeof contentBlock.id === "string"
+        ) {
+          hasToolCalls = true;
+          followUpMessages.push({
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: contentBlock.id,
+                content: "71 degrees",
+              },
+            ],
+          });
+        }
+      }
+
+      if (!hasToolCalls) {
+        followUpMessages.push({
+          role: "user",
+          content: "What should I do next?",
+        });
+      }
+
+      const followUpPayload: AnthropicMessageCreateParams = {
+        ...payload,
+        messages: followUpMessages,
+      };
+
+      const {
+        model: followupModel,
+        body: followupBody,
+        bodyObj: followupBodyObj,
+      } = buildVertexBody(followUpPayload);
+      result.followupRequest = followupBodyObj;
+
+      type FollowupResult =
+        | { type: "followupResponse"; data: Anthropic.Messages.Message }
+        | { type: "followupStreamingResponse"; data: Array<unknown> };
+
+      const followupPromises: Promise<FollowupResult>[] = [];
+
+      if (stream !== true) {
+        const url = buildUrl(followupModel, false);
+        followupPromises.push(
+          fetchVertex(url, followupBody, token).then(async (response) => {
+            if (!response.ok) {
+              const text = await response.text();
+              throw new Error(
+                `Vertex followup rawPredict failed: ${response.status} ${text}`
+              );
+            }
+            const json: unknown = await response.json();
+            const data = parseAnthropicMessageResponse(json);
+            return {
+              type: "followupResponse",
+              data,
+            };
+          })
+        );
+      }
+
+      if (stream !== false) {
+        const url = buildUrl(followupModel, true);
+        followupPromises.push(
+          fetchVertex(url, followupBody, token).then(async (response) => {
+            if (!response.ok) {
+              const text = await response.text();
+              throw new Error(
+                `Vertex followup streamRawPredict failed: ${response.status} ${text}`
+              );
+            }
+            const text = await response.text();
+            const chunks = parseStreamChunks(text);
+            return { type: "followupStreamingResponse", data: chunks };
+          })
+        );
+      }
+
+      if (followupPromises.length > 0) {
+        const followupResults = await Promise.all(followupPromises);
+
+        for (const result_ of followupResults) {
+          if (result_.type === "followupResponse") {
+            result.followupResponse = result_.data;
+          } else if (result_.type === "followupStreamingResponse") {
+            result.followupStreamingResponse = result_.data;
+          }
+        }
+      }
+    }
+  } catch (error) {
+    result.error = String(error);
+  }
+
+  return result;
+}
+
+export const vertexAnthropicExecutor: ProviderExecutor<
+  AnthropicMessageCreateParams | VertexAnthropicBody,
+  Anthropic.Messages.Message,
+  unknown
+> = {
+  name: "vertex-anthropic",
+  cases: vertexAnthropicCases,
+  execute: executeVertexAnthropic,
+  ignoredFields: ["id", "content.*.text", "usage"],
+};

--- a/payloads/snapshots/reasoningRequest/vertex-anthropic/followup-request.json
+++ b/payloads/snapshots/reasoningRequest/vertex-anthropic/followup-request.json
@@ -1,0 +1,23 @@
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 20000,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Solve this step by step: If a train travels 60 mph for 2 hours, then 80 mph for 1 hour, what's the average speed?"
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "# Average Speed Calculation\n\n## Step 1: Find the distance for each segment\n\n**First segment:**\n- Speed = 60 mph, Time = 2 hours\n- Distance = Speed × Time = 60 × 2 = **120 miles**\n\n**Second segment:**\n- Speed = 80 mph, Time = 1 hour\n- Distance = Speed × Time = 80 × 1 = **80 miles**\n\n## Step 2: Find total distance and total time\n\n- **Total distance** = 120 + 80 = **200 miles**\n- **Total time** = 2 + 1 = **3 hours**\n\n## Step 3: Calculate average speed\n\n$$\\text{Average Speed} = \\frac{\\text{Total Distance}}{\\text{Total Time}} = \\frac{200 \\text{ miles}}{3 \\text{ hours}} = 66.\\overline{6} \\text{ mph}$$\n\n## Answer\nThe average speed is **66⅔ mph** (or approximately **66.67 mph**)"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ]
+}

--- a/payloads/snapshots/reasoningRequest/vertex-anthropic/followup-response-streaming.json
+++ b/payloads/snapshots/reasoningRequest/vertex-anthropic/followup-response-streaming.json
@@ -1,0 +1,26 @@
+[
+  {
+    "model": "claude-haiku-4-5-20251001",
+    "id": "msg_vrtx_01WN6pdECork6W4tBACCMVcH",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "That depends on what you'd like to do! Here are some options:\n\n1. **Practice similar problems** - Try calculating average speed with different distances, speeds, and times\n\n2. **Learn related concepts** - Explore other motion problems like:\n   - Relative speed\n   - Time to catch up\n   - Distance, speed, and time relationships\n\n3. **Check your understanding** - I can give you a new practice problem to solve on your own\n\n4. **Move to a different topic** - Work on something completely different\n\n5. **Ask follow-up questions** - If something about this problem wasn't clear, I'm happy to explain further\n\n**What interests you most?** Or did you have a specific next step in mind?"
+      }
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 303,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 161
+    }
+  }
+]

--- a/payloads/snapshots/reasoningRequest/vertex-anthropic/followup-response.json
+++ b/payloads/snapshots/reasoningRequest/vertex-anthropic/followup-response.json
@@ -1,0 +1,24 @@
+{
+  "model": "claude-haiku-4-5-20251001",
+  "id": "msg_vrtx_017fxTDZDp4mMaowja8agXYe",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "That depends on what you'd like to do! Here are some options:\n\n1. **Practice similar problems** - Try calculating average speed with different distances, speeds, or time periods\n\n2. **Learn related concepts** - Explore topics like:\n   - Average velocity (including direction)\n   - Acceleration\n   - Distance-time graphs\n\n3. **Solve a different problem** - Ask me another math, science, or homework question\n\n4. **Go deeper into this problem** - For example:\n   - What if the train continued at a different speed?\n   - How would you find the time needed to travel a certain distance at this average speed?\n\n5. **Move on to something else entirely** - I'm happy to help with whatever you need\n\n**What sounds most helpful to you?** Let me know and I'll guide you through it!"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 303,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 185
+  }
+}

--- a/payloads/snapshots/reasoningRequest/vertex-anthropic/request.json
+++ b/payloads/snapshots/reasoningRequest/vertex-anthropic/request.json
@@ -1,0 +1,10 @@
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 20000,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Solve this step by step: If a train travels 60 mph for 2 hours, then 80 mph for 1 hour, what's the average speed?"
+    }
+  ]
+}

--- a/payloads/snapshots/reasoningRequest/vertex-anthropic/response-streaming.json
+++ b/payloads/snapshots/reasoningRequest/vertex-anthropic/response-streaming.json
@@ -1,0 +1,26 @@
+[
+  {
+    "model": "claude-haiku-4-5-20251001",
+    "id": "msg_vrtx_01EmvpNySLbNL5cRudxQ3pRJ",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "# Average Speed Problem\n\n**Step 1: Find the distance for each segment**\n\n- First segment: 60 mph × 2 hours = **120 miles**\n- Second segment: 80 mph × 1 hour = **80 miles**\n\n**Step 2: Find the total distance**\n\n120 + 80 = **200 miles**\n\n**Step 3: Find the total time**\n\n2 + 1 = **3 hours**\n\n**Step 4: Calculate average speed**\n\nAverage speed = Total distance ÷ Total time\n\nAverage speed = 200 ÷ 3 = **66.67 mph** (or 66⅔ mph)\n\n---\n\n**Key point:** Average speed is not the average of the speeds (60 + 80) ÷ 2. You must use total distance and total time."
+      }
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 45,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 201
+    }
+  }
+]

--- a/payloads/snapshots/reasoningRequest/vertex-anthropic/response.json
+++ b/payloads/snapshots/reasoningRequest/vertex-anthropic/response.json
@@ -1,0 +1,24 @@
+{
+  "model": "claude-haiku-4-5-20251001",
+  "id": "msg_vrtx_01LTp5dYLp7zkiETB1hAH8eN",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "# Average Speed Calculation\n\n## Step 1: Find the distance for each segment\n\n**First segment:**\n- Speed = 60 mph, Time = 2 hours\n- Distance = Speed × Time = 60 × 2 = **120 miles**\n\n**Second segment:**\n- Speed = 80 mph, Time = 1 hour\n- Distance = Speed × Time = 80 × 1 = **80 miles**\n\n## Step 2: Find total distance and total time\n\n- **Total distance** = 120 + 80 = **200 miles**\n- **Total time** = 2 + 1 = **3 hours**\n\n## Step 3: Calculate average speed\n\n$$\\text{Average Speed} = \\frac{\\text{Total Distance}}{\\text{Total Time}} = \\frac{200 \\text{ miles}}{3 \\text{ hours}} = 66.\\overline{6} \\text{ mph}$$\n\n## Answer\nThe average speed is **66⅔ mph** (or approximately **66.67 mph**)"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 45,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 249
+  }
+}

--- a/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/followup-request.json
+++ b/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/followup-request.json
@@ -1,0 +1,23 @@
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 100,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Solve this step by step: If a train travels 60 mph for 2 hours, then 80 mph for 1 hour, what's the average speed?"
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "# Average Speed Calculation\n\n## Step 1: Find the distance for each segment\n\n**First segment:**\n- Speed × Time = Distance\n- 60 mph × 2 hours = **120 miles**\n\n**Second segment:**\n- 80 mph × 1 hour = **80 miles**\n\n## Step 2: Find total distance\n120 + 80 = **200 miles**\n\n## Step 3: Find total time"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ]
+}

--- a/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/followup-response-streaming.json
+++ b/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/followup-response-streaming.json
@@ -1,0 +1,26 @@
+[
+  {
+    "model": "claude-haiku-4-5-20251001",
+    "id": "msg_vrtx_01CDH58qpW9i8szGhPFWM9F7",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "# Step 4: Calculate Average Speed\n\n**Average Speed = Total Distance ÷ Total Time**\n\nAverage Speed = 200 miles ÷ 3 hours\n\n**Average Speed = 66.67 mph** (or 66⅔ mph)\n\n---\n\n**Key takeaway:** Average speed is NOT the average of the two speeds (60 + 80 ÷ 2 = 70). You must use total"
+      }
+    ],
+    "stop_reason": "max_tokens",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 156,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 100
+    }
+  }
+]

--- a/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/followup-response.json
+++ b/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/followup-response.json
@@ -1,0 +1,24 @@
+{
+  "model": "claude-haiku-4-5-20251001",
+  "id": "msg_vrtx_0175F1JgAEJ65teMgfWw47ma",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "# Step 4: Calculate Average Speed\n\nUse this formula:\n\n**Average Speed = Total Distance ÷ Total Time**\n\nAverage Speed = 200 miles ÷ 3 hours = **66.67 mph**\n\n(or approximately **66.7 mph** or **66⅔ mph**)"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 156,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 75
+  }
+}

--- a/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/request.json
+++ b/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/request.json
@@ -1,0 +1,10 @@
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 100,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Solve this step by step: If a train travels 60 mph for 2 hours, then 80 mph for 1 hour, what's the average speed?"
+    }
+  ]
+}

--- a/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/response-streaming.json
+++ b/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/response-streaming.json
@@ -1,0 +1,26 @@
+[
+  {
+    "model": "claude-haiku-4-5-20251001",
+    "id": "msg_vrtx_01GN7hfZDZeSSoxA6irnD2pH",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "# Average Speed Calculation\n\n## Step 1: Find the distance for each segment\n\n**First segment:**\n- Speed = 60 mph, Time = 2 hours\n- Distance = Speed × Time = 60 × 2 = **120 miles**\n\n**Second segment:**\n- Speed = 80 mph, Time = 1 hour\n- Distance = Speed × Time = 80 × 1 = **80 miles**"
+      }
+    ],
+    "stop_reason": "max_tokens",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 45,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 100
+    }
+  }
+]

--- a/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/response.json
+++ b/payloads/snapshots/reasoningRequestTruncated/vertex-anthropic/response.json
@@ -1,0 +1,24 @@
+{
+  "model": "claude-haiku-4-5-20251001",
+  "id": "msg_vrtx_0183U13P4zFBxirMfQ5HXikZ",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "# Average Speed Calculation\n\n## Step 1: Find the distance for each segment\n\n**First segment:**\n- Speed × Time = Distance\n- 60 mph × 2 hours = **120 miles**\n\n**Second segment:**\n- 80 mph × 1 hour = **80 miles**\n\n## Step 2: Find total distance\n120 + 80 = **200 miles**\n\n## Step 3: Find total time"
+    }
+  ],
+  "stop_reason": "max_tokens",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 45,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 100
+  }
+}

--- a/payloads/snapshots/simpleRequest/vertex-anthropic/followup-request.json
+++ b/payloads/snapshots/simpleRequest/vertex-anthropic/followup-request.json
@@ -1,0 +1,23 @@
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 20000,
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the capital of France?"
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "The capital of France is Paris."
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ]
+}

--- a/payloads/snapshots/simpleRequest/vertex-anthropic/followup-response-streaming.json
+++ b/payloads/snapshots/simpleRequest/vertex-anthropic/followup-response-streaming.json
@@ -1,0 +1,26 @@
+[
+  {
+    "model": "claude-haiku-4-5-20251001",
+    "id": "msg_vrtx_01CKMoCx7wQ3bvrwHJZv7oSh",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "That depends on what you're interested in! Here are some common options:\n\n- **Learn more** about Paris or France\n- **Ask another question** on a different topic\n- **Get recommendations** for things to do, places to visit, or books to read\n- **Work on a project** - I can help with writing, coding, analysis, or brainstorming\n- **Have a conversation** about topics you're curious about\n\nWhat sounds most useful to you right now?"
+      }
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 33,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 105
+    }
+  }
+]

--- a/payloads/snapshots/simpleRequest/vertex-anthropic/followup-response.json
+++ b/payloads/snapshots/simpleRequest/vertex-anthropic/followup-response.json
@@ -1,0 +1,24 @@
+{
+  "model": "claude-haiku-4-5-20251001",
+  "id": "msg_vrtx_012gc71DkWppqojhsdaPDYF5",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "That depends on what you're interested in! Here are some common options:\n\n- **Learn more** - Ask questions about Paris, France, or another topic\n- **Plan a trip** - Get travel advice or recommendations\n- **Continue a conversation** - Tell me what you'd like to discuss\n- **Get help with a task** - Ask me to help with writing, coding, research, etc.\n- **Explore something new** - Let me know what interests you\n\nWhat would you like to do?"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 33,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 110
+  }
+}

--- a/payloads/snapshots/simpleRequest/vertex-anthropic/request.json
+++ b/payloads/snapshots/simpleRequest/vertex-anthropic/request.json
@@ -1,0 +1,10 @@
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 20000,
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the capital of France?"
+    }
+  ]
+}

--- a/payloads/snapshots/simpleRequest/vertex-anthropic/response-streaming.json
+++ b/payloads/snapshots/simpleRequest/vertex-anthropic/response-streaming.json
@@ -1,0 +1,26 @@
+[
+  {
+    "model": "claude-haiku-4-5-20251001",
+    "id": "msg_vrtx_01EwoD71dnCkV2RMh2rFNF6E",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "The capital of France is Paris."
+      }
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 14,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 10
+    }
+  }
+]

--- a/payloads/snapshots/simpleRequest/vertex-anthropic/response.json
+++ b/payloads/snapshots/simpleRequest/vertex-anthropic/response.json
@@ -1,0 +1,24 @@
+{
+  "model": "claude-haiku-4-5-20251001",
+  "id": "msg_vrtx_01VjM4i2MPjbHmBPS6bYFSUC",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "The capital of France is Paris."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 14,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 10
+  }
+}

--- a/payloads/snapshots/toolCallRequest/vertex-anthropic/followup-request.json
+++ b/payloads/snapshots/toolCallRequest/vertex-anthropic/followup-request.json
@@ -1,0 +1,54 @@
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 20000,
+  "messages": [
+    {
+      "role": "user",
+      "content": "What's the weather like in San Francisco?"
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_vrtx_01WNHSheHN2A8s9Accy2nybc",
+          "name": "get_weather",
+          "input": {
+            "location": "San Francisco, CA"
+          }
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_vrtx_01WNHSheHN2A8s9Accy2nybc",
+          "content": "71 degrees"
+        }
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Get the current weather for a location",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+          }
+        },
+        "required": [
+          "location"
+        ]
+      }
+    }
+  ],
+  "tool_choice": {
+    "type": "auto"
+  }
+}

--- a/payloads/snapshots/toolCallRequest/vertex-anthropic/followup-response-streaming.json
+++ b/payloads/snapshots/toolCallRequest/vertex-anthropic/followup-response-streaming.json
@@ -1,0 +1,26 @@
+[
+  {
+    "model": "claude-haiku-4-5-20251001",
+    "id": "msg_vrtx_01H35HXt9C627DZie4bjW1ee",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "The weather in San Francisco is currently **71 degrees** Fahrenheit. It's a pleasant temperature - mild and comfortable!"
+      }
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 657,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 29
+    }
+  }
+]

--- a/payloads/snapshots/toolCallRequest/vertex-anthropic/followup-response.json
+++ b/payloads/snapshots/toolCallRequest/vertex-anthropic/followup-response.json
@@ -1,0 +1,24 @@
+{
+  "model": "claude-haiku-4-5-20251001",
+  "id": "msg_vrtx_01G31qcgQXLY9STntzSRpbMf",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "The weather in San Francisco is currently **71 degrees**. It's a pleasant, mild temperature typical for San Francisco!"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 657,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 28
+  }
+}

--- a/payloads/snapshots/toolCallRequest/vertex-anthropic/request.json
+++ b/payloads/snapshots/toolCallRequest/vertex-anthropic/request.json
@@ -1,0 +1,31 @@
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 20000,
+  "messages": [
+    {
+      "role": "user",
+      "content": "What's the weather like in San Francisco?"
+    }
+  ],
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Get the current weather for a location",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+          }
+        },
+        "required": [
+          "location"
+        ]
+      }
+    }
+  ],
+  "tool_choice": {
+    "type": "auto"
+  }
+}

--- a/payloads/snapshots/toolCallRequest/vertex-anthropic/response-streaming.json
+++ b/payloads/snapshots/toolCallRequest/vertex-anthropic/response-streaming.json
@@ -1,0 +1,30 @@
+[
+  {
+    "model": "claude-haiku-4-5-20251001",
+    "id": "msg_vrtx_01Cdn7SH1phDwqn9PHT528Dw",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "toolu_vrtx_01LEsBMoH8UBoz8Vm2XVcQU2",
+        "name": "get_weather",
+        "input": {
+          "location": "San Francisco, CA"
+        }
+      }
+    ],
+    "stop_reason": "tool_use",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 585,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 57
+    }
+  }
+]

--- a/payloads/snapshots/toolCallRequest/vertex-anthropic/response.json
+++ b/payloads/snapshots/toolCallRequest/vertex-anthropic/response.json
@@ -1,0 +1,28 @@
+{
+  "model": "claude-haiku-4-5-20251001",
+  "id": "msg_vrtx_01PrQRSambp8M1vTb2v2f9TP",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "tool_use",
+      "id": "toolu_vrtx_01WNHSheHN2A8s9Accy2nybc",
+      "name": "get_weather",
+      "input": {
+        "location": "San Francisco, CA"
+      }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 585,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 57
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the ad-hoc `inject_anthropic_version()` function in the Vertex provider with a proper `VertexAnthropicAdapter` in the lingua transformation layer, matching how `BedrockAnthropic` is handled
- Adds `ProviderFormat::VertexAnthropic` enum variant and registers the new adapter so the resolver maps `publishers/anthropic/` models to the correct format
- Removes `inject_anthropic_version()` and its unit tests from the Vertex provider, since body manipulation is now handled by the adapter

## Test plan

- [x] `cargo test -p lingua -p braintrust-llm-router` -- all unit tests pass
- [x] `cargo build` (gateway) -- compiles cleanly
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- no warnings
- [ ] Restart gateway, run integration tests: `GATEWAY_URL=http://127.0.0.1:9090 pytest -xvs integration_tests/test_vertex_chat_completions_openai.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)