### PR TITLE
google vertex models resolve to google format regardless of model spec format

### DIFF
--- a/crates/braintrust-llm-router/src/catalog/resolver.rs
+++ b/crates/braintrust-llm-router/src/catalog/resolver.rs
@@ -41,6 +41,11 @@ impl ModelResolver {
             && lingua::is_vertex_anthropic_model(model)
         {
             ProviderFormat::VertexAnthropic
+        } else if lingua::is_vertex_google_model(model) {
+            // Force Google format regardless of what the spec says.
+            // Custom models may declare format:openai but Vertex's Generative AI
+            // API requires the Google generateContent wire format.
+            ProviderFormat::Google
         } else {
             spec.format
         };
@@ -205,6 +210,18 @@ mod tests {
 
         let (_, format, aliases) = resolver.resolve(model).expect("resolves");
         assert_eq!(format, ProviderFormat::VertexAnthropic);
+        assert_eq!(aliases, vec!["vertex".to_string()]);
+    }
+
+    #[test]
+    fn resolve_vertex_google_model_with_openai_format_forces_google() {
+        let model = "publishers/google/models/gemini-2.5-flash";
+        let mut catalog = ModelCatalog::empty();
+        catalog.insert(model.into(), spec(model, ProviderFormat::ChatCompletions));
+        let resolver = ModelResolver::new(Arc::new(catalog));
+
+        let (_, format, aliases) = resolver.resolve(model).expect("resolves");
+        assert_eq!(format, ProviderFormat::Google);
         assert_eq!(aliases, vec!["vertex".to_string()]);
     }
 

--- a/crates/lingua/src/lib.rs
+++ b/crates/lingua/src/lib.rs
@@ -51,7 +51,7 @@ pub use providers::bedrock_anthropic::{is_bedrock_anthropic_model, is_bedrock_an
 
 // Re-export vertex model utilities for router integration
 #[cfg(feature = "google")]
-pub use providers::google::is_vertex_model;
+pub use providers::google::{is_vertex_google_model, is_vertex_model};
 
 // Re-export vertex-anthropic model utilities for router integration
 #[cfg(feature = "anthropic")]

--- a/crates/lingua/src/providers/google/mod.rs
+++ b/crates/lingua/src/providers/google/mod.rs
@@ -39,3 +39,38 @@ pub type SafetySettings = Vec<SafetySetting>;
 pub fn is_vertex_model(model: &str) -> bool {
     model.starts_with("publishers/")
 }
+
+/// Returns true if the model is a Google model hosted on Vertex AI.
+///
+/// These models have IDs starting with `publishers/google/`
+/// (e.g. `publishers/google/models/gemini-2.5-flash`).
+pub fn is_vertex_google_model(model: &str) -> bool {
+    model.starts_with("publishers/google/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_vertex_google_model_matches_publishers_google_prefix() {
+        assert!(is_vertex_google_model(
+            "publishers/google/models/gemini-2.5-flash"
+        ));
+        assert!(is_vertex_google_model(
+            "publishers/google/models/gemini-pro"
+        ));
+        assert!(is_vertex_google_model("publishers/google/something-else"));
+    }
+
+    #[test]
+    fn is_vertex_google_model_rejects_other_publishers() {
+        assert!(!is_vertex_google_model(
+            "publishers/anthropic/models/claude-haiku-4-5"
+        ));
+        assert!(!is_vertex_google_model("publishers/meta/models/llama3"));
+        assert!(!is_vertex_google_model("gemini-2.5-flash"));
+        assert!(!is_vertex_google_model("publishers/"));
+        assert!(!is_vertex_google_model(""));
+    }
+}


### PR DESCRIPTION
To align behavior with old proxy, we need to always resolve google vertex models to the google format.  
  
previously, the code would just think to passthrough chat completions and error out since the output format and api format was chat completions

