### PR TITLE
Add Databricks provider

### DIFF
--- a/crates/braintrust-llm-router/src/lib.rs
+++ b/crates/braintrust-llm-router/src/lib.rs
@@ -23,9 +23,9 @@ pub use lingua::ProviderFormat;
 pub use lingua::{FinishReason, UniversalStreamChoice, UniversalStreamChunk};
 pub use providers::{
     is_openai_compatible, openai_compatible_endpoint, AnthropicConfig, AnthropicProvider,
-    AzureConfig, AzureProvider, BedrockConfig, BedrockProvider, ClientHeaders, GoogleConfig,
-    GoogleProvider, MistralConfig, MistralProvider, OpenAICompatibleEndpoint, OpenAIConfig,
-    OpenAIProvider, Provider, VertexConfig, VertexProvider,
+    AzureConfig, AzureProvider, BedrockConfig, BedrockProvider, ClientHeaders, DatabricksConfig,
+    DatabricksProvider, GoogleConfig, GoogleProvider, MistralConfig, MistralProvider,
+    OpenAICompatibleEndpoint, OpenAIConfig, OpenAIProvider, Provider, VertexConfig, VertexProvider,
 };
 pub use retry::{RetryPolicy, RetryStrategy};
 pub use router::{create_provider, extract_request_hints, RequestHints, Router, RouterBuilder};

--- a/crates/braintrust-llm-router/src/providers/databricks.rs
+++ b/crates/braintrust-llm-router/src/providers/databricks.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use lingua::serde_json;
 use reqwest::header::HeaderMap;
 use reqwest::{Client, StatusCode, Url};
 
@@ -45,30 +44,6 @@ impl DatabricksProvider {
             .cloned()
             .ok_or_else(|| Error::InvalidRequest("databricks provider requires api_base".into()))?;
         Self::new(DatabricksConfig { api_base, timeout })
-    }
-
-    /// Normalize a payload for Databricks serving endpoints:
-    /// - Strip `stream_options` (unsupported)
-    /// - Convert `max_completion_tokens` → `max_tokens` (unsupported)
-    fn normalize_payload(&self, payload: Bytes) -> Bytes {
-        let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&payload) else {
-            return payload;
-        };
-        let Some(obj) = value.as_object_mut() else {
-            return payload;
-        };
-        let mut changed = false;
-        if obj.remove("stream_options").is_some() {
-            changed = true;
-        }
-        if let Some(max_completion_tokens) = obj.remove("max_completion_tokens") {
-            obj.entry("max_tokens").or_insert(max_completion_tokens);
-            changed = true;
-        }
-        if changed {
-            return Bytes::from(serde_json::to_vec(&value).unwrap_or_else(|_| payload.to_vec()));
-        }
-        payload
     }
 
     // This does not support Databrick's new AI gateway URL format yet, only
