### PR TITLE
Fix reasoning effort loss in cross-provider thinking conversion

### DIFF
--- a/crates/lingua/src/providers/bedrock/adapter.rs
+++ b/crates/lingua/src/providers/bedrock/adapter.rs
@@ -80,7 +80,7 @@ impl ProviderAdapter for BedrockAdapter {
             .as_ref()
             .and_then(|fields| fields.get("thinking"))
             .and_then(|v| serde_json::from_value::<Thinking>(v.clone()).ok())
-            .map(|t| ReasoningConfig::from(&t));
+            .map(|t| ReasoningConfig::from((&t, max_tokens)));
 
         let mut params = UniversalParams {
             temperature,

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -1037,6 +1037,29 @@ export const paramsCases: TestCaseCollection = {
     bedrock: null,
   },
 
+  // Anthropic thinking enabled with budget_tokens - exercises budget→effort conversion
+  // with small max_tokens (1024). budget/max_tokens = 100% → high effort.
+  thinkingEnabledParam: {
+    "chat-completions": {
+      model: OPENAI_RESPONSES_MODEL,
+      messages: [{ role: "user", content: "Think hard about 2+2" }],
+      reasoning_effort: "high",
+    },
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [{ role: "user", content: "Think hard about 2+2" }],
+      reasoning: { effort: "high" },
+    },
+    anthropic: {
+      model: ANTHROPIC_MODEL,
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "Think hard about 2+2" }],
+      thinking: { type: "enabled", budget_tokens: 1024 },
+    },
+    google: null,
+    bedrock: null,
+  },
+
   // === Output Config (structured output) ===
 
   outputFormatJsonSchemaParam: {

--- a/payloads/snapshots/thinkingEnabledParam/anthropic/request.json
+++ b/payloads/snapshots/thinkingEnabledParam/anthropic/request.json
@@ -1,0 +1,14 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "max_tokens": 1024,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Think hard about 2+2"
+    }
+  ],
+  "thinking": {
+    "type": "enabled",
+    "budget_tokens": 1024
+  }
+}

--- a/payloads/snapshots/thinkingEnabledParam/chat-completions/request.json
+++ b/payloads/snapshots/thinkingEnabledParam/chat-completions/request.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Think hard about 2+2"
+    }
+  ],
+  "reasoning_effort": "high"
+}

--- a/payloads/snapshots/thinkingEnabledParam/responses/request.json
+++ b/payloads/snapshots/thinkingEnabledParam/responses/request.json
@@ -1,0 +1,12 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": "Think hard about 2+2"
+    }
+  ],
+  "reasoning": {
+    "effort": "high"
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed incorrect reasoning effort levels when converting Anthropic/Bedrock `thinking.budget_tokens` to universal format. The `budget_to_effort` heuristic was using `DEFAULT_MAX_TOKENS` (4096) instead of the actual request `max_tokens`, causing effort "high" or "medium" to become "low" when max_tokens was small.
- Added `From<(&Thinking, Option<i64>)>` impl that accepts max_tokens context, updated both Anthropic and Bedrock adapters.
- Added `thinkingEnabledParam` test case to payload snapshots and cross-provider test to reproduce the bug.

## Test plan
- [x] Unit test reproducing the bug: `test_anthropic_thinking_to_openai_effort_with_small_max_tokens`
- [x] New `From` impl unit test: `test_from_anthropic_thinking_without_max_tokens_uses_default`
- [x] All 554 lib tests pass
- [x] Cross-provider coverage test passes with new `thinkingEnabledParam` case
- [x] Snapshot payloads added for chat-completions, responses, and anthropic

🤖 Generated with [Claude Code](https://claude.com/claude-code)