### PR TITLE
Improve import logic for different output shapes

### DIFF
--- a/crates/lingua/src/import_parse.rs
+++ b/crates/lingua/src/import_parse.rs
@@ -1,0 +1,63 @@
+use crate::serde_json::{self, Value};
+use crate::universal::convert::TryFromLLM;
+use crate::universal::Message;
+use serde::de::DeserializeOwned;
+
+pub(crate) type MessageParser = fn(&Value) -> Option<Vec<Message>>;
+
+pub(crate) fn try_parsers_in_order(
+    data: &Value,
+    parsers: &[MessageParser],
+) -> Option<Vec<Message>> {
+    for parser in parsers {
+        if let Some(messages) = parser(data) {
+            if !messages.is_empty() {
+                return Some(messages);
+            }
+        }
+    }
+    None
+}
+
+pub(crate) fn non_empty_messages(messages: Vec<Message>) -> Option<Vec<Message>> {
+    if messages.is_empty() {
+        None
+    } else {
+        Some(messages)
+    }
+}
+
+pub(crate) fn try_parse<T>(data: &Value) -> Option<T>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_value::<T>(data.clone()).ok()
+}
+
+pub(crate) fn try_convert_non_empty<T>(value: T) -> Option<Vec<Message>>
+where
+    Vec<Message>: TryFromLLM<T>,
+{
+    let messages = <Vec<Message> as TryFromLLM<T>>::try_from(value).ok()?;
+    non_empty_messages(messages)
+}
+
+pub(crate) fn try_parse_and_convert<T>(data: &Value) -> Option<Vec<Message>>
+where
+    T: DeserializeOwned,
+    Vec<Message>: TryFromLLM<T>,
+{
+    let value = try_parse::<T>(data)?;
+    try_convert_non_empty(value)
+}
+
+pub(crate) fn try_parse_vec_or_single<T>(data: &Value) -> Option<Vec<T>>
+where
+    T: DeserializeOwned,
+{
+    match data {
+        Value::Array(_) => try_parse::<Vec<T>>(data),
+        Value::Object(_) => try_parse::<T>(data).map(|item| vec![item]),
+        _ => None,
+    }
+}

--- a/crates/lingua/src/lib.rs
+++ b/crates/lingua/src/lib.rs
@@ -9,6 +9,7 @@ pub use bytes::Bytes;
 pub mod capabilities;
 pub mod error;
 mod extraction;
+mod import_parse;
 pub mod processing;
 pub mod providers;
 pub mod universal;

--- a/crates/lingua/src/processing/import.rs
+++ b/crates/lingua/src/processing/import.rs
@@ -1,8 +1,13 @@
 use crate::import_parse::{try_parsers_in_order, MessageParser};
+#[cfg(feature = "anthropic")]
 use crate::providers::anthropic::convert::try_parse_anthropic_for_import;
+#[cfg(feature = "anthropic")]
 use crate::providers::anthropic::generated as anthropic;
+#[cfg(feature = "bedrock")]
 use crate::providers::bedrock::convert::try_parse_bedrock_for_import;
+#[cfg(feature = "google")]
 use crate::providers::google::convert::try_parse_google_for_import;
+#[cfg(feature = "openai")]
 use crate::providers::openai::convert::{
     try_parse_openai_for_import, ChatCompletionRequestMessageExt,
 };
