### PR TITLE
llm-router: force Responses API upstream for pro/codex chat requests

### DIFF
--- a/crates/braintrust-llm-router/src/catalog/spec.rs
+++ b/crates/braintrust-llm-router/src/catalog/spec.rs
@@ -49,3 +49,73 @@ pub struct ModelSpec {
 fn default_true() -> bool {
     true
 }
+
+pub fn model_requires_responses_api(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    lower.starts_with("o1-pro")
+        || lower.starts_with("o3-pro")
+        || lower.starts_with("gpt-5-pro")
+        || (lower.starts_with("gpt-5") && lower.contains("-codex"))
+}
+
+impl ModelSpec {
+    pub fn requires_responses_api(&self) -> bool {
+        self.flavor == ModelFlavor::Responses || model_requires_responses_api(&self.model)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_requires_responses_api_detects_required_families() {
+        let required = [
+            "o1-pro",
+            "o3-pro",
+            "gpt-5-pro",
+            "gpt-5-pro-2025-10-06",
+            "gpt-5-codex",
+            "gpt-5.1-codex",
+            "gpt-5.1-codex-mini",
+        ];
+        for model in required {
+            assert!(
+                model_requires_responses_api(model),
+                "expected Responses-required model: {model}"
+            );
+        }
+    }
+
+    #[test]
+    fn model_requires_responses_api_rejects_non_required_families() {
+        let not_required = ["gpt-5-mini", "gpt-5", "gpt-4o", "claude-sonnet-4"];
+        for model in not_required {
+            assert!(
+                !model_requires_responses_api(model),
+                "expected non-Responses model: {model}"
+            );
+        }
+    }
+
+    #[test]
+    fn model_spec_requires_responses_api_allows_flavor_override() {
+        let spec = ModelSpec {
+            model: "custom-model".to_string(),
+            format: ProviderFormat::ChatCompletions,
+            flavor: ModelFlavor::Responses,
+            display_name: None,
+            parent: None,
+            input_cost_per_mil_tokens: None,
+            output_cost_per_mil_tokens: None,
+            input_cache_read_cost_per_mil_tokens: None,
+            multimodal: None,
+            reasoning: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            supports_streaming: true,
+            extra: serde_json::Map::new(),
+        };
+        assert!(spec.requires_responses_api());
+    }
+}

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -262,19 +262,16 @@ impl Router {
             Error::NoProvider(catalog_format)
         })?;
         let provider_formats = provider.provider_formats();
-        let mut format =
-            if output_format != catalog_format && provider_formats.contains(&output_format) {
-                output_format
-            } else {
-                catalog_format
-            };
-        if output_format == ProviderFormat::ChatCompletions
-            && format == ProviderFormat::ChatCompletions
+        let format = if output_format == ProviderFormat::ChatCompletions
             && provider_formats.contains(&ProviderFormat::Responses)
             && spec.requires_responses_api()
         {
-            format = ProviderFormat::Responses;
-        }
+            ProviderFormat::Responses
+        } else if output_format != catalog_format && provider_formats.contains(&output_format) {
+            output_format
+        } else {
+            catalog_format
+        };
         let auth = self
             .auth_configs
             .get(&alias)


### PR DESCRIPTION
### Summary

- Force Responses API upstream routing for models that are Responses-only (`o1-pro*`, `o3-pro*`, `gpt-5-pro*`, `gpt-5*-codex`) when callers request Chat Completions output.
- Preserve client-facing output format as Chat Completions.

### What changed

- Added shared detection helpers in `lingua/crates/braintrust-llm-router/src/catalog/spec.rs`:
  - `model_requires_responses_api(model: &str)`
  - `ModelSpec::requires_responses_api()`
  - Supports explicit `ModelFlavor::Responses` override.
- Updated `resolve_provider()` in `lingua/crates/braintrust-llm-router/src/router.rs`:
  - If requested output is `ProviderFormat::ChatCompletions`,
  - and provider supports `ProviderFormat::Responses`,
  - and model requires Responses,
  - then upstream provider format is forced to `ProviderFormat::Responses`.
- Added regression tests in `router.rs` for:
  - `gpt-5-pro` -> forced Responses
  - `gpt-5.1-codex` -> forced Responses
  - `gpt-5-mini` -> remains Chat Completions
  - provider without Responses support -> remains Chat Completions
- Added unit tests in `spec.rs` for detector behavior and `ModelFlavor::Responses` override.

### Why

- OpenAI returns `This model is only supported in v1/responses and not in v1/chat/completions` for these model families.
- Legacy proxy already had model-based translation; this brings Rust gateway routing behavior to parity.

### Validation

- Ran targeted tests: `cargo test router::tests` in `lingua/crates/braintrust-llm-router`
- All targeted router tests passed.