@@ -114,7 +89,6 @@ impl crate::providers::Provider for DatabricksProvider {
         _format: ProviderFormat,
         client_headers: &ClientHeaders,
     ) -> Result<Bytes> {
-        let payload = self.normalize_payload(payload);
         let url = self.serving_url(&spec.model)?;
 
         #[cfg(feature = "tracing")]
@@ -174,8 +148,6 @@ impl crate::providers::Provider for DatabricksProvider {
         format: ProviderFormat,
         client_headers: &ClientHeaders,
     ) -> Result<RawResponseStream> {
-        let payload = self.normalize_payload(payload);
-
         if !spec.supports_streaming {
             let response = self
                 .complete(payload, auth, spec, format, client_headers)
@@ -299,55 +271,5 @@ mod tests {
     fn from_config_requires_api_base() {
         let err = DatabricksProvider::from_config(None, None).unwrap_err();
         assert!(matches!(err, Error::InvalidRequest(_)));
-    }
-
-    fn make_provider() -> DatabricksProvider {
-        DatabricksProvider::new(DatabricksConfig {
-            api_base: Url::parse("https://adb-123.azuredatabricks.net").unwrap(),
-            timeout: None,
-        })
-        .unwrap()
-    }
-
-    #[test]
-    fn normalize_payload_strips_stream_options() {
-        let provider = make_provider();
-        let payload = Bytes::from(
-            r#"{"model":"m","messages":[],"stream":true,"stream_options":{"include_usage":true}}"#,
-        );
-        let out = provider.normalize_payload(payload);
-        let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
-        assert!(value.get("stream_options").is_none());
-        assert!(value.get("stream").is_some());
-    }
-
-    #[test]
-    fn normalize_payload_converts_max_completion_tokens() {
-        let provider = make_provider();
-        let payload = Bytes::from(r#"{"model":"m","messages":[],"max_completion_tokens":50}"#);
-        let out = provider.normalize_payload(payload);
-        let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
-        assert!(value.get("max_completion_tokens").is_none());
-        assert_eq!(value.get("max_tokens").and_then(|v| v.as_i64()), Some(50));
-    }
-
-    #[test]
-    fn normalize_payload_preserves_max_tokens_when_both_present() {
-        let provider = make_provider();
-        let payload = Bytes::from(
-            r#"{"model":"m","messages":[],"max_tokens":100,"max_completion_tokens":50}"#,
-        );
-        let out = provider.normalize_payload(payload);
-        let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
-        assert!(value.get("max_completion_tokens").is_none());
-        assert_eq!(value.get("max_tokens").and_then(|v| v.as_i64()), Some(100));
-    }
-
-    #[test]
-    fn normalize_payload_no_op_when_nothing_to_strip() {
-        let provider = make_provider();
-        let raw = r#"{"model":"m","messages":[],"stream":true}"#;
-        let out = provider.normalize_payload(Bytes::from(raw));
-        assert_eq!(std::str::from_utf8(&out).unwrap(), raw);
     }
 }

--- a/crates/braintrust-llm-router/src/providers/databricks.rs
+++ b/crates/braintrust-llm-router/src/providers/databricks.rs
@@ -1,0 +1,323 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use lingua::serde_json;
+use reqwest::header::HeaderMap;
+use reqwest::{Client, StatusCode, Url};
+
+use crate::auth::AuthConfig;
+use crate::catalog::ModelSpec;
+use crate::client::{default_client, ClientSettings};
+use crate::error::{Error, Result, UpstreamHttpError};
+use crate::providers::ClientHeaders;
+use crate::streaming::{single_bytes_stream, sse_stream, RawResponseStream};
+use lingua::ProviderFormat;
+
+#[derive(Debug, Clone)]
+pub struct DatabricksConfig {
+    pub api_base: Url,
+    pub timeout: Option<Duration>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DatabricksProvider {
+    client: Client,
+    config: DatabricksConfig,
+}
+
+impl DatabricksProvider {
+    pub fn new(config: DatabricksConfig) -> Result<Self> {
+        let mut settings = ClientSettings::default();
+        if let Some(timeout) = config.timeout {
+            settings.request_timeout = timeout;
+        }
+        let client = if config.timeout.is_some() {
+            crate::client::build_client(&settings)?
+        } else {
+            default_client().or_else(|_| crate::client::build_client(&settings))?
+        };
+        Ok(Self { client, config })
+    }
+
+    pub fn from_config(api_base: Option<&Url>, timeout: Option<Duration>) -> Result<Self> {
+        let api_base = api_base
+            .cloned()
+            .ok_or_else(|| Error::InvalidRequest("databricks provider requires api_base".into()))?;
+        Self::new(DatabricksConfig { api_base, timeout })
+    }
+
+    /// Databricks serving endpoints do not support `stream_options`; strip it.
+    fn strip_stream_options(&self, payload: Bytes) -> Bytes {
+        let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&payload) else {
+            return payload;
+        };
+        if let Some(obj) = value.as_object_mut() {
+            if obj.remove("stream_options").is_some() {
+                return Bytes::from(
+                    serde_json::to_vec(&value).unwrap_or_else(|_| payload.to_vec()),
+                );
+            }
+        }
+        payload
+    }
+
+    // This does not support Databrick's new AI gateway URL format yet, only
+    // their model serving endpoints.
+    fn serving_url(&self, model: &str) -> Result<Url> {
+        let mut url = self.config.api_base.clone();
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .map_err(|_| Error::InvalidRequest("endpoint must be absolute".into()))?;
+            segments.pop_if_empty();
+            segments.push("serving-endpoints");
+            segments.push(model);
+            segments.push("invocations");
+        }
+        Ok(url)
+    }
+}
+
+fn extract_retry_after(status: StatusCode) -> Option<Duration> {
+    if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+        Some(Duration::from_secs(2))
+    } else {
+        None
+    }
+}
+
+#[async_trait]
+impl crate::providers::Provider for DatabricksProvider {
+    fn id(&self) -> &'static str {
+        "databricks"
+    }
+
+    fn provider_formats(&self) -> Vec<ProviderFormat> {
+        vec![ProviderFormat::ChatCompletions]
+    }
+
+    async fn complete(
+        &self,
+        payload: Bytes,
+        auth: &AuthConfig,
+        spec: &ModelSpec,
+        _format: ProviderFormat,
+        client_headers: &ClientHeaders,
+    ) -> Result<Bytes> {
+        let payload = self.strip_stream_options(payload);
+        let url = self.serving_url(&spec.model)?;
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!(
+            target: "bt.router.provider.http",
+            llm_provider = "databricks",
+            http_url = %url,
+            "sending request to Databricks"
+        );
+
+        let mut headers = client_headers.to_json_headers();
+        auth.apply_headers(&mut headers)?;
+
+        let response = self
+            .client
+            .post(url)
+            .headers(headers)
+            .body(payload)
+            .send()
+            .await?;
+
+        #[cfg(feature = "tracing")]
+        let status_code = response.status().as_u16();
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!(
+            target: "bt.router.provider.http",
+            llm_provider = "databricks",
+            http_status_code = status_code,
+            "received response from Databricks"
+        );
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let headers = response.headers().clone();
+            let text = response.text().await.unwrap_or_default();
+            return Err(Error::Provider {
+                provider: "databricks".to_string(),
+                source: anyhow::anyhow!("HTTP {status}: {text}"),
+                retry_after: extract_retry_after(status),
+                http: Some(UpstreamHttpError::new(
+                    status.as_u16(),
+                    headers,
+                    text.clone(),
+                )),
+            });
+        }
+
+        Ok(response.bytes().await?)
+    }
+
+    async fn complete_stream(
+        &self,
+        payload: Bytes,
+        auth: &AuthConfig,
+        spec: &ModelSpec,
+        format: ProviderFormat,
+        client_headers: &ClientHeaders,
+    ) -> Result<RawResponseStream> {
+        let payload = self.strip_stream_options(payload);
+
+        if !spec.supports_streaming {
+            let response = self
+                .complete(payload, auth, spec, format, client_headers)
+                .await?;
+            return Ok(single_bytes_stream(response));
+        }
+
+        let url = self.serving_url(&spec.model)?;
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!(
+            target: "bt.router.provider.http",
+            llm_provider = "databricks",
+            http_url = %url,
+            llm_streaming = true,
+            "sending streaming request to Databricks"
+        );
+
+        let mut headers = client_headers.to_json_headers();
+        auth.apply_headers(&mut headers)?;
+
+        let response = self
+            .client
+            .post(url)
+            .headers(headers)
+            .body(payload)
+            .send()
+            .await?;
+
+        #[cfg(feature = "tracing")]
+        let status_code = response.status().as_u16();
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!(
+            target: "bt.router.provider.http",
+            llm_provider = "databricks",
+            http_status_code = status_code,
+            llm_streaming = true,
+            "received streaming response from Databricks"
+        );
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let headers = response.headers().clone();
+            let text = response.text().await.unwrap_or_default();
+            return Err(Error::Provider {
+                provider: "databricks".to_string(),
+                source: anyhow::anyhow!("HTTP {status}: {text}"),
+                retry_after: extract_retry_after(status),
+                http: Some(UpstreamHttpError::new(
+                    status.as_u16(),
+                    headers,
+                    text.clone(),
+                )),
+            });
+        }
+
+        Ok(sse_stream(response))
+    }
+
+    async fn health_check(&self, auth: &AuthConfig) -> Result<()> {
+        let mut url = self.config.api_base.clone();
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .map_err(|_| Error::InvalidRequest("endpoint must be absolute".into()))?;
+            segments.pop_if_empty();
+            segments.push("serving-endpoints");
+        }
+        let mut headers = HeaderMap::new();
+        auth.apply_headers(&mut headers)?;
+
+        let response = self.client.get(url).headers(headers).send().await?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(Error::Provider {
+                provider: "databricks".to_string(),
+                source: anyhow::anyhow!("status {}", response.status()),
+                retry_after: None,
+                http: None,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serving_url_appends_model_and_invocations() {
+        let config = DatabricksConfig {
+            api_base: Url::parse("https://adb-123.azuredatabricks.net").unwrap(),
+            timeout: None,
+        };
+        let provider = DatabricksProvider::new(config).unwrap();
+        let url = provider.serving_url("my-model").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://adb-123.azuredatabricks.net/serving-endpoints/my-model/invocations"
+        );
+    }
+
+    #[test]
+    fn serving_url_with_trailing_slash_in_base() {
+        let config = DatabricksConfig {
+            api_base: Url::parse("https://adb-123.azuredatabricks.net/").unwrap(),
+            timeout: None,
+        };
+        let provider = DatabricksProvider::new(config).unwrap();
+        let url = provider.serving_url("llama-3-1-8b").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://adb-123.azuredatabricks.net/serving-endpoints/llama-3-1-8b/invocations"
+        );
+    }
+
+    #[test]
+    fn from_config_requires_api_base() {
+        let err = DatabricksProvider::from_config(None, None).unwrap_err();
+        assert!(matches!(err, Error::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn strip_stream_options_removes_field() {
+        let config = DatabricksConfig {
+            api_base: Url::parse("https://adb-123.azuredatabricks.net").unwrap(),
+            timeout: None,
+        };
+        let provider = DatabricksProvider::new(config).unwrap();
+        let payload = Bytes::from(
+            r#"{"model":"m","messages":[],"stream":true,"stream_options":{"include_usage":true}}"#,
+        );
+        let stripped = provider.strip_stream_options(payload);
+        let value: serde_json::Value = serde_json::from_slice(&stripped).unwrap();
+        assert!(value.get("stream_options").is_none());
+        assert!(value.get("stream").is_some());
+    }
+
+    #[test]
+    fn strip_stream_options_no_op_when_absent() {
+        let config = DatabricksConfig {
+            api_base: Url::parse("https://adb-123.azuredatabricks.net").unwrap(),
+            timeout: None,
+        };
+        let provider = DatabricksProvider::new(config).unwrap();
+        let raw = r#"{"model":"m","messages":[],"stream":true}"#;
+        let payload = Bytes::from(raw);
+        let stripped = provider.strip_stream_options(payload);
+        assert_eq!(std::str::from_utf8(&stripped).unwrap(), raw);
+    }
+}

--- a/crates/braintrust-llm-router/src/providers/databricks.rs
+++ b/crates/braintrust-llm-router/src/providers/databricks.rs
@@ -47,17 +47,26 @@ impl DatabricksProvider {
         Self::new(DatabricksConfig { api_base, timeout })
     }
 
-    /// Databricks serving endpoints do not support `stream_options`; strip it.
-    fn strip_stream_options(&self, payload: Bytes) -> Bytes {
+    /// Normalize a payload for Databricks serving endpoints:
+    /// - Strip `stream_options` (unsupported)
+    /// - Convert `max_completion_tokens` → `max_tokens` (unsupported)
+    fn normalize_payload(&self, payload: Bytes) -> Bytes {
         let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&payload) else {
             return payload;
         };
-        if let Some(obj) = value.as_object_mut() {
-            if obj.remove("stream_options").is_some() {
-                return Bytes::from(
-                    serde_json::to_vec(&value).unwrap_or_else(|_| payload.to_vec()),
-                );
-            }
+        let Some(obj) = value.as_object_mut() else {
+            return payload;
+        };
+        let mut changed = false;
+        if obj.remove("stream_options").is_some() {
+            changed = true;
+        }
+        if let Some(max_completion_tokens) = obj.remove("max_completion_tokens") {
+            obj.entry("max_tokens").or_insert(max_completion_tokens);
+            changed = true;
+        }
+        if changed {
+            return Bytes::from(serde_json::to_vec(&value).unwrap_or_else(|_| payload.to_vec()));
         }
         payload
     }
@@ -105,7 +114,7 @@ impl crate::providers::Provider for DatabricksProvider {
         _format: ProviderFormat,
         client_headers: &ClientHeaders,
     ) -> Result<Bytes> {
-        let payload = self.strip_stream_options(payload);
+        let payload = self.normalize_payload(payload);
         let url = self.serving_url(&spec.model)?;
 
         #[cfg(feature = "tracing")]
@@ -165,7 +174,7 @@ impl crate::providers::Provider for DatabricksProvider {
         format: ProviderFormat,
         client_headers: &ClientHeaders,
     ) -> Result<RawResponseStream> {
-        let payload = self.strip_stream_options(payload);
+        let payload = self.normalize_payload(payload);
 
         if !spec.supports_streaming {
             let response = self
@@ -292,32 +301,53 @@ mod tests {
         assert!(matches!(err, Error::InvalidRequest(_)));
     }
 
-    #[test]
-    fn strip_stream_options_removes_field() {
-        let config = DatabricksConfig {
+    fn make_provider() -> DatabricksProvider {
+        DatabricksProvider::new(DatabricksConfig {
             api_base: Url::parse("https://adb-123.azuredatabricks.net").unwrap(),
             timeout: None,
-        };
-        let provider = DatabricksProvider::new(config).unwrap();
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn normalize_payload_strips_stream_options() {
+        let provider = make_provider();
         let payload = Bytes::from(
             r#"{"model":"m","messages":[],"stream":true,"stream_options":{"include_usage":true}}"#,
         );
-        let stripped = provider.strip_stream_options(payload);
-        let value: serde_json::Value = serde_json::from_slice(&stripped).unwrap();
+        let out = provider.normalize_payload(payload);
+        let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert!(value.get("stream_options").is_none());
         assert!(value.get("stream").is_some());
     }
 
     #[test]
-    fn strip_stream_options_no_op_when_absent() {
-        let config = DatabricksConfig {
-            api_base: Url::parse("https://adb-123.azuredatabricks.net").unwrap(),
-            timeout: None,
-        };
-        let provider = DatabricksProvider::new(config).unwrap();
+    fn normalize_payload_converts_max_completion_tokens() {
+        let provider = make_provider();
+        let payload = Bytes::from(r#"{"model":"m","messages":[],"max_completion_tokens":50}"#);
+        let out = provider.normalize_payload(payload);
+        let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert!(value.get("max_completion_tokens").is_none());
+        assert_eq!(value.get("max_tokens").and_then(|v| v.as_i64()), Some(50));
+    }
+
+    #[test]
+    fn normalize_payload_preserves_max_tokens_when_both_present() {
+        let provider = make_provider();
+        let payload = Bytes::from(
+            r#"{"model":"m","messages":[],"max_tokens":100,"max_completion_tokens":50}"#,
+        );
+        let out = provider.normalize_payload(payload);
+        let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert!(value.get("max_completion_tokens").is_none());
+        assert_eq!(value.get("max_tokens").and_then(|v| v.as_i64()), Some(100));
+    }
+
+    #[test]
+    fn normalize_payload_no_op_when_nothing_to_strip() {
+        let provider = make_provider();
         let raw = r#"{"model":"m","messages":[],"stream":true}"#;
-        let payload = Bytes::from(raw);
-        let stripped = provider.strip_stream_options(payload);
-        assert_eq!(std::str::from_utf8(&stripped).unwrap(), raw);
+        let out = provider.normalize_payload(Bytes::from(raw));
+        assert_eq!(std::str::from_utf8(&out).unwrap(), raw);
     }
 }

--- a/crates/braintrust-llm-router/src/providers/mod.rs
+++ b/crates/braintrust-llm-router/src/providers/mod.rs
@@ -1,6 +1,7 @@
 mod anthropic;
 mod azure;
 mod bedrock;
+mod databricks;
 mod google;
 mod mistral;
 mod openai;
@@ -9,6 +10,7 @@ mod vertex;
 pub use anthropic::{AnthropicConfig, AnthropicProvider};
 pub use azure::{AzureConfig, AzureProvider};
 pub use bedrock::{BedrockConfig, BedrockProvider};
+pub use databricks::{DatabricksConfig, DatabricksProvider};
 pub use google::{GoogleConfig, GoogleProvider};
 pub use mistral::{MistralConfig, MistralProvider};
 pub use openai::{

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -23,8 +23,8 @@ pub use lingua::{extract_request_hints, RequestHints};
 use reqwest::Url;
 
 use crate::providers::{
-    is_openai_compatible, AnthropicProvider, AzureProvider, BedrockProvider, GoogleProvider,
-    MistralProvider, OpenAIProvider, VertexProvider,
+    is_openai_compatible, AnthropicProvider, AzureProvider, BedrockProvider, DatabricksProvider,
+    GoogleProvider, MistralProvider, OpenAIProvider, VertexProvider,
 };
 
 /// Create a provider instance from configuration parameters.
@@ -80,6 +80,9 @@ pub fn create_provider(
         )?)),
         "bedrock" => Ok(Arc::new(BedrockProvider::from_config(
             endpoint, timeout, metadata,
+        )?)),
+        "databricks" => Ok(Arc::new(DatabricksProvider::from_config(
+            endpoint, timeout,
         )?)),
         "mistral" => Ok(Arc::new(MistralProvider::from_config(endpoint, timeout)?)),
         kind if is_openai_compatible(kind) => Ok(Arc::new(OpenAIProvider::from_config(

--- a/crates/lingua/src/providers/openai/capabilities.rs
+++ b/crates/lingua/src/providers/openai/capabilities.rs
@@ -87,7 +87,7 @@ pub fn apply_model_transforms(model: &str, obj: &mut Map<String, Value>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::serde_json::json;
+    use crate::serde_json::{self, json};
 
     #[test]
     fn test_get_model_transforms() {
@@ -268,14 +268,12 @@ mod tests {
 
     #[test]
     fn test_strip_stream_options() {
-        let mut obj = json!({
+        let mut obj: Map<String, Value> = serde_json::from_value(json!({
             "model": "databricks-model",
             "messages": [{"role": "user", "content": "Hello"}],
             "stream_options": { "include_usage": true }
-        })
-        .as_object()
-        .unwrap()
-        .clone();
+        }))
+        .unwrap();
         apply_model_transforms("databricks-model", &mut obj);
         assert!(
             !obj.contains_key("stream_options"),

--- a/crates/lingua/src/providers/openai/capabilities.rs
+++ b/crates/lingua/src/providers/openai/capabilities.rs
@@ -12,6 +12,8 @@ pub enum ModelTransform {
     ForceMaxCompletionTokens,
     /// Convert max_completion_tokens to max_tokens
     ForceMaxTokens,
+    /// Strip stream_options parameter
+    StripStreamOptions,
 }
 
 use ModelTransform::*;
@@ -31,6 +33,8 @@ const MODEL_TRANSFORM_RULES: &[(&str, &[ModelTransform])] = &[
     ("pixstral", &[ForceMaxTokens]),
     ("devstral", &[ForceMaxTokens]),
     ("voxstral", &[ForceMaxTokens]),
+    // Databricks models
+    ("databricks-", &[ForceMaxTokens, StripStreamOptions]),
 ];
 
 /// Get the transforms required for a model.
@@ -72,6 +76,9 @@ pub fn apply_model_transforms(model: &str, obj: &mut Map<String, Value>) {
                 if let Some(max_tokens) = obj.remove("max_completion_tokens") {
                     obj.entry("max_tokens").or_insert(max_tokens);
                 }
+            }
+            StripStreamOptions => {
+                obj.remove("stream_options");
             }
         }
     }
@@ -257,5 +264,22 @@ mod tests {
                 model
             );
         }
+    }
+
+    #[test]
+    fn test_strip_stream_options() {
+        let mut obj = json!({
+            "model": "databricks-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream_options": { "include_usage": true }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        apply_model_transforms("databricks-model", &mut obj);
+        assert!(
+            !obj.contains_key("stream_options"),
+            "stream_options should be removed"
+        );
     }
 }


### PR DESCRIPTION
Two main tweaks we need for things to work on databricks:
* Modify URL to match the format for Databricks's serving endpoints
* Strip stream_options, which Databricks does not support
* Use max_tokens, not max_completion_tokens