### PR TITLE
llm-router: let caller decide model provider

### DIFF
--- a/crates/braintrust-llm-router/README.md
+++ b/crates/braintrust-llm-router/README.md
@@ -115,9 +115,10 @@ Two entry points:
 // handle() - auto-extracts model from body, detects streaming
 let result = router.handle(body, ProviderFormat::ChatCompletions, None).await?;
 
-// complete() / complete_stream() - explicit model parameter
-let bytes = router.complete(body, "gpt-4", ProviderFormat::ChatCompletions, None).await?;
-let stream = router.complete_stream(body, "gpt-4", ProviderFormat::ChatCompletions, None).await?;
+// complete() / complete_stream() - explicit model + default provider alias
+let provider = router.default_provider_for_model("gpt-4")?;
+let bytes = router.complete(body, "gpt-4", provider, ProviderFormat::ChatCompletions, &ClientHeaders::default()).await?;
+let stream = router.complete_stream(body, "gpt-4", provider, ProviderFormat::ChatCompletions, &ClientHeaders::default()).await?;
 ```
 
 ### Authentication

--- a/crates/braintrust-llm-router/examples/custom_auth.rs
+++ b/crates/braintrust-llm-router/examples/custom_auth.rs
@@ -136,6 +136,7 @@ async fn main() -> Result<()> {
         .complete(
             body,
             model,
+            None,
             ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )

--- a/crates/braintrust-llm-router/examples/multi_provider.rs
+++ b/crates/braintrust-llm-router/examples/multi_provider.rs
@@ -72,6 +72,8 @@ async fn main() -> Result<()> {
     if openai_key.is_some() {
         println!("📍 Sending request to GPT-4...");
         let model = "gpt-4";
+        let provider = router.default_provider_for_model(model)?;
+        println!("   Selected provider: {provider}");
         let payload = json!({
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
@@ -83,6 +85,7 @@ async fn main() -> Result<()> {
             .complete(
                 body,
                 model,
+                Some(provider.as_str()),
                 ProviderFormat::ChatCompletions,
                 &ClientHeaders::default(),
             )
@@ -103,6 +106,8 @@ async fn main() -> Result<()> {
     if anthropic_key.is_some() {
         println!("📍 Sending request to Claude...");
         let model = "claude-3-5-haiku-20241022";
+        let provider = router.default_provider_for_model(model)?;
+        println!("   Selected provider: {provider}");
         let payload = json!({
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
@@ -114,6 +119,7 @@ async fn main() -> Result<()> {
             .complete(
                 body,
                 model,
+                Some(provider.as_str()),
                 ProviderFormat::ChatCompletions,
                 &ClientHeaders::default(),
             )

--- a/crates/braintrust-llm-router/examples/simple.rs
+++ b/crates/braintrust-llm-router/examples/simple.rs
@@ -61,6 +61,7 @@ async fn main() -> Result<()> {
         .complete(
             body,
             model,
+            None,
             ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )

--- a/crates/braintrust-llm-router/examples/streaming.rs
+++ b/crates/braintrust-llm-router/examples/streaming.rs
@@ -63,6 +63,7 @@ async fn main() -> Result<()> {
         .complete_stream(
             body,
             model,
+            None,
             ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )
@@ -142,6 +143,7 @@ async fn main() -> Result<()> {
             .complete_stream(
                 body,
                 model,
+                None,
                 ProviderFormat::ChatCompletions,
                 &ClientHeaders::default(),
             )


### PR DESCRIPTION
This is a first step so that we can move model routing choices into the caller,
since it may have more knowledge about user preferences and how exactly to
choose the "right" provider. The crate now exposes all the providers for a
given model/format.