### PR TITLE
[braintrust-llm-router] Retry transient connection errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -568,6 +568,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -613,13 +619,14 @@ dependencies = [
  "lru",
  "once_cell",
  "ordered-float",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-project",
  "pretty_assertions",
  "proptest",
  "rand 0.8.5",
  "reqwest",
  "reqwest-middleware",
+ "reqwest-retry",
  "serde",
  "serde_json 1.0.143",
  "sha2",
@@ -1007,7 +1014,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -1882,6 +1889,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1890,7 +1900,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -2284,7 +2294,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2345,12 +2355,37 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -2361,7 +2396,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.0",
 ]
@@ -2530,7 +2565,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.9.3",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -2551,7 +2586,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "parking_lot 0.12.5",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -2811,11 +2846,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -2943,10 +2987,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-retry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "hyper 1.7.0",
+ "parking_lot 0.11.2",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
 name = "retain_mut"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "ring"
@@ -2995,7 +3070,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3008,7 +3083,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -3262,7 +3337,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3275,7 +3350,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3876,7 +3951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.9.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4303,6 +4378,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,6 +4434,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4351,6 +4457,12 @@ checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ serde-wasm-bindgen = "0.6"
 # Native HTTP client (non-WASM only)
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip"] }
 reqwest-middleware = { version = "0.4" }
+reqwest-retry = { version = "0.7" }
 
 # Python
 pyo3 = { version = "0.20", features = ["extension-module"] }

