### PR TITLE
Fix using anthropic models with responses API in AI SDK

### DIFF
--- a/crates/braintrust-llm-router/src/providers/anthropic.rs
+++ b/crates/braintrust-llm-router/src/providers/anthropic.rs
@@ -124,35 +124,23 @@ impl crate::providers::Provider for AnthropicProvider {
     ) -> Result<Bytes> {
         let url = self.messages_url();
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "anthropic",
-            http_url = %url,
-            "sending request to Anthropic"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "anthropic",
-            http_status_code = status_code,
-            "received response from Anthropic"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();
@@ -191,37 +179,23 @@ impl crate::providers::Provider for AnthropicProvider {
         // Router should have already added stream options to payload
         let url = self.messages_url();
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "anthropic",
-            http_url = %url,
-            llm_streaming = true,
-            "sending streaming request to Anthropic"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "anthropic",
-            http_status_code = status_code,
-            llm_streaming = true,
-            "received streaming response from Anthropic"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();

--- a/crates/braintrust-llm-router/src/providers/azure.rs
+++ b/crates/braintrust-llm-router/src/providers/azure.rs
@@ -155,35 +155,23 @@ impl crate::providers::Provider for AzureProvider {
     ) -> Result<Bytes> {
         let url = self.chat_url(&spec.model)?;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "azure",
-            http_url = %url,
-            "sending request to Azure"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "azure",
-            http_status_code = status_code,
-            "received response from Azure"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();
@@ -222,37 +210,23 @@ impl crate::providers::Provider for AzureProvider {
         // Router should have already added stream options to payload
         let url = self.chat_url(&spec.model)?;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "azure",
-            http_url = %url,
-            llm_streaming = true,
-            "sending streaming request to Azure"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "azure",
-            http_status_code = status_code,
-            llm_streaming = true,
-            "received streaming response from Azure"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();

--- a/crates/braintrust-llm-router/src/providers/bedrock.rs
+++ b/crates/braintrust-llm-router/src/providers/bedrock.rs
@@ -221,38 +221,23 @@ impl BedrockProvider {
         url: Url,
         payload: Bytes,
         auth: &AuthConfig,
-        stream: bool,
         client_headers: &ClientHeaders,
     ) -> Result<reqwest::Response> {
-        #[cfg(not(feature = "tracing"))]
-        let _ = stream;
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "bedrock",
-            http_url = %url,
-            llm_streaming = stream,
-            "sending request to Bedrock"
-        );
-
         let headers = self.build_headers(&url, payload.as_ref(), auth, client_headers)?;
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "bedrock",
-            http_status_code = response.status().as_u16(),
-            llm_streaming = stream,
-            "received response from Bedrock"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();
@@ -294,9 +279,7 @@ impl crate::providers::Provider for BedrockProvider {
         } else {
             self.converse_url(&spec.model, false)?
         };
-        let response = self
-            .send_signed(url, payload, auth, false, client_headers)
-            .await?;
+        let response = self.send_signed(url, payload, auth, client_headers).await?;
         Ok(response.bytes().await?)
     }
 
@@ -322,9 +305,7 @@ impl crate::providers::Provider for BedrockProvider {
             self.converse_url(&spec.model, true)?
         };
 
-        let response = self
-            .send_signed(url, payload, auth, true, client_headers)
-            .await?;
+        let response = self.send_signed(url, payload, auth, client_headers).await?;
         Ok(bedrock_event_stream(response))
     }
 

--- a/crates/braintrust-llm-router/src/providers/databricks.rs
+++ b/crates/braintrust-llm-router/src/providers/databricks.rs
@@ -88,35 +88,23 @@ impl crate::providers::Provider for DatabricksProvider {
     ) -> Result<Bytes> {
         let url = self.serving_url(&spec.model)?;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "databricks",
-            http_url = %url,
-            "sending request to Databricks"
-        );
-
         let mut headers = client_headers.to_json_headers();
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "databricks",
-            http_status_code = status_code,
-            "received response from Databricks"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();
@@ -154,37 +142,23 @@ impl crate::providers::Provider for DatabricksProvider {
 
         let url = self.serving_url(&spec.model)?;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "databricks",
-            http_url = %url,
-            llm_streaming = true,
-            "sending streaming request to Databricks"
-        );
-
         let mut headers = client_headers.to_json_headers();
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "databricks",
-            http_status_code = status_code,
-            llm_streaming = true,
-            "received streaming response from Databricks"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();

--- a/crates/braintrust-llm-router/src/providers/google.rs
+++ b/crates/braintrust-llm-router/src/providers/google.rs
@@ -101,35 +101,23 @@ impl crate::providers::Provider for GoogleProvider {
     ) -> Result<Bytes> {
         let url = self.generate_url(&spec.model, false)?;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "google",
-            http_url = %url,
-            "sending request to Google"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "google",
-            http_status_code = status_code,
-            "received response from Google"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();
@@ -168,37 +156,23 @@ impl crate::providers::Provider for GoogleProvider {
         // Note: Google uses endpoint-based streaming (:streamGenerateContent), not body parameter
         let url = self.generate_url(&spec.model, true)?;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "google",
-            http_url = %url,
-            llm_streaming = true,
-            "sending streaming request to Google"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "google",
-            http_status_code = status_code,
-            llm_streaming = true,
-            "received streaming response from Google"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();

--- a/crates/braintrust-llm-router/src/providers/mistral.rs
+++ b/crates/braintrust-llm-router/src/providers/mistral.rs
@@ -103,35 +103,23 @@ impl crate::providers::Provider for MistralProvider {
     ) -> Result<Bytes> {
         let url = self.chat_url()?;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "mistral",
-            http_url = %url,
-            "sending request to Mistral"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "mistral",
-            http_status_code = status_code,
-            "received response from Mistral"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();
@@ -170,37 +158,23 @@ impl crate::providers::Provider for MistralProvider {
         // Router should have already added stream options to payload
         let url = self.chat_url()?;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "mistral",
-            http_url = %url,
-            llm_streaming = true,
-            "sending streaming request to Mistral"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "mistral",
-            http_status_code = status_code,
-            llm_streaming = true,
-            "received streaming response from Mistral"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();

--- a/crates/braintrust-llm-router/src/providers/openai.rs
+++ b/crates/braintrust-llm-router/src/providers/openai.rs
@@ -192,35 +192,23 @@ impl crate::providers::Provider for OpenAIProvider {
             _ => self.chat_url(Some(&spec.model))?,
         };
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "openai",
-            http_url = %url,
-            "sending request to OpenAI"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "openai",
-            http_status_code = status_code,
-            "received response from OpenAI"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();
@@ -262,37 +250,23 @@ impl crate::providers::Provider for OpenAIProvider {
             _ => self.chat_url(Some(&spec.model))?,
         };
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "openai",
-            http_url = %url,
-            llm_streaming = true,
-            "sending streaming request to OpenAI"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "openai",
-            http_status_code = status_code,
-            llm_streaming = true,
-            "received streaming response from OpenAI"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();

--- a/crates/braintrust-llm-router/src/providers/vertex.rs
+++ b/crates/braintrust-llm-router/src/providers/vertex.rs
@@ -184,35 +184,23 @@ impl crate::providers::Provider for VertexProvider {
         let mode = self.determine_mode(&spec.model);
         let url = self.endpoint_for_mode(&mode, false)?;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "vertex",
-            http_url = %url,
-            "sending request to Vertex"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "vertex",
-            http_status_code = status_code,
-            "received response from Vertex"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();
@@ -251,38 +239,24 @@ impl crate::providers::Provider for VertexProvider {
         let mode = self.determine_mode(&spec.model);
         let url = self.endpoint_for_mode(&mode, true)?;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "vertex",
-            http_url = %url,
-            llm_streaming = true,
-            "sending streaming request to Vertex"
-        );
-
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
         // Router should have already added stream options to payload
         let response = self
             .client
-            .post(url)
+            .post(url.clone())
             .headers(headers)
             .body(payload)
             .send()
             .await?;
 
         #[cfg(feature = "tracing")]
-        let status_code = response.status().as_u16();
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            target: "bt.router.provider.http",
-            llm_provider = "vertex",
-            http_status_code = status_code,
-            llm_streaming = true,
-            "received streaming response from Vertex"
-        );
+        {
+            let span = tracing::Span::current();
+            span.record("http.url", tracing::field::display(&url));
+            span.record("http.status_code", response.status().as_u16());
+        }
 
         if !response.status().is_success() {
             let status = response.status();

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -202,7 +202,7 @@ impl Router {
         tracing::instrument(
             name = "bt.router.complete_stream",
             skip(self, body, client_headers),
-            fields(llm.model = %model)
+            fields(llm.model = %model, http.url = tracing::field::Empty, http.status_code = tracing::field::Empty)
         )
     )]
     pub async fn complete_stream(
@@ -409,6 +409,8 @@ impl Router {
                     "bt.router.provider.attempt",
                     llm.provider = %provider.id(),
                     attempt = attempt,
+                    http.url = tracing::field::Empty,
+                    http.status_code = tracing::field::Empty,
                 );
                 async {
                     provider

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -480,7 +480,7 @@ impl ProviderAdapter for AnthropicAdapter {
         let usage = UniversalUsage::extract_from_response(&payload, self.format());
 
         Ok(UniversalResponse {
-            id: payload.get("id").and_then(Value::as_str).map(String::from),
+            id: UniversalResponse::extract_id_from_payload(&payload),
             id_format: Some(self.format()),
             model: payload
                 .get("model")

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -480,6 +480,8 @@ impl ProviderAdapter for AnthropicAdapter {
         let usage = UniversalUsage::extract_from_response(&payload, self.format());
 
         Ok(UniversalResponse {
+            id: payload.get("id").and_then(Value::as_str).map(String::from),
+            id_format: Some(self.format()),
             model: payload
                 .get("model")
                 .and_then(Value::as_str)
@@ -505,10 +507,7 @@ impl ProviderAdapter for AnthropicAdapter {
             .unwrap_or_else(|| "end_turn".to_string());
 
         let mut map = serde_json::Map::new();
-        map.insert(
-            "id".into(),
-            Value::String(format!("msg_{}", PLACEHOLDER_ID)),
-        );
+        map.insert("id".into(), Value::String(resp.id_for(self.format())));
         map.insert("type".into(), Value::String("message".into()));
         map.insert("role".into(), Value::String("assistant".into()));
         map.insert("content".into(), content_value);

--- a/crates/lingua/src/providers/bedrock/adapter.rs
+++ b/crates/lingua/src/providers/bedrock/adapter.rs
@@ -321,6 +321,8 @@ impl ProviderAdapter for BedrockAdapter {
         let usage = UniversalUsage::extract_from_response(&payload, self.format());
 
         Ok(UniversalResponse {
+            id: payload.get("id").and_then(Value::as_str).map(String::from),
+            id_format: Some(self.format()),
             model: None, // Bedrock doesn't include model in response
             messages,
             usage,

--- a/crates/lingua/src/providers/bedrock/adapter.rs
+++ b/crates/lingua/src/providers/bedrock/adapter.rs
@@ -321,7 +321,7 @@ impl ProviderAdapter for BedrockAdapter {
         let usage = UniversalUsage::extract_from_response(&payload, self.format());
 
         Ok(UniversalResponse {
-            id: payload.get("id").and_then(Value::as_str).map(String::from),
+            id: UniversalResponse::extract_id_from_payload(&payload),
             id_format: Some(self.format()),
             model: None, // Bedrock doesn't include model in response
             messages,

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -416,6 +416,8 @@ impl ProviderAdapter for GoogleAdapter {
         let usage = response.usage_metadata.as_ref().map(UniversalUsage::from);
 
         Ok(UniversalResponse {
+            id: None, // Google doesn't include a top-level response ID
+            id_format: None,
             model: response.model_version,
             messages,
             usage,

--- a/crates/lingua/src/providers/openai/adapter.rs
+++ b/crates/lingua/src/providers/openai/adapter.rs
@@ -28,7 +28,7 @@ use crate::universal::request::{ReasoningConfig, ReasoningEffort, TokenBudget};
 use crate::universal::tools::tools_to_openai_chat_value;
 use crate::universal::{
     parse_stop_sequences, UniversalParams, UniversalRequest, UniversalResponse,
-    UniversalStreamChoice, UniversalStreamChunk, UniversalUsage, PLACEHOLDER_ID, PLACEHOLDER_MODEL,
+    UniversalStreamChoice, UniversalStreamChunk, UniversalUsage, PLACEHOLDER_MODEL,
 };
 use std::convert::TryInto;
 
@@ -380,6 +380,8 @@ impl ProviderAdapter for OpenAIAdapter {
         let usage = UniversalUsage::extract_from_response(&payload, self.format());
 
         Ok(UniversalResponse {
+            id: payload.get("id").and_then(Value::as_str).map(String::from),
+            id_format: Some(self.format()),
             model: payload
                 .get("model")
                 .and_then(Value::as_str)
@@ -424,10 +426,7 @@ impl ProviderAdapter for OpenAIAdapter {
             .map(|u| u.to_provider_value(self.format()));
 
         let mut map = serde_json::Map::new();
-        map.insert(
-            "id".into(),
-            Value::String(format!("chatcmpl-{}", PLACEHOLDER_ID)),
-        );
+        map.insert("id".into(), Value::String(resp.id_for(self.format())));
         map.insert("object".into(), Value::String("chat.completion".into()));
         map.insert("created".into(), serde_json::json!(0));
         map.insert(

--- a/crates/lingua/src/providers/openai/adapter.rs
+++ b/crates/lingua/src/providers/openai/adapter.rs
@@ -380,7 +380,7 @@ impl ProviderAdapter for OpenAIAdapter {
         let usage = UniversalUsage::extract_from_response(&payload, self.format());
 
         Ok(UniversalResponse {
-            id: payload.get("id").and_then(Value::as_str).map(String::from),
+            id: UniversalResponse::extract_id_from_payload(&payload),
             id_format: Some(self.format()),
             model: payload
                 .get("model")

--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -6,7 +6,7 @@ use crate::providers::openai::generated as openai;
 use crate::providers::openai::params::OpenAIResponsesExtrasView;
 use crate::serde_json;
 use crate::universal::convert::TryFromLLM;
-use crate::universal::defaults::{EMPTY_OBJECT_STR, REFUSAL_TEXT};
+use crate::universal::defaults::{EMPTY_OBJECT_STR, PLACEHOLDER_ID, REFUSAL_TEXT};
 use crate::universal::{
     AssistantContent, AssistantContentPart, Message, ProviderOptions, TextContentPart,
     ToolCallArguments, ToolContentPart, ToolResultContentPart, UserContent, UserContentPart,
@@ -2007,11 +2007,16 @@ impl TryFromLLM<Vec<openai::OutputItem>> for Vec<Message> {
                     if let Some(content) = item.content {
                         for c in content {
                             if let Some(text) = c.text {
-                                // Preserve annotations and logprobs in provider_options
+                                // Preserve logprobs and non-empty annotations in
+                                // provider_options for round-trip fidelity.
+                                // Empty `annotations` arrays are the Responses API default
+                                // injected by `response_from_universal`, so they are not
+                                // stored back to keep the universal representation clean.
+                                let non_empty_annotations = c.annotations.filter(|a| !a.is_empty());
                                 let provider_options =
-                                    if c.annotations.is_some() || c.logprobs.is_some() {
+                                    if non_empty_annotations.is_some() || c.logprobs.is_some() {
                                         let mut options = serde_json::Map::new();
-                                        if let Some(annotations) = c.annotations {
+                                        if let Some(annotations) = non_empty_annotations {
                                             if let Ok(value) = serde_json::to_value(&annotations) {
                                                 options.insert("annotations".to_string(), value);
                                             }
@@ -2247,7 +2252,7 @@ impl TryFromLLM<Vec<Message>> for Vec<openai::OutputItem> {
                             content: Some(vec![openai::OutputMessageContent {
                                 output_message_content_type: openai::ContentType::OutputText,
                                 text: Some(text),
-                                annotations: None,
+                                annotations: Some(vec![]),
                                 logprobs: None,
                                 refusal: None,
                             }]),
@@ -2313,7 +2318,9 @@ impl TryFromLLM<Vec<Message>> for Vec<openai::OutputItem> {
                                         &mut id_used,
                                         &id,
                                     );
-                                    // Extract annotations and logprobs from provider_options
+                                    // Extract annotations and logprobs from provider_options.
+                                    // Default annotations to Some(vec![]) so the Responses API
+                                    // output always has the required `annotations` array.
                                     let (annotations, logprobs) = if let Some(ref opts) =
                                         text_part.provider_options
                                     {
@@ -2330,9 +2337,9 @@ impl TryFromLLM<Vec<Message>> for Vec<openai::OutputItem> {
                                             )
                                             .ok()
                                         });
-                                        (annotations, logprobs)
+                                        (annotations.or(Some(vec![])), logprobs)
                                     } else {
-                                        (None, None)
+                                        (Some(vec![]), None)
                                     };
                                     result.push(openai::OutputItem {
                                         output_item_type: Some(openai::OutputItemType::Message),
@@ -2575,6 +2582,15 @@ impl TryFromLLM<Vec<Message>> for Vec<openai::OutputItem> {
                         );
                     }
                 }
+            }
+        }
+
+        // Fill in placeholder IDs for any items that don't have one.
+        // Responses API requires every output item to have an id; sources like
+        // Anthropic carry only a response-level id, not per-item ids.
+        for (i, item) in result.iter_mut().enumerate() {
+            if item.id.is_none() {
+                item.id = Some(format!("msg_{}_item_{}", PLACEHOLDER_ID, i));
             }
         }
 

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -424,6 +424,8 @@ impl ProviderAdapter for ResponsesAdapter {
         let usage = UniversalUsage::extract_from_response(&payload, self.format());
 
         Ok(UniversalResponse {
+            id: payload.get("id").and_then(Value::as_str).map(String::from),
+            id_format: Some(self.format()),
             model: payload
                 .get("model")
                 .and_then(Value::as_str)
@@ -471,10 +473,7 @@ impl ProviderAdapter for ResponsesAdapter {
 
         // Build response with all required fields for TheResponseObject
         let mut map = serde_json::Map::new();
-        map.insert(
-            "id".into(),
-            Value::String(format!("resp_{}", PLACEHOLDER_ID)),
-        );
+        map.insert("id".into(), Value::String(resp.id_for(self.format())));
         map.insert("object".into(), Value::String("response".into()));
         map.insert(
             "model".into(),
@@ -946,7 +945,10 @@ impl ProviderAdapter for ResponsesAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::processing::adapters::ProviderAdapter;
+    use crate::processing::transform::transform_response;
     use crate::serde_json::json;
+    use bytes::Bytes;
 
     #[test]
     fn test_responses_detect_request() {
@@ -956,5 +958,258 @@ mod tests {
             "input": [{"role": "user", "content": "Hello"}]
         });
         assert!(adapter.detect_request(&payload));
+    }
+
+    /// When transforming an Anthropic response to the Responses API format, every output
+    /// item must have a string `id` and every text content block must have an `annotations`
+    /// array.  The AI SDK validates these fields with a Zod schema and raises a
+    /// TypeValidationError when they are absent.
+    #[test]
+    fn test_anthropic_to_responses_has_id_and_annotations() {
+        use crate::providers::openai::generated::{OutputItemType, TheResponseObject};
+
+        let anthropic_response = json!({
+            "id": "msg_abc123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [{"type": "text", "text": "Paris."}],
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 14, "output_tokens": 5}
+        });
+
+        let input = Bytes::from(anthropic_response.to_string());
+        let result = transform_response(input, crate::capabilities::ProviderFormat::Responses)
+            .expect("transform should succeed");
+
+        let response: TheResponseObject = serde_json::from_slice(&result.into_bytes())
+            .expect("must deserialize as TheResponseObject");
+
+        assert!(
+            !response.output.is_empty(),
+            "output must have at least one item"
+        );
+
+        for item in &response.output {
+            assert!(
+                item.id.is_some(),
+                "output item must have an `id`, got: {:?}",
+                item
+            );
+            assert!(item
+                .id
+                .as_ref()
+                .unwrap()
+                .starts_with("msg_transformed_item_"));
+
+            if item.output_item_type == Some(OutputItemType::Message) {
+                if let Some(content) = &item.content {
+                    for c in content {
+                        assert!(
+                            c.annotations.is_some(),
+                            "text content item must have an `annotations` field: {:?}",
+                            c
+                        );
+                        assert_eq!(c.annotations.as_ref().unwrap(), &vec![]);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Transforming an Anthropic response with a tool-use content block to Responses
+    /// format should give every output item a string `id`.
+    #[test]
+    fn test_anthropic_to_responses_tool_use_has_id() {
+        use crate::providers::openai::generated::TheResponseObject;
+
+        let anthropic_response = json!({
+            "id": "msg_def456",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_01",
+                "name": "get_weather",
+                "input": { "location": "Paris" }
+            }],
+            "stop_reason": "tool_use",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 20, "output_tokens": 10}
+        });
+
+        let input = Bytes::from(anthropic_response.to_string());
+        let result = transform_response(input, crate::capabilities::ProviderFormat::Responses)
+            .expect("transform should succeed");
+
+        let response: TheResponseObject = serde_json::from_slice(&result.into_bytes())
+            .expect("must deserialize as TheResponseObject");
+
+        assert!(!response.output.is_empty());
+        for item in &response.output {
+            assert!(
+                item.id.is_some(),
+                "every output item (including function_call) must have a string `id`: {:?}",
+                item
+            );
+            assert!(item
+                .id
+                .as_ref()
+                .unwrap()
+                .starts_with("msg_transformed_item_"));
+        }
+    }
+
+    /// Round-trip: Anthropic → universal → Responses → universal should not add
+    /// spurious `provider_options` on plain text content parts (i.e. empty `annotations`
+    /// arrays from the Responses format must not leak into the universal representation).
+    /// Note: the synthetic placeholder `id` injected during `response_from_universal` is
+    /// preserved in the second universal representation; we only compare message content.
+    #[test]
+    fn test_responses_empty_annotations_not_stored_in_universal() {
+        use crate::capabilities::ProviderFormat;
+        use crate::processing::adapters::adapter_for_format;
+        use crate::universal::message::{AssistantContent, AssistantContentPart, Message};
+
+        let anthropic_response = json!({
+            "id": "msg_roundtrip",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [{"type": "text", "text": "Hello!"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 5, "output_tokens": 3}
+        });
+
+        let anthropic_adapter = adapter_for_format(ProviderFormat::Anthropic).unwrap();
+        let responses_adapter = adapter_for_format(ProviderFormat::Responses).unwrap();
+
+        let universal_a = anthropic_adapter
+            .response_to_universal(anthropic_response.clone())
+            .expect("Anthropic → universal should succeed");
+
+        let responses_value = responses_adapter
+            .response_from_universal(&universal_a)
+            .expect("universal → Responses should succeed");
+
+        let universal_b = responses_adapter
+            .response_to_universal(responses_value)
+            .expect("Responses → universal should succeed");
+
+        // Extract text content from the universal message list
+        let extract_texts = |msgs: &[Message]| -> Vec<String> {
+            msgs.iter()
+                .filter_map(|m| {
+                    if let Message::Assistant { content, .. } = m {
+                        Some(content)
+                    } else {
+                        None
+                    }
+                })
+                .flat_map(|c| match c {
+                    AssistantContent::String(s) => vec![s.clone()],
+                    AssistantContent::Array(parts) => parts
+                        .iter()
+                        .filter_map(|p| {
+                            if let AssistantContentPart::Text(t) = p {
+                                Some(t.text.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect(),
+                })
+                .collect()
+        };
+
+        assert_eq!(
+            extract_texts(&universal_a.messages),
+            extract_texts(&universal_b.messages),
+            "text content must be identical after Anthropic → Responses round-trip"
+        );
+
+        // Verify that the round-trip does NOT add spurious provider_options from empty
+        // annotations arrays.
+        for msg in &universal_b.messages {
+            if let Message::Assistant { content, .. } = msg {
+                if let AssistantContent::Array(parts) = content {
+                    for part in parts {
+                        if let AssistantContentPart::Text(tp) = part {
+                            assert!(
+                                tp.provider_options.is_none()
+                                    || tp
+                                        .provider_options
+                                        .as_ref()
+                                        .map(|o| o.options.is_empty())
+                                        .unwrap_or(false),
+                                "plain text part must not have spurious provider_options from \
+                                 empty annotations: {:?}",
+                                tp.provider_options
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// `response_from_universal` produces a valid Responses API object even when
+    /// called directly with a universal response whose messages have no IDs.
+    #[test]
+    fn test_response_from_universal_always_sets_id_and_annotations() {
+        use crate::providers::openai::generated::{OutputItemType, TheResponseObject};
+        use crate::universal::message::{AssistantContent, Message};
+        use crate::universal::{FinishReason, UniversalResponse};
+
+        let resp = UniversalResponse {
+            id: None,
+            id_format: None,
+            model: Some("claude-sonnet-4-20250514".to_string()),
+            messages: vec![Message::Assistant {
+                content: AssistantContent::String("Paris.".to_string()),
+                id: None,
+            }],
+            usage: None,
+            finish_reason: Some(FinishReason::Stop),
+        };
+
+        let adapter = ResponsesAdapter;
+        let value = adapter
+            .response_from_universal(&resp)
+            .expect("response_from_universal should succeed");
+
+        let response: TheResponseObject =
+            serde_json::from_value(value).expect("must deserialize as TheResponseObject");
+
+        assert!(!response.output.is_empty());
+
+        for item in &response.output {
+            assert!(
+                item.id.is_some(),
+                "output item must have a string `id`: {:?}",
+                item
+            );
+            assert!(item
+                .id
+                .as_ref()
+                .unwrap()
+                .starts_with("msg_transformed_item_"));
+
+            if item.output_item_type == Some(OutputItemType::Message) {
+                if let Some(content) = &item.content {
+                    for c in content {
+                        assert!(
+                            c.annotations.is_some(),
+                            "text content item must have an `annotations` field: {:?}",
+                            c
+                        );
+                        assert_eq!(c.annotations.as_ref().unwrap(), &vec![]);
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -424,7 +424,7 @@ impl ProviderAdapter for ResponsesAdapter {
         let usage = UniversalUsage::extract_from_response(&payload, self.format());
 
         Ok(UniversalResponse {
-            id: payload.get("id").and_then(Value::as_str).map(String::from),
+            id: UniversalResponse::extract_id_from_payload(&payload),
             id_format: Some(self.format()),
             model: payload
                 .get("model")
@@ -1134,22 +1134,24 @@ mod tests {
         // Verify that the round-trip does NOT add spurious provider_options from empty
         // annotations arrays.
         for msg in &universal_b.messages {
-            if let Message::Assistant { content, .. } = msg {
-                if let AssistantContent::Array(parts) = content {
-                    for part in parts {
-                        if let AssistantContentPart::Text(tp) = part {
-                            assert!(
-                                tp.provider_options.is_none()
-                                    || tp
-                                        .provider_options
-                                        .as_ref()
-                                        .map(|o| o.options.is_empty())
-                                        .unwrap_or(false),
-                                "plain text part must not have spurious provider_options from \
+            if let Message::Assistant {
+                content: AssistantContent::Array(parts),
+                ..
+            } = msg
+            {
+                for part in parts {
+                    if let AssistantContentPart::Text(tp) = part {
+                        assert!(
+                            tp.provider_options.is_none()
+                                || tp
+                                    .provider_options
+                                    .as_ref()
+                                    .map(|o| o.options.is_empty())
+                                    .unwrap_or(false),
+                            "plain text part must not have spurious provider_options from \
                                  empty annotations: {:?}",
-                                tp.provider_options
-                            );
-                        }
+                            tp.provider_options
+                        );
                     }
                 }
             }

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -9,7 +9,7 @@ use crate::capabilities::ProviderFormat;
 use crate::serde_json::{self, Value};
 use crate::universal::defaults::PLACEHOLDER_ID;
 use crate::universal::message::Message;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Universal response envelope for LLM API responses.
 ///
@@ -246,6 +246,18 @@ impl UniversalResponse {
     /// that round-trips preserve the original value.  Otherwise we attempt to
     /// generate a vaguely reasonable-looking placeholder (e.g.
     /// `"msg_transformed"`, `"chatcmpl-transformed"`).
+    /// Extract the `id` field from a provider response payload using typed
+    /// deserialization, avoiding direct `Value::get` access.
+    pub fn extract_id_from_payload(payload: &Value) -> Option<String> {
+        #[derive(Deserialize)]
+        struct IdView {
+            id: Option<String>,
+        }
+        serde_json::from_value::<IdView>(payload.clone())
+            .ok()
+            .and_then(|v| v.id)
+    }
+
     pub fn id_for(&self, format: ProviderFormat) -> String {
         self.id
             .as_deref()

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -7,6 +7,7 @@ converted to/from any provider format.
 
 use crate::capabilities::ProviderFormat;
 use crate::serde_json::{self, Value};
+use crate::universal::defaults::PLACEHOLDER_ID;
 use crate::universal::message::Message;
 use serde::Serialize;
 
@@ -15,6 +16,14 @@ use serde::Serialize;
 /// This type captures the common structure across all provider response formats.
 #[derive(Debug, Clone, Serialize)]
 pub struct UniversalResponse {
+    /// Original response ID from the provider (e.g. "msg_abc123"), and the
+    /// format it came from. Both are skipped during serialization — IDs are
+    /// format-specific and not semantically comparable across providers.
+    #[serde(skip_serializing)]
+    pub id: Option<String>,
+    #[serde(skip_serializing)]
+    pub id_format: Option<ProviderFormat>,
+
     /// Model that generated the response
     pub model: Option<String>,
 
@@ -227,6 +236,35 @@ impl FinishReason {
             // Other - pass through as-is
             (Self::Other(s), _) => s.as_str(),
         }
+    }
+}
+
+impl UniversalResponse {
+    /// Return the response ID to use when serializing to a given provider format.
+    ///
+    /// If the stored ID originated from the same format, it is returned as-is so
+    /// that round-trips preserve the original value.  Otherwise we attempt to
+    /// generate a vaguely reasonable-looking placeholder (e.g.
+    /// `"msg_transformed"`, `"chatcmpl-transformed"`).
+    pub fn id_for(&self, format: ProviderFormat) -> String {
+        self.id
+            .as_deref()
+            .filter(|_| self.id_format == Some(format))
+            .map(String::from)
+            .unwrap_or_else(|| {
+                let prefix = match format {
+                    ProviderFormat::Anthropic
+                    | ProviderFormat::BedrockAnthropic
+                    | ProviderFormat::VertexAnthropic => "msg_",
+                    ProviderFormat::ChatCompletions
+                    | ProviderFormat::Mistral
+                    | ProviderFormat::Unknown => "chatcmpl-",
+                    ProviderFormat::Responses => "resp_",
+                    ProviderFormat::Google => "resp_",
+                    ProviderFormat::Converse => "msg_",
+                };
+                format!("{}{}", prefix, PLACEHOLDER_ID)
+            })
     }
 }
 

--- a/payloads/package.json
+++ b/payloads/package.json
@@ -18,10 +18,12 @@
     "test:transforms:watch": "vitest scripts/transforms"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.41",
     "@anthropic-ai/sdk": "^0.74.0",
     "@aws-sdk/client-bedrock-runtime": "^3.700.0",
     "@braintrust/lingua-wasm": "workspace:*",
     "@google/genai": "^1.34.0",
+    "ai": "^6.0.116",
     "openai": "^6.16.0"
   },
   "devDependencies": {

--- a/payloads/scripts/anonymize-json.test.ts
+++ b/payloads/scripts/anonymize-json.test.ts
@@ -206,8 +206,7 @@ describe("anonymizeJsonValue", () => {
               type: "function",
               function: {
                 name: "CreateTodoList",
-                arguments:
-                  '{"items":["anon_1","anon_2"],"status":"anon_3"}',
+                arguments: '{"items":["anon_1","anon_2"],"status":"anon_3"}',
               },
             },
           ],

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -4700,6 +4700,7 @@ exports[`responses → anthropic > complexReasoningRequest > response 1`] = `
   "output": [
     {
       "encrypted_content": "EpklCkYICxgCKkA51CFj00oLmnT+/eYPYNPjgoWfTU0+v0mpGjSFaDg1IT4xirfKPMjkFLIW2RCi9tIRbeN5llDqnnCY2GtelARNEgxr7ri5+8TRiHsuVvAaDCNMgb26CeUhiaKhWiIwL1RSeAYJ3rBCdFe90sOwqWmwdsC/kLTwznAKKZQsZKS9wfu2zoo7KGHbWruzUEvvKoAkpM3JHJEBoe6iB1AWbegPPpvVeOdi+oifLKyOrcTXuGvgN6vPyk0EhGNzfRuszsrKCMs+NClJ0pLNckBsI39i3lgwHPcs1mAAW5pINoQOvnxj+IEHAMezcFKVtT8mlZsRtPtVB4t/apyqhBT/jmvld/k/Gf+il3J7kR8AZ8Zi1p+vfi0egiAEF3SDNiGVbQgEOMC1S/I3pz2AWLO9N7QjnT1gkmBjFj6NAYT0v7AErl6vbRU35D16lLJRjfb6eGk2EhaXUdh0oFwl1Ci15xpERmHt/jgt5TkemnTlQ+2Xg9z1DxjSIKp+61fUTXQztcXASiawOgLjV81IJCAHEh+sZmUXxfWh8cdaIMMr7QtKJRatWVN9qbiQTixy4KW4t4mdwBUog9oSs4kcCkzVeSbv0AlB60H6nnUfaGyurcYNLVLWbx1C6lXDYTlpDjvni7NVzMFPptSQAjL9HVguTeaKyYyiDcsr1Iai+D4s0jQsQzmdVfjScfaHqt9MgQdy1wGgJ8H6jPD0vgf+grtHzD5oLpnRG3kkzRRNIx1iYoGp4WOHpdrF7cOY80LX6SOhmSKoTyeFOhiUgNLelVsev402a2tnhaS4Q7l/QxuiVdLiqw46zXrGhGXcmUZS/erwwHbMMeVqyZRPsAJyq+b8pmVNTBjeKJUTyUFn0+vHX9KeivpUnW5aA8zuVT9Bj5a7pMB7ITt2ojNLQQJ775qMlfNFHJ+tW9pm4ajmttbeq/J8uNiFAfBsi84ct9m9Iyou8nTK2vG6Wifg0qnsuXem7Aock+vjHSXRQgCqx6o1KbHU19FGDOcnWmLD5DIiJTcHdtJsQYc6ZUW5gT1b7OCr+rYP0+19YmOLLWssskqBEW6RhqRa8w+01iN4ZTVNEN/hDezVl/O0v5Tjcgg5qTMP7HdVH62iQKRVrpv09wdt4A7pojPe8jwt466UHb7OG3heVfY5WfuMLLQlc2zg4ohF+z2+2ehshtkoNjsE3HG4Sk9x8TSy6KgmfI8YwOyaMzGuNGSkOHZpyGYi0aNWVOfvuwNqG2VzKNqUYhYbm4unx0YSTtbm3XltMJMjKf9WbaGNO7thTB2ALno16mzRHwGzzcp3kKY04fVoM0CsaGSGA9yApKUtbECStM7m4POKJQbtb7cGcXgOJBOBvkNDmxHhN0HAJzuNPbLmxzwak8iSp6Hh+xcQOKQ3f6oksJ+5eYdTThLfhehVV6mAq+gc89XFk3aiqeIp74S9WQLjiAgLwHQ/PFoMwmU3OtBg8cdGB0NMBm34LuMNgcHNYsjhX7+cZmk+ckqWkwwjZ12CJ5iYmvjGsnCALm/IKHrt0QkPVLNlnSkyRAgHNIaGGnfRsWcgBEADlHaVwFWX+8Phcqr6vE2LR7eEp/6XC5VrdeXo3Zqq5v/ommZQXJXk/Je5nZCMIKQW+75bmLAwjwKmaVY06J/RvVpCsrGA3g5REvHu94qxVSjAsbdIE8qnMn6e2tID9hnf1sVIIOJe3gtOLV/J874/dPWpnkusOJB3W7HY63I6tu2AbKuNGQnaW1aPkm+DMnJZ2wjRZ94hTizpWnnGnKMu92k3rBBqTDHpZJiEt+2Q8SdOrAVYgU1oL+2FywJsqvNk2i42hJi1feZ431fGAvPeyUxXLZz4cGgubg0WH6o7OzZJ/KP/SqAlrMMbJSiZWVCoQDZkVAS53ZCQRm9o+aXyVOwzgRL0pHabiqI6OxQm8n8Kvi1nwYAGyJ5OxI4SYxBDz6IvR0gQ/eKaonVIgwQ5D2RhxEhAEZP+e76J8GblmjMZ2KF4iZJQaMdnti9zdp+L74UWXjj+9PfJhGdxxdwiIf32XSL760Lxn1fEK+j1g1/mj043qDNC5T/wbuHzPsQAZF5PC/7Iz+DpgdF1ByPu03ucisIKFPGVIihta9yiHxTtqDYa/S84rWmVEtR2xIZ5wdIqwPNI5DcqvgZHKIJ8SQqDGDD+zb/DmFpn0fwZp8Cj/6Egz3RHOHs97q68QDMwiaZbGr8Q8553gFlOem3JZv5Np3eIzg9rECiXFv4SDM0Gs2J8Shz7iLBHtpKduPCSErypagy5FUxDEkcxjF5XOOmYH2MA3dcuvf+UQit1bEe9sGbW44K8SRhD+K5CGJJh2F5QQvdjOwRLMPdUKvMiZulxQnZl80l5wYpVjsQwhGBGbPZwu+oBeb008dXqCwdeRdQTOPFNsViDYQQVHknGtqQIbcX1Q1nu26eygPcRL9Ao+AGnVrLQZ3fGkI72uNAV5ZrU9vc441CtViW5t8VZ8YP1RKnlSO3RsASG+l5/u3Y/BL14b7RfI6m4bXLevuQBb2oQ+nAHqWp7rSi/YyvvE2H5vAWv2Xm+GgGuCOXzMr3Mp48sAJPWXf4hXj12qDQHV8TZl79hJvS/pmVDStqQsG0/Y3GDsZFYKeRB+Ku+uq5ex9rRRMEVZXLQg7/SiZ0cL+PaFeeTIkWcjWwLBJnQiTadeB92X1yHU5d6ZoutWlU2hDSwAggksFt9ZRmSsUVLvCue1zpASmFhPnA6QyXdju2r6I8NWKDU7bv2ij7LkF5O9P0AWQC5ajAszAPrL5tBmBJg8Gv0d0Cq968hlKcLtD23Gyir9789e0LBW11k/MWQjrtFLGRlZ9ihRG5iD+WOCQsuMBVWMINqdLlXQ/9JR6UwlM92o+84QyyPJAHJ0m0QCnZTWefV2dGW7HNErwZy4yF3uiO74RVWKAHmiFuI2aOHmgkXW5PD4qHbnVh6gOogxSc4c0/sttt9v/oIuOy+djKa413CqkLd5Zk0tGUgIW+AoAWz6lgTwmbbM8kPqJv5RVRbuK4t9Yu3vIjcpO85nbcwlLIAR5TNLid2NVze9+GghLfC5Rn76aBLd2gAqUmsbyPTZR33rjDvoTqY9FJD0k5sSasngTilCGKALwIh80r6TTiCC5SnGK5RzeUO82PWsesEoGqh/IWdbjYcwihyqYkDoZ0AkH/kiMQPZhuihwyDOrsd2bCUP7MIeq1fHSJB+FAl5JZUiLOF/H/S8Jq3dkbmMyJqEsLMqJb+oiWSQ2wobhZ44ZQLVE8LqkBu167FBUnGxa/TVaskSoQw+2X0bHIBNDAKdo+Lliq4+tUBU23awKaHucGc9bbO/VB+xYhM7bkJRJNvYJi3YqwZz77RGyFjhXd0k98XSe8XLcW2aTqiA5XQGgcdK2c3VE7hPkCWJB9Fd0gQH/03/5QumxXXTixExp4lRMySKij4XXVwKo9GkahL8chQcn0qgabvFx0T9HxnKMDMd4PKR5X/mGtuDgvE94oeExMd4JjTieY55jJXZmD2Tu3jRgnH1SMPkCvGbbUiLtUn+HQNV0LohzbW25Qk+dyinU4RTh1kmup1Z2OxKExGj0/XvhwmnsitVyAXyBESIPKghzmuaasx1mdgiEKXsTCczUCJ+sre3Hcx24RoPX62DKONzSeQD1mDyGlzeI1EslEPYfDYE2poLrVMDx59Li5T95ChG9vz8GElGiMZrsRbALJMj2pvHOugyrzDqA5Ut/ObJ5pQHz5qCH1wxQuX0RzJvYjEwX+OSQuNvA42fobNlpo8aIjxaantkNpmucvbvfW8DXHShorQ56T1RIcNtN+GxMjZD/Cy0rwLVkg8Bba1mb3o/nKV+1ShPJuiSKtxnPziTc2hI/EAZYEa1Vhj1Q5426Jo8DqSICPryYtVyI7fWsx4OlwxUJ0xqr1OZlc/PDpW+CdYW4gXa9lHDoBb0KmCsojyQKOEPlH6Y5FvT3gRVYJk9OL6/PF47q4/QW7SldJkICN+HWY/BCALoK93dMilRV61docm0G9moZb4uxDzpf+mytqpw/G5E1RdD58dW+Riy6buguH5pyOpWHWjqxN3JmjfZ86Bssx9LvIerndBEungTiEBD1Z/jv6mBCfcYCqlnci/e27DP1abXawzqi7JeNnCqxBCJPa/BeOUYrJGVpvIRqivfk4omvJKnVtyMmKny1BTx/96+2SzbYy4k6j4ZdxhW6U8Qd4o1ewGpFJF3eiCePIOJjiMI+myytEU0aoo0xgL5pIecNnIeciKvDMQeRVzba1qoD0T8NqtbP3XIIGhaKteN38y0Ef72v5sEq8+3BZOYDmGt7CzOYJBb4yoCQ8VM8MYpfMeJiky4fX3a7tN2VsE8XCW5i3tc1DLcqwFeoQ3dLWTewYJa2Q28r6l7tgcdtmM7ksHx7BnIVSblkZsK3ew9sUpfICSSidNq5SUvKXTWb2+RbjKtaP4wfNbwCokzIlwZZHEKvtP7oIRiHkZbF4s4r9BqgBXxCXVTyJrDBJzX88usQ5x5fUy5hBYEMjdeD/Qc20LMnMgC6aJVcVQ6tT/Z/BBMxm7MR5C/R2A1z74+NzV5sSGRooTKkUY2SFWu1Cdi3PM7Aet6Ltqt0JQgkIKE1zvzzoXWOP8nRC+wUp4w9JqL1s3cA9GtiiCQLx0k+Y9n42wPtO3tqPl5Y6p1DmmrzORmIGBESe5YMgEZz3C0htlT4hggZbnpFw4hDs+06EWunVCG/kQhUjq11LRQ7+RObI84Ffe3VYqG07tMQulXJ4tRXuPwWaEevk/YakW7Agdc1tPejS2trdD0ntt9Zwu/p9QxZxDOtFkLhz0/Eh78O/5ljdHvyhRDk1OTIq+mq9EsKhTRnW+eyfKH9n/a885LJDlrdYGFENvmVM/75If/R4VORmOVGFGTWqKk9shRO8Z4aWHTMfcbFLB2Ncp978NHqXEXndTDF92obtWkDdmlU3AaoqBSVbF3DcRFkRrxG+uWgkE1K0bf1laOcUP8CHTjhPD6LPt4BFVbmfxk02M92QCuGIt8m1ZBA9XYKv0xyRTNSM08lEHL4wYtIu3tHGPGhx7d1iBllmZYK+ULVXt+x0AF3yVTY2iaHi1xvwoTYqWGNYihDWVdmxOJ1tEYHbkyt2CrzA/b6m2wpk2lQFzpJfg9yhG1gsC7NQ2893boXr6Ct7+kfLYegSRkRIJya/gv5NmoO3809mLo8dxF2jr97y5xQ6BNbGmC3H4UbnRKFngai9x6elYhUJDJZ+wkRS/oL9JwoNmiBxo5pFtfLrPPkymzeEIj/ov4AeaiQpnsIm0pyLa3PLrn/qmsJQVIJ6W1IIYHstseg2ms5vYd3slV4dgGFN0MN19yZ0ZNEi9cseTvwNsuBbrmhY8CtZsREKrCbEkgoDCUG/X4k+iFSVN0UVj+v5Ag9J7u1uiflI1gZIsEhCmCj7gEra6l7VrAWzAWfYw/a2t616qNnvITBa1FXwSI7beFEc3V//gdvUxO+4ELSi3vxKzFfqebIHAwwKkEJv3w3wmtrEEnnwTD5biATr7nGmjgwhLBs7q9TcyzozcuD9Z7IoUHwLMiuw+Ww0UtgMNgiX1rjp6TTG1mDqNq0R619dcxJXxUdkIwp8q9ub0m0rg18EaHQm8uiEc86cuEctxVM8VWylYmCXaIsvyGO66dgvcI3O82+ij6QQOx/I0ShFWrgUhoCl7pb5YGWwN+KokPenOXMS0LPc4GGilB5RDVX+b+SD+NEQuzV0G37iIGKF/gJ+NdUpgdpO+FSbELFYbtojARZdEusXNAWKOu8BcFbdQBaJNQnScW1Od5mMkcT2D/LaN42HE/43F3jk1niSWtZSUvDuc5kFn8Zwt/sTflxgaPAt/Fkq2ZJgAKfar9z26oGGgTbEzZf+9nGB5HWanZnXb1bzjJPdO9ADfN9Io0d25+EQFXMHPT7AeBp9XeU1yl4Bqp2ONL9DTFfgO/Gh+1COagYkWtyNXqgks/eBz6N57jgVk2KIlq+5pWZkrHJtOd8tE+fWJMrhopQb0CarE4NGPQEsa6llouAPe/WnvEEQkvVmzw2SrHkWZHQxiI2uoTOfGxew/S3UOioWZhJJCH2TeTAhXloKdT+PySXQ7Hx+qXjiWowHDzAW4Vx5b3D/chz+K+Te/ZEct1qUDt9UTKix7AkMc8qEZ8xekoT/lxA3GFHfFPQzDa8/ArrGA2ftqqJJruXs7fJrrXa54R+Rooeras9RWiNAV02MU/bI3t/PEMxZY9XESBjUDChYbr8CRmTFpmlCIIs4zhDlCdOE0f5apLYTyG3vUCSPl0hNemkC9y1WqiK57rh03k2/DA8v8YLIObIZ6g7afIs0LndbBGgoeGAE=",
+      "id": "msg_transformed_item_0",
       "summary": [
         {
           "text": "Let me think about this step by step. I need to count how many times each digit (0-9) appears in a 24-hour digital clock format (00:00 to 23:59).
@@ -4754,6 +4755,7 @@ The sum confirms the calculation: 1,164 + 804 + 564 + 504 + 504 + 264 + 264 + 26
     {
       "content": [
         {
+          "annotations": [],
           "text": "Looking at a 24-hour digital clock (00:00 to 23:59), I need to count how often each digit appears across all 1,440 possible times.
 
 Let me break this down by position:
@@ -4800,6 +4802,7 @@ The digits 0 and 1 dominate because they appear frequently in both hours (00-19)
           "type": "output_text",
         },
       ],
+      "id": "msg_transformed_item_1",
       "role": "assistant",
       "status": "completed",
       "type": "message",
@@ -4901,10 +4904,12 @@ exports[`responses → anthropic > multimodalRequest > response 1`] = `
     {
       "content": [
         {
+          "annotations": [],
           "text": "I see an adorable tabby kitten lying on its side on what appears to be a wooden floor. The kitten has beautiful striped markings in brown and gray, with distinctive large yellow-green eyes that are looking directly at the camera. Its head is tilted in a very cute, curious pose. The kitten appears to be quite young, with soft fur and the typical playful posture of a young cat. In the blurred background, I can see what looks like furniture or shelving. The lighting creates a warm, cozy atmosphere that really highlights the kitten's sweet expression and beautiful markings.",
           "type": "output_text",
         },
       ],
+      "id": "msg_transformed_item_0",
       "role": "assistant",
       "status": "completed",
       "type": "message",
@@ -4955,6 +4960,7 @@ exports[`responses → anthropic > reasoningRequest > response 1`] = `
   "output": [
     {
       "encrypted_content": "Eo0GCkYICxgCKkCWf5Li7DwaRpTlXZCfNw43LgmK9ISm7pa+HJwOBIujpZp0rVwyqs4pp9tyLYcmHMcDn+3snF7mmekHzpIxPnkpEgzmJ2TOpmD7L2HwIH0aDE3GPAjq0ucjYgh3IiIwuHKY7BkarOdihXcA0/3Sd3wOLI6SS2OFQNYJfx+UYpJ3LNOh/Rdj6E3eBJTodUWqKvQEb2v8j7bjyzZT0Y6NCQCDlnmVx2vZDWScj//tuqA6385lL4OhjWyV9QPkzJDmL3aojSR+Jm1N9OFy5tPEHZ3P5OAF4ITS2pSTzxtQgMG5CdTD/GwLneAFoY0UBmDdareTfcoohR4YrPbbWEjR059NfcTzimPwNVI/YcGNLDj6GUPmhPcQlaz1z+rEnLOYwDb+Vv28xnuNMQgrjl3sbcsgrqOBRfkv8EAQqRv8ITZMkZgv5CrS4SOsnjDzYo3Ii91W4IXtsm7lOT3aJhZgLAyriP1dUa7dYByz5U1uqk18GEZMyd907UOtNRZCw+HdnOr5Saf06KemTjVvxaTQdMDurfKCPAVWICGhgLwHlIYv41y5hpyYfaKUB9X4x/j0Op8u72x+s0kqDY+JOpnhyx0CN8Cn0xyiepq0rfi76eBuJvs0k0mEb9TIlCHiSGfYHF7w73pM6NWOd5CHXD4tcxcuyGOjUn4CBb/HrQNGT+7zRQxUsq65XN6kDeWYxV6PhChu6JWuU35FI9Fh1IvEjJVxGcVkJQNQM7Gz7/ZdH19AScmZy79ysQV1A09l72sesM0FwGy3LY+Gr6N9YxjaKRcmJa8Za2qocxR9EDYl6ZS4tIwjbm1+l5bfvwfxiJZznAKxalB+hWR5T9Ifktqny114HuJy/s1lv3LrD06I0D2vF+CboOpYgzHvanjRGVIIRZw8KqQOSoolqAW561kRVFnR+Ra7KVoLqZkpYKwIVXwRG4hKUPViQ6oe43LDRS0rO/7aFYpc1lMMDdIiLxTQdr/Z98NgRV3aAiYCNysgOuVA5u+NplUsezolBViAfPWqLRuwAqHcxRgB",
+      "id": "msg_transformed_item_0",
       "summary": [
         {
           "text": "To find the average speed, I need to use the formula:
@@ -4985,6 +4991,7 @@ Average speed = Total distance / Total time = 200 miles / 3 hours = 66.67 mph (r
     {
       "content": [
         {
+          "annotations": [],
           "text": "I'll solve this step-by-step using the average speed formula.
 
 **Step 1: Calculate distance for each segment**
@@ -5015,6 +5022,7 @@ Note: Average speed is not the same as the average of the speeds (which would be
           "type": "output_text",
         },
       ],
+      "id": "msg_transformed_item_1",
       "role": "assistant",
       "status": "completed",
       "type": "message",
@@ -5108,6 +5116,7 @@ exports[`responses → anthropic > reasoningWithOutput > response 1`] = `
   "output": [
     {
       "encrypted_content": "EpYGCkYICxgCKkDN0nKcZq8FjobVKFRb/xmfE/ZmkXPjejR+8xqPKeX6NMwzUgZBwYF732MyAKiER9EaUnbQDjpWFRkaIQd0aZeSEgwqn1/xoeOa7mMd7iAaDBBrJWYvm/rxe+qXdCIwl09l4kLNYU9hXlt2DplQnw/vXj7+4nkQr9QfDtGPHSfB8qT7N/EvX2u1NNPCE/33Kv0EcrFjnsFD3It5CCbrEBch1E9YSCCqO3lO1toOZv+ZTxyJ+TM1ihlwUVbIYAMWNn0/4+m2Yav7NygZzUXqn23AVsA+dS5snO3DzoS5YMhRVlZD2BwqLcZ+wHB2oDHV32/JCLLS0FukolqHFK8zh/Nlr8NPj0EfY5eaSf7O0JzcwmbjKQh/LNuM4gFbOZHHsCQU53ehWJKIXUNzDZEA2Po/ZlLKCOMKwyPmZrHHKihckJNi2R0cNgb2VfL5yjnOOmyfPwnqlgQxxQB5fJjtIjnZSLo/gIU6ec+8JYriPU4oDAITptadCfTYxqc6sAw2arzkC+DksfWIfzJBU9FihHwvzi1a8QoAzWrn+yRT9CgKfkB8JKLA2LnwWFouMAGBfMuO3wLlmxtftdNjZXroL7jTv3WC6y3S1P0Yk1re+wR2OcNdiOUOgnKASW3ItCj+WD25dsnMOuCm4efKpziFtHEczXIzrs6prTmh6NaVUrQ1UfwTP8zAlpXbSwmBO0fT/GHRQifwk+WWqxclld7lmM9eEqYQ9gv0oXyuFBnG56sbFErHxE3qEOeXJESCTTAutERl9W47KDGfqcUzZ9CaOuKDvBajAgLWtbyXeNYB/tQeQ+Gs8It8mOimYpOIFAZ8fewxwG5uK5rH2qbTbZwR9Xu6+Hqu2t4zHB7Vmyk+m4zo+HTI7/sCibKUnzawqmLuRIpTzlKM8B8sMdV/p/2gps24E4FgpR2ZZqLLSnsn3mvxO6sJdOzo/JbnOZbw5ur0K9VZs6rIiPLHlVtkVmQ0rOhcF+N4afArXpW3/ZfdDlOrsWPJ6dTZJE83oaM75sABow5RSQBtQ4CcZt+M5r3oSRgB",
+      "id": "msg_transformed_item_0",
       "summary": [
         {
           "text": "This is a straightforward question about the color of the sky. The sky appears blue during the day under normal clear weather conditions. This is due to a phenomenon called Rayleigh scattering, where shorter blue wavelengths of light are scattered more by the molecules in Earth's atmosphere than longer wavelengths like red.
@@ -5127,6 +5136,7 @@ I'll give the most common answer but acknowledge it can vary.",
     {
       "content": [
         {
+          "annotations": [],
           "text": "The sky is typically blue during the day when it's clear. This blue color is caused by the way sunlight interacts with particles in Earth's atmosphere - shorter blue wavelengths of light get scattered more than other colors.
 
 However, the sky can appear different colors depending on conditions:
@@ -5137,6 +5147,7 @@ However, the sky can appear different colors depending on conditions:
           "type": "output_text",
         },
       ],
+      "id": "msg_transformed_item_1",
       "role": "assistant",
       "status": "completed",
       "type": "message",
@@ -5193,6 +5204,7 @@ exports[`responses → anthropic > simpleRequest > response 1`] = `
   "output": [
     {
       "encrypted_content": "EsoCCkYICxgCKkD5zM+jgIUOjDIU1NKWmzpNdQCwQNYUkunavnh72prMHBnjZcKGxtNT7MGMpcPg0oPpsj6mhkPR6WqafUiIZ5oXEgxZ3jOspYjQZ1/H2BkaDD2yEjUiKzYpFeL8hCIwsUxcqKLB15jz7steuNJ1I3E6zTBnL8mffUALE2O5kHsEMr66BT58XjJnu+2UDbhOKrEBTltQkF5iDAOchP5zay+8PZkvWQuoGKO2q9IMRvP/69sAXngSnbbp/kMpIfXmVRSC187MAB1RmURe0zzeQAcQz5hTyAOl5sAi00X6pYOgtz1YaDtkO/MSDwMWqIEQwB/kBj9Nat9WXXMH674G9gLcmJij5MumEuvPYcZ6NqfY8hQ0y/tO/Pxhp6gzgthGzQse1EzWI1Shh1LAaoFDRWCHbl/4Rcb4rpPGx0Xon5Qtnv67GAE=",
+      "id": "msg_transformed_item_0",
       "summary": [
         {
           "text": "This is a straightforward factual question about geography. The capital of France is Paris. This is basic, well-established knowledge that I can answer directly.",
@@ -5204,10 +5216,12 @@ exports[`responses → anthropic > simpleRequest > response 1`] = `
     {
       "content": [
         {
+          "annotations": [],
           "text": "The capital of France is Paris.",
           "type": "output_text",
         },
       ],
+      "id": "msg_transformed_item_1",
       "role": "assistant",
       "status": "completed",
       "type": "message",
@@ -5256,6 +5270,7 @@ exports[`responses → anthropic > systemMessageArrayContent > response 1`] = `
     {
       "content": [
         {
+          "annotations": [],
           "text": "I'll help you find recent errors from the project logs. Let me query the data to identify error occurrences.
 
 \`\`\`sql
@@ -5288,6 +5303,7 @@ Would you like me to modify the query for a different time range, or can you sha
           "type": "output_text",
         },
       ],
+      "id": "msg_transformed_item_0",
       "role": "assistant",
       "status": "completed",
       "type": "message",
@@ -5385,10 +5401,12 @@ exports[`responses → anthropic > toolCallRequest > response 1`] = `
     {
       "content": [
         {
+          "annotations": [],
           "text": "I'll check the current weather in San Francisco for you.",
           "type": "output_text",
         },
       ],
+      "id": "msg_transformed_item_0",
       "role": "assistant",
       "status": "completed",
       "type": "message",
@@ -5396,6 +5414,7 @@ exports[`responses → anthropic > toolCallRequest > response 1`] = `
     {
       "arguments": "{"location":"San Francisco, CA"}",
       "call_id": "toolu_01FZCXngG3VBF2g2vvnzsh3T",
+      "id": "msg_transformed_item_1",
       "name": "get_weather",
       "status": "completed",
       "type": "function_call",

--- a/payloads/scripts/transforms/transforms-ai-sdk.test.ts
+++ b/payloads/scripts/transforms/transforms-ai-sdk.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText } from "ai";
+import { allTestCases, getCaseForProvider } from "../../cases";
+import {
+  TRANSFORM_PAIRS,
+  TARGET_MODELS,
+  loadAndValidateResponse,
+  transformResponseData,
+  getTransformableCases,
+  getResponsePath,
+} from "./helpers";
+
+const AI_SDK_TEST_TIMEOUT = 30000;
+
+// Test the responses → anthropic path: the captured response is from Anthropic,
+// and Lingua transforms it back to responses format. The AI SDK consumes that
+// transformed output, so it must pass the AI SDK's Zod validation.
+const RESPONSES_TO_ANTHROPIC_PAIRS = TRANSFORM_PAIRS.filter(
+  (p) => p.source === "responses" && p.target === "anthropic"
+);
+
+for (const pair of RESPONSES_TO_ANTHROPIC_PAIRS) {
+  describe(`AI SDK validation: ${pair.target} response → ${pair.source} format`, () => {
+    const cases = getTransformableCases(pair);
+
+    for (const caseName of cases) {
+      const responsePath = getResponsePath(pair.source, pair.target, caseName);
+
+      // Skip cases where the captured response is an API error (not a valid provider response)
+      const isErrorResponse =
+        existsSync(responsePath) &&
+        (() => {
+          const raw = JSON.parse(readFileSync(responsePath, "utf-8"));
+          return "error" in raw && !("id" in raw);
+        })();
+
+      test.skipIf(!existsSync(responsePath) || isErrorResponse)(
+        caseName,
+        async () => {
+          // 1. Load the captured Anthropic response
+          const anthropicResponse = loadAndValidateResponse(
+            responsePath,
+            pair.target
+          );
+
+          // 2. Transform it to responses format via wasm — this is what the gateway
+          //    would return to the AI SDK
+          const responsesOutput = transformResponseData(
+            anthropicResponse,
+            pair.wasmSource
+          );
+
+          // 3. Validate through the actual AI SDK by using a mock fetch that returns
+          //    the wasm-transformed output. The AI SDK internally parses with its Zod
+          //    schema and throws TypeValidationError when fields like `id` or
+          //    `annotations` are missing.
+          const targetCase = getCaseForProvider(
+            allTestCases,
+            caseName,
+            pair.source
+          );
+          const model =
+            targetCase &&
+            typeof targetCase === "object" &&
+            "model" in targetCase
+              ? String(targetCase.model)
+              : TARGET_MODELS[pair.source];
+
+          const provider = createOpenAI({
+            apiKey: "test-key",
+            /* eslint-disable @typescript-eslint/consistent-type-assertions -- mock fetch for testing */
+            fetch: (async () => {
+              return new Response(JSON.stringify(responsesOutput), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              });
+            }) as unknown as typeof fetch,
+            /* eslint-enable @typescript-eslint/consistent-type-assertions */
+          });
+
+          // generateText will parse the response through the AI SDK's Zod schema.
+          // If the response is missing required fields (id, annotations, etc.),
+          // it throws TypeValidationError — which is exactly what this test catches.
+          await expect(
+            generateText({
+              model: provider.responses(model),
+              prompt: "test",
+            })
+          ).resolves.toBeDefined();
+        },
+        AI_SDK_TEST_TIMEOUT
+      );
+    }
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,12 @@ importers:
 
   payloads:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^3.0.41
+        version: 3.0.41(zod@4.3.6)
       '@anthropic-ai/sdk':
         specifier: ^0.74.0
-        version: 0.74.0
+        version: 0.74.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime':
         specifier: ^3.700.0
         version: 3.958.0
@@ -81,9 +84,12 @@ importers:
       '@google/genai':
         specifier: ^1.34.0
         version: 1.34.0
+      ai:
+        specifier: ^6.0.116
+        version: 6.0.116(zod@4.3.6)
       openai:
         specifier: ^6.16.0
-        version: 6.16.0(ws@8.18.3)
+        version: 6.16.0(ws@8.18.3)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^22.9.0
@@ -114,6 +120,28 @@ importers:
         version: 3.2.4(@types/node@22.19.1)
 
 packages:
+
+  '@ai-sdk/gateway@3.0.66':
+    resolution: {integrity: sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.41':
+    resolution: {integrity: sha512-IZ42A+FO+vuEQCVNqlnAPYQnnUpUfdJIwn1BEDOBywiEHa23fw7PahxVtlX9zm3/zMvTW4JKPzWyvAgDu+SQ2A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.19':
+    resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
 
   '@anthropic-ai/sdk@0.63.1':
     resolution: {integrity: sha512-wMA/Xx5GLO+npV992YKUfsmlI6699XG/jFjCPTf/nsMBfUh3e3KmNiOKuhqSMZibOjoLOlhYc7L4pfLPI8A+RA==}
@@ -803,6 +831,10 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1121,6 +1153,9 @@ packages:
     resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
     engines: {node: '>=18.0.0'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/core-darwin-arm64@1.15.7':
     resolution: {integrity: sha512-+hNVUfezUid7LeSHqnhoC6Gh3BROABxjlDNInuZ/fie1RUxaEX4qzDwdTgozJELgHhvYxyPIg1ro8ibnKtgO4g==}
     engines: {node: '>=10'}
@@ -1273,6 +1308,10 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
 
@@ -1334,6 +1373,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@6.0.116:
+    resolution: {integrity: sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -1583,6 +1628,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -1791,6 +1840,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2424,15 +2476,44 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
+
+  '@ai-sdk/gateway@3.0.66(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
+  '@ai-sdk/openai@3.0.41(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.19(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
 
   '@anthropic-ai/sdk@0.63.1':
     dependencies:
       json-schema-to-ts: 3.1.1
 
-  '@anthropic-ai/sdk@0.74.0':
+  '@anthropic-ai/sdk@0.74.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -3165,6 +3246,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -3544,6 +3627,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/core-darwin-arm64@1.15.7':
     optional: true
 
@@ -3705,6 +3790,8 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vitest/expect@1.6.1':
     dependencies:
       '@vitest/spy': 1.6.1
@@ -3787,6 +3874,14 @@ snapshots:
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
+
+  ai@6.0.116(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
 
   ajv@6.12.6:
     dependencies:
@@ -4107,6 +4202,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventsource-parser@3.0.6: {}
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -4327,6 +4424,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   jwa@2.0.1:
@@ -4439,9 +4538,10 @@ snapshots:
     optionalDependencies:
       ws: 8.18.3
 
-  openai@6.16.0(ws@8.18.3):
+  openai@6.16.0(ws@8.18.3)(zod@4.3.6):
     optionalDependencies:
       ws: 8.18.3
+      zod: 4.3.6
 
   optionator@0.9.4:
     dependencies:
@@ -4913,3 +5013,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
A customer ran into an issue where AI SDK was failing because it has strict
type checks using a zod format. It expects responses API to always have IDs for
items and an annotations field, even if empty. We were dropping these when
translating between providers. Fix this by restoring the ID if the format
matches, otherwise putting a placeholder in. Also always fill in an empty
annotations.

At some point in the future we should look at adding annotations (openai) and
citations (anthropic's version) to the universal format.