### PR TITLE
Add rust dependencies to globalDependencies for proper cache invalidation

### DIFF
--- a/bindings/lingua-wasm/turbo.json
+++ b/bindings/lingua-wasm/turbo.json
@@ -1,10 +1,18 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
+  "extends": [
+    "//"
+  ],
+  "globalDependencies": [
+    "../../crates/lingua/src/**/*.rs",
+    "../../crates/lingua/Cargo.toml"
+  ],
   "tasks": {
     "build": {
-      "outputs": ["nodejs/**", "web/**"]
+      "outputs": [
+        "nodejs/**",
+        "web/**"
+      ]
     }
   }
 }
-


### PR DESCRIPTION
When a Turbo repo build runs, it hashes relevant js/ts files but doesn't consider rust. We need to add these to turbo.json so Turbo repo invalidates the cache when these files change.