### PR TITLE
Fix setup.sh: Pin python 3.11 for PyO3 (0.20)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ typescript: generate-types lingua-wasm ## Build TypeScript bindings (WASM)
 
 python: ## Build Python bindings (PyO3)
 	@echo "Building Python bindings..."
-	cd bindings/python && uv sync --all-extras --group dev
+	cd bindings/python && uv sync --python 3.11 --all-extras --group dev
 
 test: test-rust test-typescript test-python test-payloads ## Run all tests
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -81,7 +81,7 @@ if [ -f "bindings/python/pyproject.toml" ]; then
 
     echo "📦 Installing Python dependencies..."
     cd bindings/python
-    uv sync --extra dev
+    uv sync --python 3.11 --extra dev
     cd ../..
 fi
 


### PR DESCRIPTION
### Summary
- Pin python 3.11 in `scripts/setup.sh` + `make python` because PyO3 fails to build on 3.14 and 3.13
- Use python 3.11 instead of 3.12 for consistency with `.github/workflows/ci.yml` (and I don't see python versions declared anywhere else)

### Test plan
Before:
```sh
$ scripts/setup.sh
...
🐍 Setting up Python environment...
📦 Installing Python dependencies...
Resolved 44 packages in 13ms
  × Failed to build `jiter==0.9.1`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `maturin.build_wheel` failed (exit status: 1)

      [stdout]
      Running `maturin pep517 build-wheel -i /Users/dan/.cache/uv/builds-v0/.tmpRHwpKj/bin/python --compatibility off`

      [stderr]
      🔗 Found pyo3 bindings
      🐍 Found CPython 3.14 at /Users/dan/.cache/uv/builds-v0/.tmpRHwpKj/bin/python
      📡 Using build options features, bindings from pyproject.toml
      💻 Using `MACOSX_DEPLOYMENT_TARGET=11.0` for aarch64-apple-darwin by default
         Compiling pyo3-build-config v0.24.2
         Compiling pyo3-macros-backend v0.24.2
         Compiling pyo3-ffi v0.24.2
         Compiling pyo3 v0.24.2
         Compiling jiter v0.9.1 (/Users/dan/.cache/uv/sdists-v9/pypi/jiter/0.9.1/uUN5VlmBzy6i1HMrhyRR4/src/crates/jiter)
      error: failed to run custom build command for `pyo3-ffi v0.24.2`

      Caused by:
        process didn't exit successfully:
      `/Users/dan/.cache/uv/sdists-v9/pypi/jiter/0.9.1/uUN5VlmBzy6i1HMrhyRR4/src/target/release/build/pyo3-ffi-83bd9f1fbab8b137/build-script-build`
      (exit status: 1)
        --- stdout
        cargo:rustc-check-cfg=cfg(Py_LIMITED_API)
        cargo:rustc-check-cfg=cfg(Py_GIL_DISABLED)
        cargo:rustc-check-cfg=cfg(PyPy)
        cargo:rustc-check-cfg=cfg(GraalPy)
        cargo:rustc-check-cfg=cfg(py_sys_config, values("Py_DEBUG", "Py_REF_DEBUG", "Py_TRACE_REFS", "COUNT_ALLOCS"))
        cargo:rustc-check-cfg=cfg(pyo3_disable_reference_pool)
        cargo:rustc-check-cfg=cfg(pyo3_leak_on_drop_without_reference_pool)
        cargo:rustc-check-cfg=cfg(Py_3_7)
        cargo:rustc-check-cfg=cfg(Py_3_8)
        cargo:rustc-check-cfg=cfg(Py_3_9)
        cargo:rustc-check-cfg=cfg(Py_3_10)
        cargo:rustc-check-cfg=cfg(Py_3_11)
        cargo:rustc-check-cfg=cfg(Py_3_12)
        cargo:rustc-check-cfg=cfg(Py_3_13)
        cargo:rustc-check-cfg=cfg(Py_3_14)
        cargo:rerun-if-env-changed=PYO3_CROSS
        cargo:rerun-if-env-changed=PYO3_CROSS_LIB_DIR
        cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_VERSION
        cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_IMPLEMENTATION
        cargo:rerun-if-env-changed=PYO3_PRINT_CONFIG
        cargo:rerun-if-env-changed=PYO3_USE_ABI3_FORWARD_COMPATIBILITY

        --- stderr
        error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)
        = help: please check if an updated version of PyO3 is available. Current version: 0.24.2
        = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI
      warning: build failed, waiting for other jobs to finish...
      💥 maturin failed
        Caused by: Failed to build a native library through cargo
        Caused by: Cargo build finished with "exit status: 101": `env -u CARGO MACOSX_DEPLOYMENT_TARGET="11.0" PYO3_BUILD_EXTENSION_MODULE="1"
      PYO3_ENVIRONMENT_SIGNATURE="cpython-3.14-64bit" PYO3_PYTHON="/Users/dan/.cache/uv/builds-v0/.tmpRHwpKj/bin/python"
      PYTHON_SYS_EXECUTABLE="/Users/dan/.cache/uv/builds-v0/.tmpRHwpKj/bin/python" "cargo" "rustc" "--profile" "release" "--features"
      "pyo3/extension-module" "--features" "pyo3/generate-import-lib" "--message-format" "json-render-diagnostics" "--manifest-path"
      "/Users/dan/.cache/uv/sdists-v9/pypi/jiter/0.9.1/uUN5VlmBzy6i1HMrhyRR4/src/crates/jiter-python/Cargo.toml" "--lib" "--crate-type" "cdylib" "--"
      "-C" "link-arg=-undefined" "-C" "link-arg=dynamic_lookup" "-C" "link-args=-Wl,-install_name,@rpath/jiter.cpython-314-darwin.so"`
      Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/Users/dan/.cache/uv/builds-v0/.tmpRHwpKj/bin/python', '--compatibility', 'off']
      returned non-zero exit status 1

      hint: This usually indicates a problem with the package or the build environment.
  help: `jiter` (v0.9.1) was included because `braintrust-lingua:dev` (v0.1.0) depends on `openai` (v2.1.0) which depends on `jiter`
```

After:
```sh
$ scripts/setup.sh
...
🐍 Setting up Python environment...
📦 Installing Python dependencies...
Using CPython 3.11.15
Removed virtual environment at: .venv
Creating virtual environment at: .venv
Resolved 44 packages in 5ms
Installed 41 packages in 69ms
 + annotated-types==0.7.0
 + anthropic==0.69.0
 + anyio==4.5.2
 + appnope==0.1.4
 + asttokens==3.0.0
 + backcall==0.2.0
 + braintrust-lingua==0.1.0 (from file:///Users/dan/work/lingua/bindings/python)
 + certifi==2025.8.3
 + decorator==5.2.1
 + distro==1.9.0
 + docstring-parser==0.17.0
 + executing==2.2.1
 + h11==0.16.0
 + httpcore==1.0.9
 + httpx==0.28.1
 + idna==3.10
 + iniconfig==2.1.0
 + ipython==8.12.3
 + jedi==0.19.2
 + jiter==0.9.1
 + matplotlib-inline==0.1.7
 + maturin==1.9.4
 + openai==2.1.0
 + packaging==25.0
 + parso==0.8.5
 + pexpect==4.9.0
 + pickleshare==0.7.5
 + pluggy==1.5.0
 + prompt-toolkit==3.0.52
 + ptyprocess==0.7.0
 + pure-eval==0.2.3
 + pydantic==2.10.6
 + pydantic-core==2.27.2
 + pygments==2.19.2
 + pytest==8.3.5
 + sniffio==1.3.1
 + stack-data==0.6.3
 + tqdm==4.67.1
 + traitlets==5.14.3
 + typing-extensions==4.13.2
 + wcwidth==0.2.14
✅ Setup complete!
```

```sh
$ make python
Building Python bindings...
cd bindings/python && uv sync --python 3.11 --all-extras --group dev
Resolved 44 packages in 14ms
Checked 41 packages in 8ms
```