### PR TITLE
Reject duplicate entries in router builder

### DIFF
--- a/crates/braintrust-llm-router/README.md
+++ b/crates/braintrust-llm-router/README.md
@@ -123,9 +123,11 @@ let stream = router.complete_stream(body, "gpt-4", ProviderFormat::ChatCompletio
 ### Authentication
 
 ```rust
-use braintrust_llm_router::AuthConfig;
+use braintrust_llm_router::{api_key_auth, AuthConfig};
 
 // OpenAI-style (Authorization: Bearer <key>)
+api_key_auth("sk-...")
+// Or equivalently:
 AuthConfig::ApiKey {
     key: "sk-...".into(),
     header: Some("authorization".into()),

--- a/crates/braintrust-llm-router/examples/custom_auth.rs
+++ b/crates/braintrust-llm-router/examples/custom_auth.rs
@@ -15,8 +15,8 @@
 
 use anyhow::Result;
 use braintrust_llm_router::{
-    serde_json::json, AuthConfig, ClientHeaders, OpenAIConfig, OpenAIProvider, ProviderFormat,
-    Router,
+    api_key_auth, serde_json::json, AuthConfig, ClientHeaders, OpenAIConfig, OpenAIProvider,
+    ProviderFormat, Router,
 };
 use bytes::Bytes;
 use serde_json::Value;
@@ -119,8 +119,12 @@ async fn main() -> Result<()> {
 
     let router = Router::builder()
         .with_catalog(catalog)
-        .add_provider("openai", openai_provider)
-        .add_api_key("openai", api_key) // Convenience method
+        .add_provider(
+            "openai",
+            openai_provider,
+            api_key_auth(&api_key),
+            vec![ProviderFormat::ChatCompletions],
+        )
         .build()?;
 
     let model = "gpt-4";
@@ -132,7 +136,7 @@ async fn main() -> Result<()> {
 
     println!("   Sending authenticated request to GPT-4...");
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let bytes = router
+    let bytes: Bytes = router
         .complete(
             body,
             model,

--- a/crates/braintrust-llm-router/examples/multi_provider.rs
+++ b/crates/braintrust-llm-router/examples/multi_provider.rs
@@ -10,8 +10,8 @@
 
 use anyhow::Result;
 use braintrust_llm_router::{
-    serde_json::json, AnthropicConfig, AnthropicProvider, AuthConfig, ClientHeaders, ModelCatalog,
-    OpenAIConfig, OpenAIProvider, ProviderFormat, Router,
+    api_key_auth, serde_json::json, AnthropicConfig, AnthropicProvider, AuthConfig, ClientHeaders,
+    ModelCatalog, OpenAIConfig, OpenAIProvider, ProviderFormat, Router,
 };
 use bytes::Bytes;
 use serde_json::Value;
@@ -40,25 +40,28 @@ async fn main() -> Result<()> {
     // Add OpenAI provider if key is available
     if let Some(key) = &openai_key {
         let openai_provider = OpenAIProvider::new(OpenAIConfig::default())?;
-        builder = builder
-            .add_provider("openai", openai_provider)
-            .add_api_key("openai", key.clone());
+        builder = builder.add_provider(
+            "openai",
+            openai_provider,
+            api_key_auth(key),
+            vec![ProviderFormat::ChatCompletions],
+        );
         println!("✅ OpenAI provider configured");
     }
 
     // Add Anthropic provider if key is available
     if let Some(key) = &anthropic_key {
         let anthropic_provider = AnthropicProvider::new(AnthropicConfig::default())?;
-        builder = builder
-            .add_provider("anthropic", anthropic_provider)
-            .add_auth(
-                "anthropic",
-                AuthConfig::ApiKey {
-                    key: key.clone(),
-                    header: Some("x-api-key".into()),
-                    prefix: None,
-                },
-            );
+        builder = builder.add_provider(
+            "anthropic",
+            anthropic_provider,
+            AuthConfig::ApiKey {
+                key: key.clone(),
+                header: Some("x-api-key".into()),
+                prefix: None,
+            },
+            vec![ProviderFormat::ChatCompletions],
+        );
         println!("✅ Anthropic provider configured");
     }
 

--- a/crates/braintrust-llm-router/examples/simple.rs
+++ b/crates/braintrust-llm-router/examples/simple.rs
@@ -7,8 +7,8 @@
 
 use anyhow::Result;
 use braintrust_llm_router::{
-    serde_json::json, ClientHeaders, ModelCatalog, OpenAIConfig, OpenAIProvider, ProviderFormat,
-    Router,
+    api_key_auth, serde_json::json, ClientHeaders, ModelCatalog, OpenAIConfig, OpenAIProvider,
+    ProviderFormat, Router,
 };
 use bytes::Bytes;
 use serde_json::Value;
@@ -37,8 +37,12 @@ async fn main() -> Result<()> {
 
     let router = Router::builder()
         .with_catalog(catalog)
-        .add_provider("openai", openai_provider)
-        .add_api_key("openai", api_key)
+        .add_provider(
+            "openai",
+            openai_provider,
+            api_key_auth(&api_key),
+            vec![ProviderFormat::ChatCompletions],
+        )
         .build()?;
 
     // Simple chat completion
@@ -57,7 +61,7 @@ async fn main() -> Result<()> {
 
     // Convert payload to bytes and send request
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let bytes = router
+    let bytes: Bytes = router
         .complete(
             body,
             model,
@@ -91,7 +95,7 @@ async fn main() -> Result<()> {
     // Print model information
     println!("\n🔍 Model Information:");
     if let Some(spec) = router.catalog().get("gpt-4") {
-        let spec = spec.as_ref();
+        let spec: &braintrust_llm_router::ModelSpec = spec.as_ref();
         println!(
             "  Display Name: {}",
             spec.display_name.as_deref().unwrap_or("GPT-4")

--- a/crates/braintrust-llm-router/examples/streaming.rs
+++ b/crates/braintrust-llm-router/examples/streaming.rs
@@ -30,14 +30,15 @@ async fn main() -> Result<()> {
 
     let router = Router::builder()
         .with_catalog(catalog)
-        .add_provider("anthropic", anthropic_provider)
-        .add_auth(
+        .add_provider(
             "anthropic",
+            anthropic_provider,
             AuthConfig::ApiKey {
                 key: anthropic_api_key,
                 header: Some("x-api-key".into()),
                 prefix: None,
             },
+            vec![ProviderFormat::ChatCompletions],
         )
         .build()?;
 
@@ -59,7 +60,7 @@ async fn main() -> Result<()> {
     });
 
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let mut stream = router
+    let mut stream: ResponseStream = router
         .complete_stream(
             body,
             model,

--- a/crates/braintrust-llm-router/src/auth/mod.rs
+++ b/crates/braintrust-llm-router/src/auth/mod.rs
@@ -50,6 +50,15 @@ pub enum AuthConfig {
     },
 }
 
+/// Convenience function to create an API key authentication configuration.
+pub fn api_key_auth(api_key: &str) -> AuthConfig {
+    AuthConfig::ApiKey {
+        key: api_key.to_string(),
+        header: Some("authorization".into()),
+        prefix: Some("Bearer".into()),
+    }
+}
+
 impl AuthConfig {
     pub fn auth_type(&self) -> AuthType {
         match self {

--- a/crates/braintrust-llm-router/src/client.rs
+++ b/crates/braintrust-llm-router/src/client.rs
@@ -40,21 +40,15 @@ pub fn build_client(settings: &ClientSettings) -> Result<Client> {
 }
 
 pub fn build_middleware_client(settings: &ClientSettings) -> Result<ClientWithMiddleware> {
+    if let Some(existing) = OVERRIDE_CLIENT.read().clone() {
+        return Ok(existing);
+    }
     let client = build_client(settings)?;
     Ok(reqwest_middleware::ClientBuilder::new(client).build())
 }
 
 static OVERRIDE_CLIENT: Lazy<RwLock<Option<ClientWithMiddleware>>> =
     Lazy::new(|| RwLock::new(None));
-
-pub fn override_client() -> Result<ClientWithMiddleware> {
-    if let Some(existing) = OVERRIDE_CLIENT.read().clone() {
-        return Ok(existing);
-    }
-    let client = build_middleware_client(&ClientSettings::default())?;
-    *OVERRIDE_CLIENT.write() = Some(client.clone());
-    Ok(client)
-}
 
 pub fn set_override_client(client: ClientWithMiddleware) {
     *OVERRIDE_CLIENT.write() = Some(client);

--- a/crates/braintrust-llm-router/src/lib.rs
+++ b/crates/braintrust-llm-router/src/lib.rs
@@ -14,6 +14,7 @@ mod streaming;
 pub use lingua::serde_json;
 
 pub use auth::{
+    api_key_auth,
     azure::{AzureEntraCredentials, AzureEntraTokenManager},
     databricks::{DatabricksCredentials, DatabricksTokenManager},
     google::{GoogleServiceAccountConfig, GoogleTokenManager, ServiceAccountKey},

--- a/crates/braintrust-llm-router/src/providers/anthropic.rs
+++ b/crates/braintrust-llm-router/src/providers/anthropic.rs
@@ -8,7 +8,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
-use crate::client::{build_middleware_client, override_client, ClientSettings};
+use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::ClientHeaders;
 use crate::streaming::{single_bytes_stream, sse_stream, RawResponseStream};
@@ -48,7 +48,7 @@ impl AnthropicProvider {
         if let Some(timeout) = config.timeout {
             settings.request_timeout = timeout;
         }
-        let client = override_client().or_else(|_| build_middleware_client(&settings))?;
+        let client = build_middleware_client(&settings)?;
         Ok(Self { client, config })
     }
 

--- a/crates/braintrust-llm-router/src/providers/azure.rs
+++ b/crates/braintrust-llm-router/src/providers/azure.rs
@@ -9,7 +9,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
-use crate::client::{build_middleware_client, override_client, ClientSettings};
+use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::ClientHeaders;
 use crate::streaming::{single_bytes_stream, sse_stream, RawResponseStream};
@@ -49,7 +49,7 @@ impl AzureProvider {
         if let Some(timeout) = config.timeout {
             settings.request_timeout = timeout;
         }
-        let client = override_client().or_else(|_| build_middleware_client(&settings))?;
+        let client = build_middleware_client(&settings)?;
         Ok(Self { client, config })
     }
 

--- a/crates/braintrust-llm-router/src/providers/bedrock.rs
+++ b/crates/braintrust-llm-router/src/providers/bedrock.rs
@@ -16,7 +16,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
-use crate::client::{build_middleware_client, override_client, ClientSettings};
+use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::ClientHeaders;
 use crate::streaming::{bedrock_event_stream, single_bytes_stream, RawResponseStream};
@@ -52,7 +52,7 @@ impl BedrockProvider {
         if let Some(timeout) = config.timeout {
             settings.request_timeout = timeout;
         }
-        let client = override_client().or_else(|_| build_middleware_client(&settings))?;
+        let client = build_middleware_client(&settings)?;
         Ok(Self { client, config })
     }
 

--- a/crates/braintrust-llm-router/src/providers/databricks.rs
+++ b/crates/braintrust-llm-router/src/providers/databricks.rs
@@ -8,7 +8,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
-use crate::client::{override_client, ClientSettings};
+use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::ClientHeaders;
 use crate::streaming::{single_bytes_stream, sse_stream, RawResponseStream};
@@ -32,8 +32,7 @@ impl DatabricksProvider {
         if let Some(timeout) = config.timeout {
             settings.request_timeout = timeout;
         }
-        let client =
-            override_client().or_else(|_| crate::client::build_middleware_client(&settings))?;
+        let client = build_middleware_client(&settings)?;
         Ok(Self { client, config })
     }
 

--- a/crates/braintrust-llm-router/src/providers/google.rs
+++ b/crates/braintrust-llm-router/src/providers/google.rs
@@ -8,7 +8,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
-use crate::client::{build_middleware_client, override_client, ClientSettings};
+use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::ClientHeaders;
 use crate::streaming::{single_bytes_stream, sse_stream, RawResponseStream};
@@ -42,7 +42,7 @@ impl GoogleProvider {
         if let Some(timeout) = config.timeout {
             settings.request_timeout = timeout;
         }
-        let client = override_client().or_else(|_| build_middleware_client(&settings))?;
+        let client = build_middleware_client(&settings)?;
         Ok(Self { client, config })
     }
 

--- a/crates/braintrust-llm-router/src/providers/mistral.rs
+++ b/crates/braintrust-llm-router/src/providers/mistral.rs
@@ -8,7 +8,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
-use crate::client::{build_middleware_client, override_client, ClientSettings};
+use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::ClientHeaders;
 use crate::streaming::{single_bytes_stream, sse_stream, RawResponseStream};
@@ -41,8 +41,7 @@ impl MistralProvider {
         if let Some(timeout) = config.timeout {
             settings.request_timeout = timeout;
         }
-        let client = override_client().or_else(|_| build_middleware_client(&settings))?;
-
+        let client = build_middleware_client(&settings)?;
         Ok(Self { client, config })
     }
 

--- a/crates/braintrust-llm-router/src/providers/openai.rs
+++ b/crates/braintrust-llm-router/src/providers/openai.rs
@@ -9,7 +9,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
-use crate::client::{build_middleware_client, override_client, ClientSettings};
+use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::ClientHeaders;
 use crate::streaming::{single_bytes_stream, sse_stream, RawResponseStream};
@@ -51,7 +51,7 @@ impl OpenAIProvider {
         if let Some(timeout) = config.timeout {
             settings.request_timeout = timeout;
         }
-        let client = override_client().or_else(|_| build_middleware_client(&settings))?;
+        let client = build_middleware_client(&settings)?;
         let endpoint_template = config.endpoint_template.clone();
         Ok(Self {
             client,

--- a/crates/braintrust-llm-router/src/providers/vertex.rs
+++ b/crates/braintrust-llm-router/src/providers/vertex.rs
@@ -9,7 +9,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
-use crate::client::{build_middleware_client, override_client, ClientSettings};
+use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::ClientHeaders;
 use crate::streaming::{single_bytes_stream, sse_stream, RawResponseStream};
@@ -49,7 +49,7 @@ impl VertexProvider {
         if let Some(timeout) = config.timeout {
             settings.request_timeout = timeout;
         }
-        let client = override_client().or_else(|_| build_middleware_client(&settings))?;
+        let client = build_middleware_client(&settings)?;
         Ok(Self { client, config })
     }
 

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -110,8 +110,8 @@ pub struct Router {
     catalog: Arc<ModelCatalog>,
     resolver: ModelResolver,
     providers: HashMap<String, Arc<dyn Provider>>, // alias -> provider
-    formats: HashMap<ProviderFormat, String>,      // format -> alias
     auth_configs: HashMap<String, AuthConfig>,     // alias -> auth
+    formats: HashMap<ProviderFormat, String>,      // format -> default alias
     retry_policy: RetryPolicy,
 }
 
@@ -347,11 +347,12 @@ impl Router {
     }
 }
 
+/// One provider registration: alias, provider, auth, and default formats.
+type ProviderEntry = (String, Arc<dyn Provider>, AuthConfig, Vec<ProviderFormat>);
+
 pub struct RouterBuilder {
     catalog: Option<Arc<ModelCatalog>>,
-    providers: HashMap<String, Arc<dyn Provider>>,
-    formats: HashMap<ProviderFormat, String>,
-    auth_configs: HashMap<String, AuthConfig>,
+    provider_entries: Vec<ProviderEntry>,
     retry_policy: RetryPolicy,
 }
 
@@ -365,9 +366,7 @@ impl RouterBuilder {
     pub fn new() -> Self {
         Self {
             catalog: None,
-            providers: HashMap::new(),
-            formats: HashMap::new(),
-            auth_configs: HashMap::new(),
+            provider_entries: Vec::new(),
             retry_policy: RetryPolicy::default(),
         }
     }
@@ -388,15 +387,18 @@ impl RouterBuilder {
         self
     }
 
-    pub fn add_provider<P>(mut self, alias: impl Into<String>, provider: P) -> Self
+    pub fn add_provider<P>(
+        mut self,
+        alias: impl Into<String>,
+        provider: P,
+        auth: AuthConfig,
+        default_for_formats: Vec<ProviderFormat>,
+    ) -> Self
     where
         P: Provider + 'static,
     {
-        let alias = alias.into();
-        for format in provider.provider_formats() {
-            self.formats.insert(format, alias.clone());
-        }
-        self.providers.insert(alias, Arc::new(provider));
+        self.provider_entries
+            .push((alias.into(), Arc::new(provider), auth, default_for_formats));
         self
     }
 
@@ -405,29 +407,11 @@ impl RouterBuilder {
         mut self,
         alias: impl Into<String>,
         provider: Arc<dyn Provider>,
+        auth: AuthConfig,
+        default_for_formats: Vec<ProviderFormat>,
     ) -> Self {
-        let alias = alias.into();
-        for format in provider.provider_formats() {
-            self.formats.insert(format, alias.clone());
-        }
-        self.providers.insert(alias, provider);
-        self
-    }
-
-    pub fn add_auth(mut self, alias: impl Into<String>, auth: AuthConfig) -> Self {
-        self.auth_configs.insert(alias.into(), auth);
-        self
-    }
-
-    pub fn add_api_key(mut self, alias: impl Into<String>, key: impl Into<String>) -> Self {
-        self.auth_configs.insert(
-            alias.into(),
-            AuthConfig::ApiKey {
-                key: key.into(),
-                header: Some("authorization".into()),
-                prefix: Some("Bearer".into()),
-            },
-        );
+        self.provider_entries
+            .push((alias.into(), provider, auth, default_for_formats));
         self
     }
 
@@ -437,12 +421,43 @@ impl RouterBuilder {
             .ok_or_else(|| Error::InvalidRequest("model catalog not configured".into()))?;
         let resolver = ModelResolver::new(Arc::clone(&catalog));
 
+        let mut providers = HashMap::new();
+        let mut auth_configs = HashMap::new();
+        let mut formats = HashMap::new();
+        let mut backup_formats = HashMap::new();
+        for (alias, provider, auth, default_for_formats) in self.provider_entries {
+            if providers.contains_key(&alias) {
+                return Err(Error::InvalidRequest(format!(
+                    "provider alias already exists: {alias}"
+                )));
+            }
+            providers.insert(alias.clone(), provider.clone());
+            auth_configs.insert(alias.clone(), auth);
+
+            for format in default_for_formats {
+                if let Some(existing_alias) = formats.get(&format) {
+                    return Err(Error::InvalidRequest(format!("format already has a default provider: {format}: {existing_alias}, {alias}")));
+                }
+                formats.insert(format, alias.clone());
+            }
+            for format in provider.provider_formats() {
+                backup_formats
+                    .entry(format)
+                    .or_insert_with(|| alias.clone());
+            }
+        }
+        // Do a second pass to find any formats with no default provider, and
+        // add a default provider chosen at random.
+        for (format, alias) in backup_formats {
+            formats.entry(format).or_insert(alias);
+        }
+
         Ok(Router {
             catalog,
             resolver,
-            providers: self.providers,
-            formats: self.formats,
-            auth_configs: self.auth_configs,
+            providers,
+            formats,
+            auth_configs,
             retry_policy: self.retry_policy,
         })
     }
@@ -452,6 +467,7 @@ impl RouterBuilder {
 mod tests {
     use super::*;
     use crate::catalog::{ModelCatalog, ModelFlavor, ModelSpec};
+    use crate::error::Error;
     use crate::streaming::RawResponseStream;
     use async_trait::async_trait;
     use reqwest::header::HeaderMap;
@@ -565,6 +581,8 @@ mod tests {
                     name: "google",
                     formats: vec![ProviderFormat::Google],
                 },
+                dummy_auth(),
+                vec![ProviderFormat::Google],
             )
             .add_provider(
                 "vertex",
@@ -572,9 +590,9 @@ mod tests {
                     name: "vertex",
                     formats: vec![ProviderFormat::Google],
                 },
+                dummy_auth(),
+                vec![], // not default; vertex models resolved via catalog
             )
-            .add_auth("google", dummy_auth())
-            .add_auth("vertex", dummy_auth())
             .build()
             .expect("router builds");
 
@@ -597,8 +615,9 @@ mod tests {
                     name: "google",
                     formats: vec![ProviderFormat::Google],
                 },
+                dummy_auth(),
+                vec![ProviderFormat::Google],
             )
-            .add_auth("google", dummy_auth())
             .build()
             .expect("router builds");
 
@@ -618,8 +637,9 @@ mod tests {
                     name: "openai",
                     formats: vec![ProviderFormat::ChatCompletions, ProviderFormat::Responses],
                 },
+                dummy_auth(),
+                vec![ProviderFormat::ChatCompletions, ProviderFormat::Responses],
             )
-            .add_auth("openai", dummy_auth())
             .build()
             .expect("router builds");
 
@@ -642,8 +662,9 @@ mod tests {
                     name: "openai",
                     formats: vec![ProviderFormat::ChatCompletions, ProviderFormat::Responses],
                 },
+                dummy_auth(),
+                vec![ProviderFormat::ChatCompletions, ProviderFormat::Responses],
             )
-            .add_auth("openai", dummy_auth())
             .build()
             .expect("router builds");
 
@@ -666,8 +687,9 @@ mod tests {
                     name: "openai",
                     formats: vec![ProviderFormat::ChatCompletions, ProviderFormat::Responses],
                 },
+                dummy_auth(),
+                vec![ProviderFormat::ChatCompletions, ProviderFormat::Responses],
             )
-            .add_auth("openai", dummy_auth())
             .build()
             .expect("router builds");
 
@@ -690,8 +712,9 @@ mod tests {
                     name: "openai",
                     formats: vec![ProviderFormat::ChatCompletions],
                 },
+                dummy_auth(),
+                vec![ProviderFormat::ChatCompletions],
             )
-            .add_auth("openai", dummy_auth())
             .build()
             .expect("router builds");
 
@@ -699,5 +722,101 @@ mod tests {
             .resolve_provider(model, ProviderFormat::ChatCompletions)
             .expect("resolves");
         assert_eq!(format, ProviderFormat::ChatCompletions);
+    }
+
+    #[test]
+    fn build_fails_when_provider_alias_duplicated() {
+        let catalog = Arc::new(ModelCatalog::empty());
+        let result = Router::builder()
+            .with_catalog(Arc::clone(&catalog))
+            .add_provider(
+                "openai",
+                FakeProvider {
+                    name: "openai",
+                    formats: vec![],
+                },
+                dummy_auth(),
+                vec![ProviderFormat::ChatCompletions],
+            )
+            .add_provider(
+                "openai",
+                FakeProvider {
+                    name: "openai2",
+                    formats: vec![],
+                },
+                dummy_auth(),
+                vec![],
+            )
+            .build();
+        let err = match result {
+            Ok(_) => panic!("expected duplicate alias error"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, Error::InvalidRequest(ref msg) if msg.contains("provider alias already exists") && msg.contains("openai")),
+            "expected InvalidRequest about duplicate alias, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn build_fails_when_format_has_two_default_providers() {
+        let catalog = Arc::new(ModelCatalog::empty());
+        let result = Router::builder()
+            .with_catalog(Arc::clone(&catalog))
+            .add_provider(
+                "openai",
+                FakeProvider {
+                    name: "openai",
+                    formats: vec![ProviderFormat::ChatCompletions],
+                },
+                dummy_auth(),
+                vec![ProviderFormat::ChatCompletions],
+            )
+            .add_provider(
+                "openai2",
+                FakeProvider {
+                    name: "openai2",
+                    formats: vec![ProviderFormat::ChatCompletions],
+                },
+                dummy_auth(),
+                vec![ProviderFormat::ChatCompletions],
+            )
+            .build();
+        let err = match result {
+            Ok(_) => panic!("expected duplicate default for format error"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, Error::InvalidRequest(ref msg) if msg.contains("format already has a default provider") && msg.contains("openai") && msg.contains("openai2")),
+            "expected InvalidRequest about format already has default, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn build_succeeds_when_same_format_multiple_providers_only_one_default() {
+        let catalog = Arc::new(ModelCatalog::empty());
+        let router = Router::builder()
+            .with_catalog(Arc::clone(&catalog))
+            .add_provider(
+                "openai",
+                FakeProvider {
+                    name: "openai",
+                    formats: vec![ProviderFormat::ChatCompletions],
+                },
+                dummy_auth(),
+                vec![ProviderFormat::ChatCompletions],
+            )
+            .add_provider(
+                "openai2",
+                FakeProvider {
+                    name: "openai2",
+                    formats: vec![ProviderFormat::ChatCompletions],
+                },
+                dummy_auth(),
+                vec![], // not default
+            )
+            .build()
+            .expect("router builds");
+        assert!(router.catalog().get("any").is_none());
     }
 }

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -348,7 +348,12 @@ impl Router {
 }
 
 /// One provider registration: alias, provider, auth, and default formats.
-type ProviderEntry = (String, Arc<dyn Provider>, AuthConfig, Vec<ProviderFormat>);
+struct ProviderEntry {
+    alias: String,
+    provider: Arc<dyn Provider>,
+    auth: AuthConfig,
+    default_for_formats: Vec<ProviderFormat>,
+}
 
 pub struct RouterBuilder {
     catalog: Option<Arc<ModelCatalog>>,
@@ -397,8 +402,12 @@ impl RouterBuilder {
     where
         P: Provider + 'static,
     {
-        self.provider_entries
-            .push((alias.into(), Arc::new(provider), auth, default_for_formats));
+        self.provider_entries.push(ProviderEntry {
+            alias: alias.into(),
+            provider: Arc::new(provider),
+            auth,
+            default_for_formats,
+        });
         self
     }
 
@@ -410,8 +419,12 @@ impl RouterBuilder {
         auth: AuthConfig,
         default_for_formats: Vec<ProviderFormat>,
     ) -> Self {
-        self.provider_entries
-            .push((alias.into(), provider, auth, default_for_formats));
+        self.provider_entries.push(ProviderEntry {
+            alias: alias.into(),
+            provider,
+            auth,
+            default_for_formats,
+        });
         self
     }
 
@@ -425,25 +438,34 @@ impl RouterBuilder {
         let mut auth_configs = HashMap::new();
         let mut formats = HashMap::new();
         let mut backup_formats = HashMap::new();
-        for (alias, provider, auth, default_for_formats) in self.provider_entries {
-            if providers.contains_key(&alias) {
+        for entry in self.provider_entries {
+            if providers.contains_key(&entry.alias) {
                 return Err(Error::InvalidRequest(format!(
-                    "provider alias already exists: {alias}"
+                    "provider alias already exists: {}",
+                    entry.alias
                 )));
             }
-            providers.insert(alias.clone(), provider.clone());
-            auth_configs.insert(alias.clone(), auth);
+            providers.insert(entry.alias.clone(), entry.provider.clone());
+            auth_configs.insert(entry.alias.clone(), entry.auth);
 
-            for format in default_for_formats {
+            for format in entry.default_for_formats {
                 if let Some(existing_alias) = formats.get(&format) {
-                    return Err(Error::InvalidRequest(format!("format already has a default provider: {format}: {existing_alias}, {alias}")));
+                    return Err(Error::InvalidRequest(format!(
+                        "format already has a default provider: {format}: {existing_alias}, {}",
+                        entry.alias
+                    )));
                 }
-                formats.insert(format, alias.clone());
+                formats.insert(format, entry.alias.clone());
             }
-            for format in provider.provider_formats() {
+            for format in entry.provider.provider_formats() {
+                #[cfg(feature = "tracing")]
+                tracing::debug!(
+                    "adding backup format: {format} -> {alias}",
+                    alias = entry.alias
+                );
                 backup_formats
                     .entry(format)
-                    .or_insert_with(|| alias.clone());
+                    .or_insert_with(|| entry.alias.clone());
             }
         }
         // Do a second pass to find any formats with no default provider, and

--- a/crates/braintrust-llm-router/tests/router.rs
+++ b/crates/braintrust-llm-router/tests/router.rs
@@ -111,14 +111,15 @@ async fn router_routes_to_stub_provider() {
     let router = RouterBuilder::new()
         .with_catalog(Arc::clone(&catalog))
         .with_retry_policy(RetryPolicy::default())
-        .add_provider("stub", StubProvider)
-        .add_auth(
+        .add_provider(
             "stub",
+            StubProvider,
             AuthConfig::ApiKey {
                 key: "test".into(),
                 header: Some("authorization".into()),
                 prefix: Some("Bearer".into()),
             },
+            vec![ProviderFormat::ChatCompletions],
         )
         .build()
         .expect("router builds");
@@ -132,7 +133,7 @@ async fn router_routes_to_stub_provider() {
         ]
     }));
 
-    let bytes = router
+    let bytes: Bytes = router
         .complete(
             body,
             model,
@@ -177,7 +178,16 @@ async fn router_requires_auth_for_provider() {
 
     let router = RouterBuilder::new()
         .with_catalog(Arc::clone(&catalog))
-        .add_provider("stub", StubProvider)
+        .add_provider(
+            "stub",
+            StubProvider,
+            AuthConfig::ApiKey {
+                key: "test".into(),
+                header: Some("authorization".into()),
+                prefix: Some("Bearer".into()),
+            },
+            vec![ProviderFormat::ChatCompletions],
+        )
         .build()
         .expect("router builds");
 
@@ -187,7 +197,7 @@ async fn router_requires_auth_for_provider() {
         "messages": [{"role": "user", "content": "Ping"}]
     }));
 
-    let err = router
+    let bytes: Bytes = router
         .complete(
             body,
             model,
@@ -195,8 +205,13 @@ async fn router_requires_auth_for_provider() {
             &ClientHeaders::default(),
         )
         .await
-        .expect_err("missing auth");
-    assert!(matches!(err, Error::NoAuth(alias) if alias == "stub"));
+        .expect("complete succeeds when auth is configured");
+    let response: Value =
+        braintrust_llm_router::serde_json::from_slice(&bytes).expect("valid json");
+    assert_eq!(
+        response.get("model").and_then(Value::as_str),
+        Some("stub-model")
+    );
 }
 
 #[tokio::test]
@@ -252,14 +267,15 @@ async fn router_reports_missing_provider() {
 async fn router_propagates_validation_errors() {
     let router = RouterBuilder::new()
         .with_catalog(Arc::new(ModelCatalog::empty()))
-        .add_provider("stub", StubProvider)
-        .add_auth(
+        .add_provider(
             "stub",
+            StubProvider,
             AuthConfig::ApiKey {
                 key: "test".into(),
                 header: None,
                 prefix: None,
             },
+            vec![ProviderFormat::ChatCompletions],
         )
         .build()
         .expect("router builds");
@@ -269,15 +285,15 @@ async fn router_propagates_validation_errors() {
         "model": "",
         "messages": []
     }));
-    let err = router
+    let err: braintrust_llm_router::Result<Bytes> = router
         .complete(
             body,
             "",
             ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )
-        .await
-        .expect_err("validation");
+        .await;
+    let err = err.expect_err("validation");
     // Empty model is treated as unknown model, not invalid request
     assert!(matches!(err, Error::UnknownModel(_)));
 }
@@ -366,14 +382,12 @@ async fn router_retries_and_propagates_terminal_error() {
             FailingProvider {
                 attempts: Arc::clone(&attempts),
             },
-        )
-        .add_auth(
-            "failing",
             AuthConfig::ApiKey {
                 key: "test".into(),
                 header: None,
                 prefix: None,
             },
+            vec![ProviderFormat::ChatCompletions],
         )
         .build()
         .expect("router builds");
@@ -384,15 +398,15 @@ async fn router_retries_and_propagates_terminal_error() {
         "messages": [{"role": "user", "content": "Ping"}]
     }));
 
-    let err = router
+    let err: braintrust_llm_router::Result<Bytes> = router
         .complete(
             body,
             model,
             ProviderFormat::ChatCompletions,
             &ClientHeaders::default(),
         )
-        .await
-        .expect_err("terminal error");
+        .await;
+    let err = err.expect_err("terminal error");
     assert!(matches!(err, Error::Timeout));
     assert_eq!(attempts.load(Ordering::SeqCst), 3);
 }


### PR DESCRIPTION
Currently the router builder silently drops duplicate entries, solve this by
returning an error if the builder sees that. Also explicitly set default format
-> provider mappings, and also error if there are duplicate entries in the
builder there.

Also clean up some override client stuff.