### PR TITLE
Fix plain string output parsing

### DIFF
--- a/crates/lingua/src/processing/import.rs
+++ b/crates/lingua/src/processing/import.rs
@@ -535,7 +535,14 @@ pub fn import_messages_from_spans(spans: Vec<Span>) -> Vec<Message> {
         messages.extend(span_messages);
 
         // Try to extract messages from output
-        if let Some(output) = &span.output {
+        if let Some(Value::String(output_text)) = &span.output {
+            if !output_text.is_empty() {
+                messages.push(Message::Assistant {
+                    content: AssistantContent::String(output_text.clone()),
+                    id: None,
+                });
+            }
+        } else if let Some(output) = &span.output {
             let output_messages = try_converting_to_messages(output);
             messages.extend(output_messages);
         }

--- a/payloads/import-cases/output-string-assistant-message.assertions.json
+++ b/payloads/import-cases/output-string-assistant-message.assertions.json
@@ -1,0 +1,11 @@
+{
+  "expectedMessageCount": 2,
+  "expectedRolesInOrder": [
+    "user",
+    "assistant"
+  ],
+  "mustContainText": [
+    "anon_input",
+    "anon_output"
+  ]
+}

--- a/payloads/import-cases/output-string-assistant-message.spans.json
+++ b/payloads/import-cases/output-string-assistant-message.spans.json
@@ -1,0 +1,13 @@
+[
+  {
+    "input": {
+      "messages": [
+        {
+          "role": "user",
+          "content": "anon_input"
+        }
+      ]
+    },
+    "output": "anon_output"
+  }
+]


### PR DESCRIPTION
If the input looks like an LLM and the output is just a string, we should parse it as an assistant mesage.