--- a/crates/braintrust-llm-router/Cargo.toml
+++ b/crates/braintrust-llm-router/Cargo.toml
@@ -26,6 +26,7 @@ lingua = { workspace = true, features = ["openai", "anthropic", "google", "bedro
 # HTTP client
 reqwest = { workspace = true, features = ["json", "stream", "gzip"] }
 reqwest-middleware = { workspace = true }
+reqwest-retry = { workspace = true }
 hyper = { workspace = true, optional = true }
 http = { workspace = true }
 

--- a/crates/braintrust-llm-router/src/client.rs
+++ b/crates/braintrust-llm-router/src/client.rs
@@ -1,3 +1,5 @@
+use std::error::Error as StdError;
+use std::io::ErrorKind;
 use std::time::Duration;
 
 use dashmap::DashMap;
@@ -5,6 +7,10 @@ use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use reqwest::{Client, ClientBuilder};
 use reqwest_middleware::ClientWithMiddleware;
+use reqwest_retry::{
+    default_on_request_failure, policies::ExponentialBackoff, RetryTransientMiddleware, Retryable,
+    RetryableStrategy,
+};
 
 use crate::error::{Error, Result};
 
@@ -94,13 +100,13 @@ fn build_middleware_client_inner(settings: &ClientSettings) -> Result<ClientWith
     )
     .in_scope(|| {
         let client = build_client(settings)?;
-        Ok::<ClientWithMiddleware, Error>(reqwest_middleware::ClientBuilder::new(client).build())
+        Ok::<ClientWithMiddleware, Error>(build_retrying_middleware_client(client))
     })?;
 
     #[cfg(not(feature = "tracing"))]
     let client = {
         let client = build_client(settings)?;
-        reqwest_middleware::ClientBuilder::new(client).build()
+        build_retrying_middleware_client(client)
     };
 
     if let Some(existing) = SHARED_CLIENTS.get(settings) {
@@ -108,6 +114,71 @@ fn build_middleware_client_inner(settings: &ClientSettings) -> Result<ClientWith
     }
     SHARED_CLIENTS.insert(settings.clone(), client.clone());
     Ok(client)
+}
+
+fn build_retrying_middleware_client(client: Client) -> ClientWithMiddleware {
+    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+    let retry_middleware = RetryTransientMiddleware::new_with_policy_and_strategy(
+        retry_policy,
+        ConnectionRetryStrategy,
+    );
+
+    reqwest_middleware::ClientBuilder::new(client)
+        .with(retry_middleware)
+        .build()
+}
+
+fn retryable_transport_failure(err: &reqwest_middleware::Error) -> Option<Retryable> {
+    match default_on_request_failure(err) {
+        Some(Retryable::Transient) => Some(Retryable::Transient),
+        default_retryability => match err {
+            reqwest_middleware::Error::Reqwest(err) if chain_has_connection_io_error(err) => {
+                Some(Retryable::Transient)
+            }
+            reqwest_middleware::Error::Middleware(err)
+                if chain_has_connection_io_error(err.as_ref()) =>
+            {
+                Some(Retryable::Transient)
+            }
+            _ => default_retryability,
+        },
+    }
+}
+
+fn chain_has_connection_io_error(err: &(dyn StdError + 'static)) -> bool {
+    // Reqwest does not always classify mid-flight resets as `is_connect()`, so
+    // inspect the source chain for concrete socket teardown errors as well.
+    let mut current: Option<&(dyn StdError + 'static)> = Some(err);
+    while let Some(source) = current {
+        if let Some(io_err) = source.downcast_ref::<std::io::Error>() {
+            if matches!(
+                io_err.kind(),
+                ErrorKind::ConnectionReset
+                    | ErrorKind::ConnectionAborted
+                    | ErrorKind::BrokenPipe
+                    | ErrorKind::NotConnected
+            ) {
+                return true;
+            }
+        }
+        current = source.source();
+    }
+    false
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ConnectionRetryStrategy;
+
+impl RetryableStrategy for ConnectionRetryStrategy {
+    fn handle(
+        &self,
+        result: &std::result::Result<reqwest::Response, reqwest_middleware::Error>,
+    ) -> Option<Retryable> {
+        match result {
+            Ok(_) => None,
+            Err(err) => retryable_transport_failure(err).or(Some(Retryable::Fatal)),
+        }
+    }
 }
 
 static OVERRIDE_CLIENT: Lazy<RwLock<Option<ClientWithMiddleware>>> =

--- a/crates/braintrust-llm-router/src/client.rs
+++ b/crates/braintrust-llm-router/src/client.rs
@@ -14,6 +14,9 @@ use reqwest_retry::{
 
 use crate::error::{Error, Result};
 
+// The default number of retries for transient transport failures.
+const DEFAULT_MAX_RETRIES: u32 = 2;
+
 // Shared reqwest clients are cached by these settings. Keep this key
 // low-cardinality and effectively process-wide; request-scoped values do not
 // belong here because they fragment client reuse and connection pooling.
@@ -117,7 +120,7 @@ fn build_middleware_client_inner(settings: &ClientSettings) -> Result<ClientWith
 }
 
 fn build_retrying_middleware_client(client: Client) -> ClientWithMiddleware {
-    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(DEFAULT_MAX_RETRIES);
     let retry_middleware = RetryTransientMiddleware::new_with_policy_and_strategy(
         retry_policy,
         ConnectionRetryStrategy,

--- a/crates/braintrust-llm-router/src/client.rs
+++ b/crates/braintrust-llm-router/src/client.rs
@@ -132,7 +132,7 @@ fn build_retrying_middleware_client(client: Client) -> ClientWithMiddleware {
 }
 
 fn retryable_transport_failure(err: &reqwest_middleware::Error) -> Option<Retryable> {
-    match default_on_request_failure(err) {
+    let retryable = match default_on_request_failure(err) {
         Some(Retryable::Transient) => Some(Retryable::Transient),
         default_retryability => match err {
             reqwest_middleware::Error::Reqwest(err) if chain_has_connection_io_error(err) => {
@@ -145,7 +145,14 @@ fn retryable_transport_failure(err: &reqwest_middleware::Error) -> Option<Retrya
             }
             _ => default_retryability,
         },
+    };
+
+    #[cfg(feature = "tracing")]
+    if matches!(retryable, Some(Retryable::Transient)) {
+        tracing::warn!(error = %err, "retrying middleware request after transient error");
     }
+
+    retryable
 }
 
 fn chain_has_connection_io_error(err: &(dyn StdError + 'static)) -> bool {

--- a/crates/braintrust-llm-router/src/error.rs
+++ b/crates/braintrust-llm-router/src/error.rs
@@ -98,6 +98,20 @@ pub enum Error {
 }
 
 impl Error {
+    // Transport failures happen before we have a usable upstream HTTP response to
+    // preserve, so normalize them as provider errors with `http: None`.
+    pub fn provider_transport_error<E>(provider: &str, err: E) -> Self
+    where
+        E: Into<anyhow::Error>,
+    {
+        Self::Provider {
+            provider: provider.to_string(),
+            source: err.into(),
+            retry_after: None,
+            http: None,
+        }
+    }
+
     pub fn is_retryable(&self) -> bool {
         matches!(self, Error::Http(err) if err.is_timeout() || err.is_connect() || err.is_request() || err.status().map(|c| c.is_server_error()).unwrap_or(false))
             || matches!(self, Error::Provider { retry_after, .. } if retry_after.is_some())

--- a/crates/braintrust-llm-router/src/error.rs
+++ b/crates/braintrust-llm-router/src/error.rs
@@ -60,6 +60,13 @@ pub enum Error {
     #[error("no authentication configured for provider '{0}'")]
     NoAuth(String),
 
+    #[error("provider '{provider}' unavailable")]
+    UpstreamUnavailable {
+        provider: String,
+        #[source]
+        source: anyhow::Error,
+    },
+
     #[error("provider '{provider}' error: {source}")]
     Provider {
         provider: String,
@@ -229,6 +236,11 @@ mod tests {
 
         // Not client errors
         assert!(!Error::Timeout.is_client_error());
+        assert!(!Error::UpstreamUnavailable {
+            provider: "openai".into(),
+            source: anyhow::anyhow!("connection reset"),
+        }
+        .is_client_error());
         assert!(
             !Error::Lingua(lingua::TransformError::SerializationFailed("test".into()))
                 .is_client_error()

--- a/crates/braintrust-llm-router/src/error.rs
+++ b/crates/braintrust-llm-router/src/error.rs
@@ -98,22 +98,12 @@ pub enum Error {
 }
 
 impl Error {
-    // Transport failures happen before we have a usable upstream HTTP response to
-    // preserve, so normalize them as provider errors with `http: None`.
-    pub fn provider_transport_error<E>(provider: &str, err: E) -> Self
-    where
-        E: Into<anyhow::Error>,
-    {
-        Self::Provider {
-            provider: provider.to_string(),
-            source: err.into(),
-            retry_after: None,
-            http: None,
-        }
-    }
-
     pub fn is_retryable(&self) -> bool {
-        matches!(self, Error::Http(err) if err.is_timeout() || err.is_connect() || err.is_request() || err.status().map(|c| c.is_server_error()).unwrap_or(false))
+        // Router-level retries are reserved for errors that originate outside the
+        // provider HTTP wrapper's connection-retry path, such as raw reqwest
+        // errors, middleware errors, explicit Retry-After responses, or timeouts.
+        matches!(self, Error::Http(err) if is_reqwest_retryable(err))
+            || matches!(self, Error::Middleware(err) if is_middleware_retryable(err))
             || matches!(self, Error::Provider { retry_after, .. } if retry_after.is_some())
             || matches!(self, Error::Timeout)
     }
@@ -150,6 +140,29 @@ impl Error {
     pub fn is_upstream_error(&self) -> bool {
         matches!(self, Error::Provider { http: Some(_), .. })
     }
+}
+
+fn is_reqwest_retryable(err: &reqwest::Error) -> bool {
+    err.is_timeout()
+        || err.is_connect()
+        || err.is_request()
+        || err.status().map(|c| c.is_server_error()).unwrap_or(false)
+}
+
+fn is_middleware_retryable(err: &reqwest_middleware::Error) -> bool {
+    err.is_timeout()
+        || err.is_request()
+        || {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                err.is_connect()
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                false
+            }
+        }
+        || err.status().map(|c| c.is_server_error()).unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/crates/braintrust-llm-router/src/providers/anthropic.rs
+++ b/crates/braintrust-llm-router/src/providers/anthropic.rs
@@ -10,7 +10,7 @@ use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::ClientHeaders;
+use crate::providers::{read_provider_body, send_provider_request, ClientHeaders};
 use crate::streaming::{sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
 
@@ -128,13 +128,15 @@ impl crate::providers::Provider for AnthropicProvider {
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
-        let response = self
-            .client
-            .post(url.clone())
-            .headers(headers)
-            .body(payload)
-            .send()
-            .await?;
+        let response = send_provider_request(
+            self.id(),
+            self.client
+                .post(url.clone())
+                .headers(headers)
+                .body(payload)
+                .send(),
+        )
+        .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -159,7 +161,7 @@ impl crate::providers::Provider for AnthropicProvider {
             });
         }
 
-        Ok(response.bytes().await?)
+        read_provider_body(self.id(), response).await
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/anthropic.rs
+++ b/crates/braintrust-llm-router/src/providers/anthropic.rs
@@ -1,18 +1,17 @@
 use std::time::Duration;
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use reqwest::header::{HeaderMap, HeaderValue};
-use reqwest::Url;
-use reqwest_middleware::ClientWithMiddleware;
-
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::{read_provider_body, send_provider_request, ClientHeaders};
+use crate::providers::ClientHeaders;
 use crate::streaming::{sse_stream, RawResponseStream};
+use async_trait::async_trait;
+use bytes::Bytes;
 use lingua::ProviderFormat;
+use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::Url;
+use reqwest_middleware::ClientWithMiddleware;
 
 pub const ANTHROPIC_VERSION: &str = "anthropic-version";
 pub const DEFAULT_ANTHROPIC_VERSION_VALUE: &str = "2023-06-01";
@@ -128,15 +127,13 @@ impl crate::providers::Provider for AnthropicProvider {
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
-        let response = send_provider_request(
-            self.id(),
-            self.client
-                .post(url.clone())
-                .headers(headers)
-                .body(payload)
-                .send(),
-        )
-        .await?;
+        let response = self
+            .client
+            .post(url.clone())
+            .headers(headers)
+            .body(payload)
+            .send()
+            .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -161,7 +158,7 @@ impl crate::providers::Provider for AnthropicProvider {
             });
         }
 
-        read_provider_body(self.id(), response).await
+        Ok(response.bytes().await?)
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/azure.rs
+++ b/crates/braintrust-llm-router/src/providers/azure.rs
@@ -5,16 +5,16 @@ use bytes::Bytes;
 use lingua::serde_json::Value as MetadataValue;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::Url;
-use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::anthropic::{ANTHROPIC_VERSION, DEFAULT_ANTHROPIC_VERSION_VALUE};
-use crate::providers::{read_provider_body, ClientHeaders, Provider};
+use crate::providers::{ClientHeaders, Provider};
 use crate::streaming::{sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
+use reqwest_middleware::ClientWithMiddleware;
 
 #[derive(Debug, Clone)]
 pub struct AzureConfig {
@@ -271,7 +271,7 @@ impl crate::providers::Provider for AzureProvider {
             });
         }
 
-        read_provider_body(self.id(), response).await
+        Ok(response.bytes().await?)
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/azure.rs
+++ b/crates/braintrust-llm-router/src/providers/azure.rs
@@ -12,7 +12,7 @@ use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
 use crate::providers::anthropic::{ANTHROPIC_VERSION, DEFAULT_ANTHROPIC_VERSION_VALUE};
-use crate::providers::{ClientHeaders, Provider};
+use crate::providers::{read_provider_body, ClientHeaders, Provider};
 use crate::streaming::{sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
 
@@ -271,7 +271,7 @@ impl crate::providers::Provider for AzureProvider {
             });
         }
 
-        Ok(response.bytes().await?)
+        read_provider_body(self.id(), response).await
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/bedrock.rs
+++ b/crates/braintrust-llm-router/src/providers/bedrock.rs
@@ -18,7 +18,7 @@ use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::ClientHeaders;
+use crate::providers::{read_provider_body, ClientHeaders};
 use crate::streaming::{bedrock_event_stream, RawResponseStream};
 use lingua::ProviderFormat;
 
@@ -230,7 +230,13 @@ impl BedrockProvider {
             .headers(headers)
             .body(payload)
             .send()
-            .await?;
+            .await
+            .map_err(|err| {
+                Error::provider_transport_error(
+                    <BedrockProvider as crate::providers::Provider>::id(self),
+                    err,
+                )
+            })?;
 
         #[cfg(feature = "tracing")]
         {
@@ -280,7 +286,7 @@ impl crate::providers::Provider for BedrockProvider {
             self.converse_url(&spec.model, false)?
         };
         let response = self.send_signed(url, payload, auth, client_headers).await?;
-        Ok(response.bytes().await?)
+        read_provider_body(self.id(), response).await
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/bedrock.rs
+++ b/crates/braintrust-llm-router/src/providers/bedrock.rs
@@ -12,15 +12,15 @@ use http::Request as HttpRequest;
 use lingua::serde_json::Value;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use reqwest::Url;
-use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::{read_provider_body, ClientHeaders};
+use crate::providers::ClientHeaders;
 use crate::streaming::{bedrock_event_stream, RawResponseStream};
 use lingua::ProviderFormat;
+use reqwest_middleware::ClientWithMiddleware;
 
 #[derive(Debug, Clone)]
 pub struct BedrockConfig {
@@ -230,13 +230,7 @@ impl BedrockProvider {
             .headers(headers)
             .body(payload)
             .send()
-            .await
-            .map_err(|err| {
-                Error::provider_transport_error(
-                    <BedrockProvider as crate::providers::Provider>::id(self),
-                    err,
-                )
-            })?;
+            .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -286,7 +280,7 @@ impl crate::providers::Provider for BedrockProvider {
             self.converse_url(&spec.model, false)?
         };
         let response = self.send_signed(url, payload, auth, client_headers).await?;
-        read_provider_body(self.id(), response).await
+        Ok(response.bytes().await?)
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/databricks.rs
+++ b/crates/braintrust-llm-router/src/providers/databricks.rs
@@ -1,18 +1,17 @@
 use std::time::Duration;
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use reqwest::header::HeaderMap;
-use reqwest::Url;
-use reqwest_middleware::ClientWithMiddleware;
-
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::{read_provider_body, send_provider_request, ClientHeaders};
+use crate::providers::ClientHeaders;
 use crate::streaming::{sse_stream, RawResponseStream};
+use async_trait::async_trait;
+use bytes::Bytes;
 use lingua::ProviderFormat;
+use reqwest::header::HeaderMap;
+use reqwest::Url;
+use reqwest_middleware::ClientWithMiddleware;
 
 #[derive(Debug, Clone)]
 pub struct DatabricksConfig {
@@ -83,15 +82,13 @@ impl crate::providers::Provider for DatabricksProvider {
         let mut headers = client_headers.to_json_headers();
         auth.apply_headers(&mut headers)?;
 
-        let response = send_provider_request(
-            self.id(),
-            self.client
-                .post(url.clone())
-                .headers(headers)
-                .body(payload)
-                .send(),
-        )
-        .await?;
+        let response = self
+            .client
+            .post(url.clone())
+            .headers(headers)
+            .body(payload)
+            .send()
+            .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -116,7 +113,7 @@ impl crate::providers::Provider for DatabricksProvider {
             });
         }
 
-        read_provider_body(self.id(), response).await
+        Ok(response.bytes().await?)
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/databricks.rs
+++ b/crates/braintrust-llm-router/src/providers/databricks.rs
@@ -10,7 +10,7 @@ use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::ClientHeaders;
+use crate::providers::{read_provider_body, send_provider_request, ClientHeaders};
 use crate::streaming::{sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
 
@@ -83,13 +83,15 @@ impl crate::providers::Provider for DatabricksProvider {
         let mut headers = client_headers.to_json_headers();
         auth.apply_headers(&mut headers)?;
 
-        let response = self
-            .client
-            .post(url.clone())
-            .headers(headers)
-            .body(payload)
-            .send()
-            .await?;
+        let response = send_provider_request(
+            self.id(),
+            self.client
+                .post(url.clone())
+                .headers(headers)
+                .body(payload)
+                .send(),
+        )
+        .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -114,7 +116,7 @@ impl crate::providers::Provider for DatabricksProvider {
             });
         }
 
-        Ok(response.bytes().await?)
+        read_provider_body(self.id(), response).await
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/google.rs
+++ b/crates/braintrust-llm-router/src/providers/google.rs
@@ -10,7 +10,7 @@ use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::ClientHeaders;
+use crate::providers::{read_provider_body, send_provider_request, ClientHeaders};
 use crate::streaming::{sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
 
@@ -104,13 +104,15 @@ impl crate::providers::Provider for GoogleProvider {
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
-        let response = self
-            .client
-            .post(url.clone())
-            .headers(headers)
-            .body(payload)
-            .send()
-            .await?;
+        let response = send_provider_request(
+            self.id(),
+            self.client
+                .post(url.clone())
+                .headers(headers)
+                .body(payload)
+                .send(),
+        )
+        .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -135,7 +137,7 @@ impl crate::providers::Provider for GoogleProvider {
             });
         }
 
-        Ok(response.bytes().await?)
+        read_provider_body(self.id(), response).await
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/google.rs
+++ b/crates/braintrust-llm-router/src/providers/google.rs
@@ -1,18 +1,17 @@
 use std::time::Duration;
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use reqwest::header::HeaderMap;
-use reqwest::Url;
-use reqwest_middleware::ClientWithMiddleware;
-
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::{read_provider_body, send_provider_request, ClientHeaders};
+use crate::providers::ClientHeaders;
 use crate::streaming::{sse_stream, RawResponseStream};
+use async_trait::async_trait;
+use bytes::Bytes;
 use lingua::ProviderFormat;
+use reqwest::header::HeaderMap;
+use reqwest::Url;
+use reqwest_middleware::ClientWithMiddleware;
 
 #[derive(Debug, Clone)]
 pub struct GoogleConfig {
@@ -104,15 +103,13 @@ impl crate::providers::Provider for GoogleProvider {
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
-        let response = send_provider_request(
-            self.id(),
-            self.client
-                .post(url.clone())
-                .headers(headers)
-                .body(payload)
-                .send(),
-        )
-        .await?;
+        let response = self
+            .client
+            .post(url.clone())
+            .headers(headers)
+            .body(payload)
+            .send()
+            .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -137,7 +134,7 @@ impl crate::providers::Provider for GoogleProvider {
             });
         }
 
-        read_provider_body(self.id(), response).await
+        Ok(response.bytes().await?)
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/mistral.rs
+++ b/crates/braintrust-llm-router/src/providers/mistral.rs
@@ -10,7 +10,7 @@ use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::ClientHeaders;
+use crate::providers::{read_provider_body, send_provider_request, ClientHeaders};
 use crate::streaming::{sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
 
@@ -98,13 +98,15 @@ impl crate::providers::Provider for MistralProvider {
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
-        let response = self
-            .client
-            .post(url.clone())
-            .headers(headers)
-            .body(payload)
-            .send()
-            .await?;
+        let response = send_provider_request(
+            self.id(),
+            self.client
+                .post(url.clone())
+                .headers(headers)
+                .body(payload)
+                .send(),
+        )
+        .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -129,7 +131,7 @@ impl crate::providers::Provider for MistralProvider {
             });
         }
 
-        Ok(response.bytes().await?)
+        read_provider_body(self.id(), response).await
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/mistral.rs
+++ b/crates/braintrust-llm-router/src/providers/mistral.rs
@@ -1,18 +1,17 @@
 use std::time::Duration;
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use reqwest::header::HeaderMap;
-use reqwest::Url;
-use reqwest_middleware::ClientWithMiddleware;
-
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::{read_provider_body, send_provider_request, ClientHeaders};
+use crate::providers::ClientHeaders;
 use crate::streaming::{sse_stream, RawResponseStream};
+use async_trait::async_trait;
+use bytes::Bytes;
 use lingua::ProviderFormat;
+use reqwest::header::HeaderMap;
+use reqwest::Url;
+use reqwest_middleware::ClientWithMiddleware;
 
 #[derive(Debug, Clone)]
 pub struct MistralConfig {
@@ -98,15 +97,13 @@ impl crate::providers::Provider for MistralProvider {
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
-        let response = send_provider_request(
-            self.id(),
-            self.client
-                .post(url.clone())
-                .headers(headers)
-                .body(payload)
-                .send(),
-        )
-        .await?;
+        let response = self
+            .client
+            .post(url.clone())
+            .headers(headers)
+            .body(payload)
+            .send()
+            .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -131,7 +128,7 @@ impl crate::providers::Provider for MistralProvider {
             });
         }
 
-        read_provider_body(self.id(), response).await
+        Ok(response.bytes().await?)
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/mod.rs
+++ b/crates/braintrust-llm-router/src/providers/mod.rs
@@ -24,11 +24,12 @@ use bytes::Bytes;
 use lingua::serde_json::{self, Value};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::streaming::RawResponseStream;
 use lingua::ProviderFormat;
 
@@ -137,6 +138,28 @@ pub(crate) fn disable_streaming_payload(payload: Bytes) -> Bytes {
         Ok(serialized) => Bytes::from(serialized),
         Err(_) => payload,
     }
+}
+
+pub(crate) async fn send_provider_request<F>(
+    provider: &str,
+    request: F,
+) -> Result<reqwest::Response>
+where
+    F: Future<Output = std::result::Result<reqwest::Response, reqwest_middleware::Error>>,
+{
+    request
+        .await
+        .map_err(|err| Error::provider_transport_error(provider, err))
+}
+
+pub(crate) async fn read_provider_body(
+    provider: &str,
+    response: reqwest::Response,
+) -> Result<Bytes> {
+    response
+        .bytes()
+        .await
+        .map_err(|err| Error::provider_transport_error(provider, err))
 }
 
 /// Provider trait for LLM API backends.

--- a/crates/braintrust-llm-router/src/providers/mod.rs
+++ b/crates/braintrust-llm-router/src/providers/mod.rs
@@ -24,12 +24,11 @@ use bytes::Bytes;
 use lingua::serde_json::{self, Value};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
 use std::collections::HashMap;
-use std::future::Future;
 use std::sync::Arc;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::streaming::RawResponseStream;
 use lingua::ProviderFormat;
 
@@ -138,28 +137,6 @@ pub(crate) fn disable_streaming_payload(payload: Bytes) -> Bytes {
         Ok(serialized) => Bytes::from(serialized),
         Err(_) => payload,
     }
-}
-
-pub(crate) async fn send_provider_request<F>(
-    provider: &str,
-    request: F,
-) -> Result<reqwest::Response>
-where
-    F: Future<Output = std::result::Result<reqwest::Response, reqwest_middleware::Error>>,
-{
-    request
-        .await
-        .map_err(|err| Error::provider_transport_error(provider, err))
-}
-
-pub(crate) async fn read_provider_body(
-    provider: &str,
-    response: reqwest::Response,
-) -> Result<Bytes> {
-    response
-        .bytes()
-        .await
-        .map_err(|err| Error::provider_transport_error(provider, err))
 }
 
 /// Provider trait for LLM API backends.

--- a/crates/braintrust-llm-router/src/providers/openai.rs
+++ b/crates/braintrust-llm-router/src/providers/openai.rs
@@ -11,7 +11,7 @@ use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::ClientHeaders;
+use crate::providers::{read_provider_body, send_provider_request, ClientHeaders};
 use crate::streaming::{sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
 
@@ -195,13 +195,15 @@ impl crate::providers::Provider for OpenAIProvider {
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
-        let response = self
-            .client
-            .post(url.clone())
-            .headers(headers)
-            .body(payload)
-            .send()
-            .await?;
+        let response = send_provider_request(
+            self.id(),
+            self.client
+                .post(url.clone())
+                .headers(headers)
+                .body(payload)
+                .send(),
+        )
+        .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -226,7 +228,7 @@ impl crate::providers::Provider for OpenAIProvider {
             });
         }
 
-        Ok(response.bytes().await?)
+        read_provider_body(self.id(), response).await
     }
 
     async fn complete_stream(
@@ -252,13 +254,15 @@ impl crate::providers::Provider for OpenAIProvider {
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
-        let response = self
-            .client
-            .post(url.clone())
-            .headers(headers)
-            .body(payload)
-            .send()
-            .await?;
+        let response = send_provider_request(
+            self.id(),
+            self.client
+                .post(url.clone())
+                .headers(headers)
+                .body(payload)
+                .send(),
+        )
+        .await?;
 
         #[cfg(feature = "tracing")]
         {

--- a/crates/braintrust-llm-router/src/providers/openai.rs
+++ b/crates/braintrust-llm-router/src/providers/openai.rs
@@ -5,15 +5,15 @@ use bytes::Bytes;
 use lingua::serde_json::Value;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Url;
-use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::{read_provider_body, send_provider_request, ClientHeaders};
+use crate::providers::ClientHeaders;
 use crate::streaming::{sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
+use reqwest_middleware::ClientWithMiddleware;
 
 #[derive(Debug, Clone)]
 pub struct OpenAIConfig {
@@ -195,15 +195,13 @@ impl crate::providers::Provider for OpenAIProvider {
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
-        let response = send_provider_request(
-            self.id(),
-            self.client
-                .post(url.clone())
-                .headers(headers)
-                .body(payload)
-                .send(),
-        )
-        .await?;
+        let response = self
+            .client
+            .post(url.clone())
+            .headers(headers)
+            .body(payload)
+            .send()
+            .await?;
 
         #[cfg(feature = "tracing")]
         {
@@ -228,7 +226,7 @@ impl crate::providers::Provider for OpenAIProvider {
             });
         }
 
-        read_provider_body(self.id(), response).await
+        Ok(response.bytes().await?)
     }
 
     async fn complete_stream(
@@ -254,15 +252,13 @@ impl crate::providers::Provider for OpenAIProvider {
         let mut headers = self.build_headers(client_headers);
         auth.apply_headers(&mut headers)?;
 
-        let response = send_provider_request(
-            self.id(),
-            self.client
-                .post(url.clone())
-                .headers(headers)
-                .body(payload)
-                .send(),
-        )
-        .await?;
+        let response = self
+            .client
+            .post(url.clone())
+            .headers(headers)
+            .body(payload)
+            .send()
+            .await?;
 
         #[cfg(feature = "tracing")]
         {

--- a/crates/braintrust-llm-router/src/providers/vertex.rs
+++ b/crates/braintrust-llm-router/src/providers/vertex.rs
@@ -6,15 +6,15 @@ use lingua::serde_json::Value;
 use rand::Rng;
 use reqwest::header::HeaderMap;
 use reqwest::Url;
-use reqwest_middleware::ClientWithMiddleware;
 
 use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::{read_provider_body, ClientHeaders};
+use crate::providers::ClientHeaders;
 use crate::streaming::{sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
+use reqwest_middleware::ClientWithMiddleware;
 
 const DEFAULT_LOCATION: &str = "us-central1";
 const ANTHROPIC_DEFAULT_LOCATION: &str = "us-east5";
@@ -279,7 +279,7 @@ impl crate::providers::Provider for VertexProvider {
             });
         }
 
-        read_provider_body(self.id(), response).await
+        Ok(response.bytes().await?)
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/providers/vertex.rs
+++ b/crates/braintrust-llm-router/src/providers/vertex.rs
@@ -12,7 +12,7 @@ use crate::auth::AuthConfig;
 use crate::catalog::ModelSpec;
 use crate::client::{build_middleware_client, ClientSettings};
 use crate::error::{Error, Result, UpstreamHttpError};
-use crate::providers::ClientHeaders;
+use crate::providers::{read_provider_body, ClientHeaders};
 use crate::streaming::{sse_stream, RawResponseStream};
 use lingua::ProviderFormat;
 
@@ -279,7 +279,7 @@ impl crate::providers::Provider for VertexProvider {
             });
         }
 
-        Ok(response.bytes().await?)
+        read_provider_body(self.id(), response).await
     }
 
     async fn complete_stream(

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -449,7 +449,17 @@ impl Router {
                         sleep(delay).await;
                         continue;
                     } else {
-                        return Err(err);
+                        return Err(match err {
+                            Error::Http(source) => Error::UpstreamUnavailable {
+                                provider: provider.id().to_string(),
+                                source: source.into(),
+                            },
+                            Error::Middleware(source) => Error::UpstreamUnavailable {
+                                provider: provider.id().to_string(),
+                                source: source.into(),
+                            },
+                            other => other,
+                        });
                     }
                 }
             }

--- a/crates/braintrust-llm-router/tests/router.rs
+++ b/crates/braintrust-llm-router/tests/router.rs
@@ -344,8 +344,98 @@ impl Provider for FailingProvider {
     }
 }
 
-#[tokio::test]
-async fn router_retries_and_propagates_terminal_error() {
+#[derive(Clone)]
+struct HttpFailingProvider;
+
+#[async_trait]
+impl Provider for HttpFailingProvider {
+    fn id(&self) -> &'static str {
+        "http-failing"
+    }
+
+    fn provider_formats(&self) -> Vec<ProviderFormat> {
+        vec![ProviderFormat::ChatCompletions]
+    }
+
+    async fn complete(
+        &self,
+        _payload: Bytes,
+        _auth: &AuthConfig,
+        _spec: &ModelSpec,
+        _format: ProviderFormat,
+        _client_headers: &ClientHeaders,
+    ) -> braintrust_llm_router::Result<Bytes> {
+        let err = reqwest::Client::new()
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .expect_err("connection failure");
+        Err(err.into())
+    }
+
+    async fn complete_stream(
+        &self,
+        _payload: Bytes,
+        _auth: &AuthConfig,
+        _spec: &ModelSpec,
+        _format: ProviderFormat,
+        _client_headers: &ClientHeaders,
+    ) -> braintrust_llm_router::Result<RawResponseStream> {
+        Ok(Box::pin(tokio_stream::empty()))
+    }
+
+    async fn health_check(&self, _auth: &AuthConfig) -> braintrust_llm_router::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct MiddlewareFailingProvider;
+
+#[async_trait]
+impl Provider for MiddlewareFailingProvider {
+    fn id(&self) -> &'static str {
+        "middleware-failing"
+    }
+
+    fn provider_formats(&self) -> Vec<ProviderFormat> {
+        vec![ProviderFormat::ChatCompletions]
+    }
+
+    async fn complete(
+        &self,
+        _payload: Bytes,
+        _auth: &AuthConfig,
+        _spec: &ModelSpec,
+        _format: ProviderFormat,
+        _client_headers: &ClientHeaders,
+    ) -> braintrust_llm_router::Result<Bytes> {
+        let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build();
+        let err = client
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .expect_err("connection failure");
+        Err(err.into())
+    }
+
+    async fn complete_stream(
+        &self,
+        _payload: Bytes,
+        _auth: &AuthConfig,
+        _spec: &ModelSpec,
+        _format: ProviderFormat,
+        _client_headers: &ClientHeaders,
+    ) -> braintrust_llm_router::Result<RawResponseStream> {
+        Ok(Box::pin(tokio_stream::empty()))
+    }
+
+    async fn health_check(&self, _auth: &AuthConfig) -> braintrust_llm_router::Result<()> {
+        Ok(())
+    }
+}
+
+fn retry_model_catalog() -> Arc<ModelCatalog> {
     let mut catalog = ModelCatalog::empty();
     catalog.insert(
         "retry-model".into(),
@@ -367,8 +457,11 @@ async fn router_retries_and_propagates_terminal_error() {
             available_providers: Default::default(),
         },
     );
-    let catalog = Arc::new(catalog);
+    Arc::new(catalog)
+}
 
+#[tokio::test]
+async fn router_retries_and_propagates_terminal_error() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let retry_policy = RetryPolicy {
         max_attempts: 2,
@@ -380,7 +473,7 @@ async fn router_retries_and_propagates_terminal_error() {
 
     let router = RouterBuilder::new()
         .with_retry_policy(retry_policy)
-        .with_catalog(Arc::clone(&catalog))
+        .with_catalog(retry_model_catalog())
         .add_provider(
             "failing",
             FailingProvider {
@@ -413,4 +506,102 @@ async fn router_retries_and_propagates_terminal_error() {
     let err = err.expect_err("terminal error");
     assert!(matches!(err, Error::Timeout));
     assert_eq!(attempts.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn router_maps_terminal_http_errors_to_upstream_unavailable() {
+    let retry_policy = RetryPolicy {
+        max_attempts: 0,
+        initial_delay: Duration::from_millis(0),
+        max_delay: Duration::from_millis(0),
+        exponential_base: 2.0,
+        jitter: false,
+    };
+
+    let router = RouterBuilder::new()
+        .with_retry_policy(retry_policy)
+        .with_catalog(retry_model_catalog())
+        .add_provider(
+            "http-failing",
+            HttpFailingProvider,
+            AuthConfig::ApiKey {
+                key: "test".into(),
+                header: None,
+                prefix: None,
+            },
+            vec![ProviderFormat::ChatCompletions],
+        )
+        .build()
+        .expect("router builds");
+
+    let body = to_body(json!({
+        "model": "retry-model",
+        "messages": [{"role": "user", "content": "Ping"}]
+    }));
+
+    let err = router
+        .complete(
+            body,
+            "retry-model",
+            ProviderFormat::ChatCompletions,
+            &ClientHeaders::default(),
+        )
+        .await
+        .expect_err("terminal error");
+
+    match err {
+        Error::UpstreamUnavailable { provider, .. } => {
+            assert_eq!(provider, "http-failing");
+        }
+        other => panic!("expected UpstreamUnavailable, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn router_maps_terminal_middleware_errors_to_upstream_unavailable() {
+    let retry_policy = RetryPolicy {
+        max_attempts: 0,
+        initial_delay: Duration::from_millis(0),
+        max_delay: Duration::from_millis(0),
+        exponential_base: 2.0,
+        jitter: false,
+    };
+
+    let router = RouterBuilder::new()
+        .with_retry_policy(retry_policy)
+        .with_catalog(retry_model_catalog())
+        .add_provider(
+            "middleware-failing",
+            MiddlewareFailingProvider,
+            AuthConfig::ApiKey {
+                key: "test".into(),
+                header: None,
+                prefix: None,
+            },
+            vec![ProviderFormat::ChatCompletions],
+        )
+        .build()
+        .expect("router builds");
+
+    let body = to_body(json!({
+        "model": "retry-model",
+        "messages": [{"role": "user", "content": "Ping"}]
+    }));
+
+    let err = router
+        .complete(
+            body,
+            "retry-model",
+            ProviderFormat::ChatCompletions,
+            &ClientHeaders::default(),
+        )
+        .await
+        .expect_err("terminal error");
+
+    match err {
+        Error::UpstreamUnavailable { provider, .. } => {
+            assert_eq!(provider, "middleware-failing");
+        }
+        other => panic!("expected UpstreamUnavailable, got {other:?}"),
+    }
 }


### PR DESCRIPTION
For intermittent connection reset by peer, we should retry the request.