@@ -89,24 +94,29 @@ fn try_converting_to_messages(data: &Value) -> Vec<Message> {
 
     // Try Chat Completions format (most common)
     // Use extended type to capture reasoning field from vLLM/OpenRouter convention
-    if let Ok(provider_messages) =
-        serde_json::from_value::<Vec<ChatCompletionRequestMessageExt>>(data_to_parse.clone())
+    #[cfg(feature = "openai")]
     {
-        if let Ok(messages) =
-            <Vec<Message> as TryFromLLM<Vec<ChatCompletionRequestMessageExt>>>::try_from(
-                provider_messages,
-            )
+        if let Ok(provider_messages) =
+            serde_json::from_value::<Vec<ChatCompletionRequestMessageExt>>(data_to_parse.clone())
         {
-            if !messages.is_empty() {
-                return messages;
+            if let Ok(messages) = <Vec<Message> as TryFromLLM<
+                Vec<ChatCompletionRequestMessageExt>,
+            >>::try_from(provider_messages)
+            {
+                if !messages.is_empty() {
+                    return messages;
+                }
             }
         }
     }
 
     // Try Anthropic format (including role-based system/developer messages).
-    if let Some(anthropic_messages) = try_anthropic_or_system_messages(data_to_parse) {
-        if !anthropic_messages.is_empty() {
-            return anthropic_messages;
+    #[cfg(feature = "anthropic")]
+    {
+        if let Some(anthropic_messages) = try_anthropic_or_system_messages(data_to_parse) {
+            if !anthropic_messages.is_empty() {
+                return anthropic_messages;
+            }
         }
     }
 
@@ -129,15 +139,21 @@ fn try_converting_to_messages(data: &Value) -> Vec<Message> {
 }
 
 fn try_parse_provider_messages_for_import(data: &Value) -> Option<Vec<Message>> {
-    const PROVIDER_PARSERS: &[MessageParser] = &[
-        try_parse_openai_for_import,
-        try_parse_anthropic_for_import,
-        try_parse_google_for_import,
-        try_parse_bedrock_for_import,
-    ];
-    try_parsers_in_order(data, PROVIDER_PARSERS)
+    let mut provider_parsers: Vec<MessageParser> = Vec::new();
+
+    #[cfg(feature = "openai")]
+    provider_parsers.push(try_parse_openai_for_import);
+    #[cfg(feature = "anthropic")]
+    provider_parsers.push(try_parse_anthropic_for_import);
+    #[cfg(feature = "google")]
+    provider_parsers.push(try_parse_google_for_import);
+    #[cfg(feature = "bedrock")]
+    provider_parsers.push(try_parse_bedrock_for_import);
+
+    try_parsers_in_order(data, &provider_parsers)
 }
 
+#[cfg(feature = "anthropic")]
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 enum AnthropicOrSystemMessage {
@@ -145,12 +161,14 @@ enum AnthropicOrSystemMessage {
     SystemOrDeveloper(SystemOrDeveloperMessage),
 }
 
+#[cfg(feature = "anthropic")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct SystemOrDeveloperMessage {
     role: SystemOrDeveloperRole,
     content: Value,
 }
 
+#[cfg(feature = "anthropic")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum SystemOrDeveloperRole {
@@ -158,6 +176,7 @@ enum SystemOrDeveloperRole {
     Developer,
 }
 
+#[cfg(feature = "anthropic")]
 fn try_parse_anthropic_or_system_message(item: AnthropicOrSystemMessage) -> Option<Message> {
     match item {
         AnthropicOrSystemMessage::Anthropic(provider_message) => {
@@ -170,6 +189,7 @@ fn try_parse_anthropic_or_system_message(item: AnthropicOrSystemMessage) -> Opti
     }
 }
 
+#[cfg(feature = "anthropic")]
 fn try_anthropic_or_system_messages(data: &Value) -> Option<Vec<Message>> {
     let items: Vec<AnthropicOrSystemMessage> = serde_json::from_value(data.clone()).ok()?;
     if items.is_empty() {

--- a/crates/lingua/src/processing/import.rs
+++ b/crates/lingua/src/processing/import.rs
@@ -139,16 +139,16 @@ fn try_converting_to_messages(data: &Value) -> Vec<Message> {
 }
 
 fn try_parse_provider_messages_for_import(data: &Value) -> Option<Vec<Message>> {
-    let mut provider_parsers: Vec<MessageParser> = Vec::new();
-
-    #[cfg(feature = "openai")]
-    provider_parsers.push(try_parse_openai_for_import);
-    #[cfg(feature = "anthropic")]
-    provider_parsers.push(try_parse_anthropic_for_import);
-    #[cfg(feature = "google")]
-    provider_parsers.push(try_parse_google_for_import);
-    #[cfg(feature = "bedrock")]
-    provider_parsers.push(try_parse_bedrock_for_import);
+    let provider_parsers: Vec<MessageParser> = vec![
+        #[cfg(feature = "openai")]
+        try_parse_openai_for_import,
+        #[cfg(feature = "anthropic")]
+        try_parse_anthropic_for_import,
+        #[cfg(feature = "google")]
+        try_parse_google_for_import,
+        #[cfg(feature = "bedrock")]
+        try_parse_bedrock_for_import,
+    ];
 
     try_parsers_in_order(data, &provider_parsers)
 }

--- a/payloads/import-cases/adk-basic-input-output.assertions.json
+++ b/payloads/import-cases/adk-basic-input-output.assertions.json
@@ -1,6 +1,9 @@
 {
-  "_migrationNote": "Diverges from app/ui/trace/converters/adk-converter.test.ts (basic ADK input/output): the old converter normalized ADK/Gemini-shaped `contents/parts` + `content.parts` into user+assistant messages, but lingua import_messages_from_spans currently imports 0 messages for this ADK span shape.",
-  "expectedMessageCount": 0,
-  "expectedRolesInOrder": [],
+  "_migrationNote": "Now aligned with app/ui/trace/converters/adk-converter.test.ts (basic ADK input/output): lingua imports ADK/Gemini-shaped `contents/parts` + `content.parts` as user+assistant messages.",
+  "expectedMessageCount": 2,
+  "expectedRolesInOrder": [
+    "user",
+    "assistant"
+  ],
   "mustContainText": []
 }

--- a/payloads/import-cases/anthropic-thinking-output-with-system-input.assertions.json
+++ b/payloads/import-cases/anthropic-thinking-output-with-system-input.assertions.json
@@ -1,0 +1,12 @@
+{
+  "expectedMessageCount": 3,
+  "expectedRolesInOrder": [
+    "system",
+    "user",
+    "assistant"
+  ],
+  "mustContainText": [
+    "anon_15",
+    "anon_16"
+  ]
+}

--- a/payloads/import-cases/anthropic-thinking-output-with-system-input.json
+++ b/payloads/import-cases/anthropic-thinking-output-with-system-input.json
@@ -1,0 +1,96 @@
+[
+  {
+    "_pagination_key": "p07611302904676089857",
+    "_xact_id": "1000196731518474014",
+    "classifications": null,
+    "created": "2026-02-26T22:20:12.210Z",
+    "facets": null,
+    "id": "dfb401fe2b5514b4",
+    "metrics": {
+      "completion_tokens": 8666,
+      "end": 1772144552.146522,
+      "prompt_tokens": 171566,
+      "start": 1772144412.210261,
+      "tokens": 180232,
+      "estimated_cost": 0.6446879999999999
+    },
+    "model": "claude-sonnet-4-5-20250929",
+    "origin": null,
+    "root_span_id": "e96c91ed31ece85733866e1705eaba8d",
+    "scores": null,
+    "span_attributes": {
+      "name": "GenerateSelectFieldOptionDescriptions",
+      "type": "llm"
+    },
+    "span_id": "dfb401fe2b5514b4",
+    "tags": [],
+    "_async_scoring_state": null,
+    "audit_data": [
+      {
+        "_xact_id": "1000196731518474014",
+        "audit_data": {
+          "action": "upsert"
+        },
+        "metadata": {},
+        "source": "api"
+      }
+    ],
+    "input": [
+      {
+        "content": "anon_1",
+        "role": "system"
+      },
+      {
+        "content": "anon_2",
+        "role": "user"
+      }
+    ],
+    "is_root": true,
+    "log_id": "g",
+    "metadata": {
+      "braintrust.metrics.completion_tokens": 8666,
+      "braintrust.metrics.end": 1772144552.146522,
+      "braintrust.metrics.prompt_tokens": 171566,
+      "braintrust.metrics.start": 1772144412.210261,
+      "braintrust.metrics.tokens": 180232,
+      "custom_field_definition_id": "anon_3",
+      "detailed_tokens": {
+        "completion_tokens": 8666,
+        "prompt_tokens": 171566
+      },
+      "ecsService": "anon_4",
+      "gen_ai.operation.name": "anon_5",
+      "gen_ai.provider.name": "anon_6",
+      "gen_ai.request.model": "anon_7",
+      "gen_ai.response.model": "anon_7",
+      "gen_ai.usage.input_tokens": 171566,
+      "gen_ai.usage.output_tokens": 8666,
+      "input": {
+        "custom_field_name": "anon_8",
+        "custom_field_value_options": "anon_9",
+        "sampled_issue_data": "anon_10"
+      },
+      "model": "claude-sonnet-4-5-20250929",
+      "org_id": "anon_11",
+      "org_name": "anon_12",
+      "promptName": "anon_13",
+      "pylon.org.id": "anon_11",
+      "pylon.org.name": "anon_12",
+      "pylon.prompt.name": "anon_13",
+      "pylon.span.emit_always": true
+    },
+    "org_id": "f1b9d63a-0673-4a90-a9aa-fcda2f5313b0",
+    "output": [
+      {
+        "signature": "anon_14",
+        "thinking": "anon_15",
+        "type": "thinking"
+      },
+      {
+        "text": "anon_16",
+        "type": "text"
+      }
+    ],
+    "project_id": "b2fe0186-16e9-429d-8ec5-123da617ef13"
+  }
+]

--- a/payloads/import-cases/gemini-basic-generate-content.assertions.json
+++ b/payloads/import-cases/gemini-basic-generate-content.assertions.json
@@ -1,6 +1,8 @@
 {
-  "_migrationNote": "Diverges from app/ui/trace/converters/gemini-converter.test.ts (Gemini input without output): the old converter normalized Gemini `contents/parts` into a user chat message, but lingua import_messages_from_spans currently imports 0 messages for raw Gemini generateContent request shape.",
-  "expectedMessageCount": 0,
-  "expectedRolesInOrder": [],
+  "_migrationNote": "Now aligned with app/ui/trace/converters/gemini-converter.test.ts (Gemini input without output): lingua imports raw Gemini `contents/parts` request shape as a user message.",
+  "expectedMessageCount": 1,
+  "expectedRolesInOrder": [
+    "user"
+  ],
   "mustContainText": []
 }

--- a/payloads/import-cases/mastra-agent-run-parts-input.assertions.json
+++ b/payloads/import-cases/mastra-agent-run-parts-input.assertions.json
@@ -1,6 +1,8 @@
 {
-  "_migrationNote": "Diverges from app/ui/trace/converters/mastra-response-converter.test.ts (agent_run parts-based input): the old converter normalized `parts` input plus `{text}` output into user+assistant messages, but lingua import_messages_from_spans currently imports 0 messages for this Mastra-specific shape.",
-  "expectedMessageCount": 0,
-  "expectedRolesInOrder": [],
+  "_migrationNote": "Partially aligned with app/ui/trace/converters/mastra-response-converter.test.ts (agent_run parts-based input): lingua now imports the `parts` user input, but still does not synthesize an assistant message from `{text}` output.",
+  "expectedMessageCount": 1,
+  "expectedRolesInOrder": [
+    "user"
+  ],
   "mustContainText": []
 }


### PR DESCRIPTION
You can output a list of messages, a single message (which itself may be a list of content parts), or just text. This change fixes the logic so that we try all of these in a provider-agnostic way (though the specific bug has to do with Anthropic)