### PR TITLE
return metadata for logging when sending a completion request

### DIFF
--- a/crates/braintrust-llm-router/examples/custom_auth.rs
+++ b/crates/braintrust-llm-router/examples/custom_auth.rs
@@ -136,7 +136,7 @@ async fn main() -> Result<()> {
 
     println!("   Sending authenticated request to GPT-4...");
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let bytes: Bytes = router
+    let (bytes, _) = router
         .complete(
             body,
             model,

--- a/crates/braintrust-llm-router/examples/custom_auth.rs
+++ b/crates/braintrust-llm-router/examples/custom_auth.rs
@@ -136,14 +136,10 @@ async fn main() -> Result<()> {
 
     println!("   Sending authenticated request to GPT-4...");
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let (bytes, _) = router
-        .complete(
-            body,
-            model,
-            ProviderFormat::ChatCompletions,
-            &ClientHeaders::default(),
-        )
+    let (request, _metadata) = router
+        .create_request(body, model, ProviderFormat::ChatCompletions)
         .await?;
+    let bytes = router.complete(request, &ClientHeaders::default()).await?;
     let response: Value = serde_json::from_slice(&bytes)?;
 
     if let Some(text) = extract_assistant_text(&response) {

--- a/crates/braintrust-llm-router/examples/multi_provider.rs
+++ b/crates/braintrust-llm-router/examples/multi_provider.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<()> {
             )
             .await
         {
-            Ok(bytes) => {
+            Ok((bytes, _)) => {
                 if let Ok(response) = serde_json::from_slice::<Value>(&bytes) {
                     if let Some(text) = extract_assistant_text(&response) {
                         println!("   Response: {}\n", text.trim());
@@ -122,7 +122,7 @@ async fn main() -> Result<()> {
             )
             .await
         {
-            Ok(bytes) => {
+            Ok((bytes, _)) => {
                 if let Ok(response) = serde_json::from_slice::<Value>(&bytes) {
                     if let Some(text) = extract_assistant_text(&response) {
                         println!("   Response: {}\n", text.trim());

--- a/crates/braintrust-llm-router/examples/multi_provider.rs
+++ b/crates/braintrust-llm-router/examples/multi_provider.rs
@@ -83,19 +83,19 @@ async fn main() -> Result<()> {
 
         let body = Bytes::from(serde_json::to_vec(&payload)?);
         match router
-            .complete(
-                body,
-                model,
-                ProviderFormat::ChatCompletions,
-                &ClientHeaders::default(),
-            )
+            .create_request(body, model, ProviderFormat::ChatCompletions)
             .await
         {
-            Ok((bytes, _)) => {
-                if let Ok(response) = serde_json::from_slice::<Value>(&bytes) {
-                    if let Some(text) = extract_assistant_text(&response) {
-                        println!("   Response: {}\n", text.trim());
+            Ok((request, _metadata)) => {
+                match router.complete(request, &ClientHeaders::default()).await {
+                    Ok(bytes) => {
+                        if let Ok(response) = serde_json::from_slice::<Value>(&bytes) {
+                            if let Some(text) = extract_assistant_text(&response) {
+                                println!("   Response: {}\n", text.trim());
+                            }
+                        }
                     }
+                    Err(e) => println!("   Error: {e}\n"),
                 }
             }
             Err(e) => println!("   Error: {e}\n"),
@@ -114,19 +114,19 @@ async fn main() -> Result<()> {
 
         let body = Bytes::from(serde_json::to_vec(&payload)?);
         match router
-            .complete(
-                body,
-                model,
-                ProviderFormat::ChatCompletions,
-                &ClientHeaders::default(),
-            )
+            .create_request(body, model, ProviderFormat::ChatCompletions)
             .await
         {
-            Ok((bytes, _)) => {
-                if let Ok(response) = serde_json::from_slice::<Value>(&bytes) {
-                    if let Some(text) = extract_assistant_text(&response) {
-                        println!("   Response: {}\n", text.trim());
+            Ok((request, _metadata)) => {
+                match router.complete(request, &ClientHeaders::default()).await {
+                    Ok(bytes) => {
+                        if let Ok(response) = serde_json::from_slice::<Value>(&bytes) {
+                            if let Some(text) = extract_assistant_text(&response) {
+                                println!("   Response: {}\n", text.trim());
+                            }
+                        }
                     }
+                    Err(e) => println!("   Error: {e}\n"),
                 }
             }
             Err(e) => println!("   Error: {e}\n"),

--- a/crates/braintrust-llm-router/examples/simple.rs
+++ b/crates/braintrust-llm-router/examples/simple.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
 
     // Convert payload to bytes and send request
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let bytes: Bytes = router
+    let (bytes, _) = router
         .complete(
             body,
             model,

--- a/crates/braintrust-llm-router/examples/simple.rs
+++ b/crates/braintrust-llm-router/examples/simple.rs
@@ -61,14 +61,10 @@ async fn main() -> Result<()> {
 
     // Convert payload to bytes and send request
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let (bytes, _) = router
-        .complete(
-            body,
-            model,
-            ProviderFormat::ChatCompletions,
-            &ClientHeaders::default(),
-        )
+    let (request, _metadata) = router
+        .create_request(body, model, ProviderFormat::ChatCompletions)
         .await?;
+    let bytes = router.complete(request, &ClientHeaders::default()).await?;
     let response: Value = serde_json::from_slice(&bytes)?;
 
     println!("📝 Response:\n");

--- a/crates/braintrust-llm-router/examples/streaming.rs
+++ b/crates/braintrust-llm-router/examples/streaming.rs
@@ -60,13 +60,11 @@ async fn main() -> Result<()> {
     });
 
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let (mut stream, _) = router
-        .complete_stream(
-            body,
-            model,
-            ProviderFormat::ChatCompletions,
-            &ClientHeaders::default(),
-        )
+    let (request, _metadata) = router
+        .create_stream_request(body, model, ProviderFormat::ChatCompletions)
+        .await?;
+    let mut stream = router
+        .complete_stream(request, &ClientHeaders::default())
         .await?;
 
     // Process the stream
@@ -139,13 +137,11 @@ async fn main() -> Result<()> {
             "stream": true
         });
         let body = Bytes::from(serde_json::to_vec(&payload)?);
-        let (stream, _) = router
-            .complete_stream(
-                body,
-                model,
-                ProviderFormat::ChatCompletions,
-                &ClientHeaders::default(),
-            )
+        let (request, _metadata) = router
+            .create_stream_request(body, model, ProviderFormat::ChatCompletions)
+            .await?;
+        let stream = router
+            .complete_stream(request, &ClientHeaders::default())
             .await?;
         streams.push((model.to_string(), stream));
     }

--- a/crates/braintrust-llm-router/examples/streaming.rs
+++ b/crates/braintrust-llm-router/examples/streaming.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
     });
 
     let body = Bytes::from(serde_json::to_vec(&payload)?);
-    let mut stream: ResponseStream = router
+    let (mut stream, _) = router
         .complete_stream(
             body,
             model,
@@ -139,7 +139,7 @@ async fn main() -> Result<()> {
             "stream": true
         });
         let body = Bytes::from(serde_json::to_vec(&payload)?);
-        let stream = router
+        let (stream, _) = router
             .complete_stream(
                 body,
                 model,

--- a/crates/braintrust-llm-router/src/lib.rs
+++ b/crates/braintrust-llm-router/src/lib.rs
@@ -31,7 +31,9 @@ pub use providers::{
     OpenAICompatibleEndpoint, OpenAIConfig, OpenAIProvider, Provider, VertexConfig, VertexProvider,
 };
 pub use retry::{RetryPolicy, RetryStrategy};
-pub use router::{create_provider, extract_request_hints, RequestHints, Router, RouterBuilder};
+pub use router::{
+    create_provider, extract_request_hints, RequestHints, Router, RouterBuilder, RouterMetadata,
+};
 pub use streaming::{RawResponseStream, ResponseStream, StreamChunk};
 
 // Provider trait requirement (for custom provider implementations)

--- a/crates/braintrust-llm-router/src/lib.rs
+++ b/crates/braintrust-llm-router/src/lib.rs
@@ -32,7 +32,8 @@ pub use providers::{
 };
 pub use retry::{RetryPolicy, RetryStrategy};
 pub use router::{
-    create_provider, extract_request_hints, RequestHints, Router, RouterBuilder, RouterMetadata,
+    create_provider, extract_request_hints, PreparedRequest, PreparedStreamRequest, RequestHints,
+    Router, RouterBuilder, RouterMetadata,
 };
 pub use streaming::{RawResponseStream, ResponseStream, StreamChunk};
 

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -266,9 +266,13 @@ impl Router {
         &self,
         model: &str,
         output_format: ProviderFormat,
-    ) -> Result<Vec<String>> {
-        self.resolve_providers(model, output_format)
-            .map(|routes| routes.into_iter().map(|(alias, ..)| alias).collect())
+    ) -> Result<Vec<(String, ProviderFormat)>> {
+        self.resolve_providers(model, output_format).map(|routes| {
+            routes
+                .into_iter()
+                .map(|(alias, _, _, _, format, _)| (alias, format))
+                .collect()
+        })
     }
 
     /// Resolve all providers for a given model and output format.
@@ -802,13 +806,13 @@ mod tests {
             router
                 .provider_aliases(vertex_model, ProviderFormat::Google)
                 .unwrap(),
-            vec!["vertex".to_string()]
+            vec![("vertex".to_string(), ProviderFormat::Google)]
         );
         assert_eq!(
             router
                 .provider_aliases(google_model, ProviderFormat::Google)
                 .unwrap(),
-            vec!["google".to_string()]
+            vec![("google".to_string(), ProviderFormat::Google)]
         );
     }
 
@@ -837,7 +841,7 @@ mod tests {
             router
                 .provider_aliases(vertex_model, ProviderFormat::Google)
                 .unwrap(),
-            vec!["google".to_string()]
+            vec![("google".to_string(), ProviderFormat::Google)]
         );
     }
 
@@ -1108,7 +1112,13 @@ mod tests {
         let aliases = router
             .provider_aliases(model, ProviderFormat::ChatCompletions)
             .expect("provider_aliases");
-        assert_eq!(aliases, vec!["openai".to_string(), "azure".to_string()]);
+        assert_eq!(
+            aliases,
+            vec![
+                ("openai".to_string(), ProviderFormat::ChatCompletions),
+                ("azure".to_string(), ProviderFormat::ChatCompletions),
+            ]
+        );
     }
 
     #[test]
@@ -1144,7 +1154,7 @@ mod tests {
             router
                 .provider_aliases(model, ProviderFormat::ChatCompletions)
                 .unwrap(),
-            vec!["other_gpt".to_string()],
+            vec![("other_gpt".to_string(), ProviderFormat::ChatCompletions)],
             "provider_aliases returns only registered providers from available_providers"
         );
     }

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -102,7 +102,7 @@ pub fn create_provider(
 
 /// Resolved route information from model resolution.
 type ResolvedRoute<'a> = (
-    String,
+    String, // alias
     Arc<dyn Provider>,
     &'a AuthConfig,
     Arc<ModelSpec>,
@@ -110,7 +110,8 @@ type ResolvedRoute<'a> = (
     RetryStrategy,
 );
 
-/// Metadata about how an incoming request was interpreted.
+/// Metadata about how an incoming request was interpreted, mainly to be used
+/// for observability.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouterMetadata {
     /// The detected format of the incoming request payload.
@@ -119,6 +120,33 @@ pub struct RouterMetadata {
     /// that format. When the payload was transformed, this is the source format
     /// that was detected.
     pub detected_input_format: ProviderFormat,
+
+    /// The alias of the provider that was used to execute the request.
+    pub provider_alias: String,
+
+    /// The output format of the provider response, which may not always match
+    /// the requested output format.
+    pub provider_format: ProviderFormat,
+}
+
+/// Request prepared by the router and ready for execution.
+pub struct PreparedRequest<'a> {
+    inner: PreparedRequestInner<'a>,
+}
+
+/// Streaming request prepared by the router and ready for execution.
+pub struct PreparedStreamRequest<'a> {
+    inner: PreparedRequestInner<'a>,
+}
+
+struct PreparedRequestInner<'a> {
+    provider: Arc<dyn Provider>,
+    auth: &'a AuthConfig,
+    spec: Arc<ModelSpec>,
+    format: ProviderFormat,
+    payload: Bytes,
+    output_format: ProviderFormat,
+    strategy: RetryStrategy,
 }
 
 async fn prepare_provider_request(
@@ -173,139 +201,167 @@ impl Router {
         Arc::clone(&self.catalog)
     }
 
-    /// Execute a completion request with the given body bytes.
+    // Internal method to create a prepared request, handles streaming and non-streaming requests.
+    async fn create_prepared_request_internal(
+        &self,
+        body: Bytes,
+        model: &str,
+        output_format: ProviderFormat,
+        stream: bool,
+    ) -> Result<(PreparedRequestInner<'_>, RouterMetadata)> {
+        let routes = self.resolve_providers(model, output_format)?;
+        let route = routes
+            .first()
+            .ok_or_else(|| Error::NoProvider(output_format))?;
+        let (provider_alias, provider, auth, spec, format, strategy) = route;
+        let (payload, detected_format) =
+            prepare_provider_request(body, spec.as_ref(), *format, stream).await?;
+        Ok((
+            PreparedRequestInner {
+                provider: provider.clone(),
+                auth,
+                spec: spec.clone(),
+                format: *format,
+                payload,
+                output_format,
+                strategy: strategy.clone(),
+            },
+            RouterMetadata {
+                detected_input_format: detected_format.unwrap_or(*format),
+                provider_alias: provider_alias.clone(),
+                provider_format: *format,
+            },
+        ))
+    }
+
+    /// Create a prepared request from raw body bytes.
     ///
     /// # Arguments
     ///
     /// * `body` - Raw request body bytes in any supported format (OpenAI, Anthropic, Google, etc.)
     /// * `model` - The model name for routing (e.g., "gpt-4", "claude-3-opus")
     /// * `output_format` - The output format, or None to auto-detect from body
-    /// * `client_headers` - Client headers to forward to the upstream provider
     ///
-    /// The body will be automatically transformed to the target provider's format if needed.
-    /// The response will be converted to the requested output format.
+    /// The body will be automatically transformed to the selected provider format if needed.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "bt.router.create_request",
+            skip(self, body),
+            fields(llm.model = %model)
+        )
+    )]
+    pub async fn create_request(
+        &self,
+        body: Bytes,
+        model: &str,
+        output_format: ProviderFormat,
+    ) -> Result<(PreparedRequest<'_>, RouterMetadata)> {
+        let (inner, metadata) = self
+            .create_prepared_request_internal(body, model, output_format, false)
+            .await?;
+        Ok((PreparedRequest { inner }, metadata))
+    }
+
+    /// Execute a prepared request and return transformed response bytes.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
             name = "bt.router.complete",
-            skip(self, body, client_headers),
-            fields(llm.model = %model)
+            skip(self, request, client_headers),
+            fields(llm.model = %request.inner.spec.model)
         )
     )]
     pub async fn complete(
         &self,
-        body: Bytes,
-        model: &str,
-        output_format: ProviderFormat,
+        request: PreparedRequest<'_>,
         client_headers: &ClientHeaders,
-    ) -> Result<(Bytes, RouterMetadata)> {
-        let routes = self.resolve_providers(model, output_format)?;
-        // Choose the first provider
-        let route = routes
-            .first()
-            .ok_or_else(|| Error::NoProvider(output_format))?;
-        let (_, provider, auth, spec, format, strategy) = route;
-        let (payload, detected_format) =
-            prepare_provider_request(body, spec.as_ref(), *format, false).await?;
-        let input_format = detected_format.unwrap_or(*format);
-
+    ) -> Result<Bytes> {
+        let PreparedRequestInner {
+            provider,
+            auth,
+            spec,
+            format,
+            payload,
+            output_format,
+            strategy,
+        } = request.inner;
         let response_bytes = self
             .execute_with_retry(
-                provider.clone(),
+                provider,
                 auth,
-                spec.clone(),
-                *format,
+                spec,
+                format,
                 payload,
-                strategy.clone(),
+                strategy,
                 client_headers,
             )
             .await?;
-
         let result = lingua::transform_response(response_bytes.clone(), output_format)?;
-
         let response = match result {
             TransformResult::PassThrough(bytes) => bytes,
             TransformResult::Transformed { bytes, .. } => bytes,
         };
-
-        Ok((
-            response,
-            RouterMetadata {
-                detected_input_format: input_format,
-            },
-        ))
+        Ok(response)
     }
 
-    /// Execute a streaming completion request with the given body bytes.
+    /// Create a prepared streaming request from raw body bytes.
     ///
     /// # Arguments
     ///
     /// * `body` - Raw request body bytes in any supported format (OpenAI, Anthropic, Google, etc.)
     /// * `model` - The model name for routing (e.g., "gpt-4", "claude-3-opus")
     /// * `output_format` - The output format, or None to auto-detect from body
-    /// * `client_headers` - Client headers to forward to the upstream provider
     ///
-    /// The body will be automatically transformed to the target provider's format if needed.
-    /// Stream chunks will be transformed to the requested output format.
+    /// The body will be automatically transformed to the selected provider format if needed.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
-            name = "bt.router.complete_stream",
-            skip(self, body, client_headers),
-            fields(llm.model = %model, http.url = tracing::field::Empty, http.status_code = tracing::field::Empty)
+            name = "bt.router.create_stream_request",
+            skip(self, body),
+            fields(llm.model = %model)
         )
     )]
-    pub async fn complete_stream(
+    pub async fn create_stream_request(
         &self,
         body: Bytes,
         model: &str,
         output_format: ProviderFormat,
-        client_headers: &ClientHeaders,
-    ) -> Result<(ResponseStream, RouterMetadata)> {
-        let routes = self.resolve_providers(model, output_format)?;
-        let route = routes
-            .first()
-            .ok_or_else(|| Error::NoProvider(output_format))?;
-        let (_, provider, auth, spec, format, _) = route;
-        let (payload, detected_format) =
-            prepare_provider_request(body, spec.as_ref(), *format, true).await?;
-        let input_format = detected_format.unwrap_or(*format);
-
-        let raw_stream = provider
-            .clone()
-            .complete_stream(payload, auth, spec.as_ref(), *format, client_headers)
+    ) -> Result<(PreparedStreamRequest<'_>, RouterMetadata)> {
+        let (inner, metadata) = self
+            .create_prepared_request_internal(body, model, output_format, true)
             .await?;
-
-        Ok((
-            transform_stream(raw_stream, output_format),
-            RouterMetadata {
-                detected_input_format: input_format,
-            },
-        ))
+        Ok((PreparedStreamRequest { inner }, metadata))
     }
 
-    /// Get the aliases of the providers that can handle the given model and output format.
-    ///
-    /// # Arguments
-    ///
-    /// * `model` - The model name for routing (e.g., "gpt-4", "claude-3-opus")
-    /// * `output_format` - The output format, or None to auto-detect from body
-    ///
-    /// # Returns
-    /// A vector of provider aliases that can handle the given model and output
-    /// format. The aliases are in priority order. Follows the same order as the
-    /// complete and complete_stream methods.
-    pub fn provider_aliases(
+    /// Execute a prepared streaming request.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "bt.router.complete_stream",
+            skip(self, request, client_headers),
+            fields(llm.model = %request.inner.spec.model)
+        )
+    )]
+    pub async fn complete_stream(
         &self,
-        model: &str,
-        output_format: ProviderFormat,
-    ) -> Result<Vec<(String, ProviderFormat)>> {
-        self.resolve_providers(model, output_format).map(|routes| {
-            routes
-                .into_iter()
-                .map(|(alias, _, _, _, format, _)| (alias, format))
-                .collect()
-        })
+        request: PreparedStreamRequest<'_>,
+        client_headers: &ClientHeaders,
+    ) -> Result<ResponseStream> {
+        let PreparedRequestInner {
+            provider,
+            auth,
+            spec,
+            format,
+            payload,
+            output_format,
+            strategy: _,
+        } = request.inner;
+        let raw_stream = provider
+            .clone()
+            .complete_stream(payload, auth, spec.as_ref(), format, client_headers)
+            .await?;
+        Ok(transform_stream(raw_stream, output_format))
     }
 
     /// Resolve all providers for a given model and output format.
@@ -762,6 +818,21 @@ mod tests {
         spec
     }
 
+    fn resolved_aliases(
+        router: &Router,
+        model: &str,
+        output_format: ProviderFormat,
+    ) -> Result<Vec<String>> {
+        router
+            .resolve_providers(model, output_format)
+            .map(|routes| {
+                routes
+                    .into_iter()
+                    .map(|(alias, _, _, _, _, _)| alias)
+                    .collect()
+            })
+    }
+
     #[tokio::test]
     async fn prepare_provider_request_enables_stream_for_google_to_chat_completions() {
         let body = Bytes::from_static(
@@ -838,16 +909,12 @@ mod tests {
             .expect("router builds");
 
         assert_eq!(
-            router
-                .provider_aliases(vertex_model, ProviderFormat::Google)
-                .unwrap(),
-            vec![("vertex".to_string(), ProviderFormat::Google)]
+            resolved_aliases(&router, vertex_model, ProviderFormat::Google).unwrap(),
+            vec!["vertex".to_string()]
         );
         assert_eq!(
-            router
-                .provider_aliases(google_model, ProviderFormat::Google)
-                .unwrap(),
-            vec![("google".to_string(), ProviderFormat::Google)]
+            resolved_aliases(&router, google_model, ProviderFormat::Google).unwrap(),
+            vec!["google".to_string()]
         );
     }
 
@@ -873,10 +940,8 @@ mod tests {
             .expect("router builds");
 
         assert_eq!(
-            router
-                .provider_aliases(vertex_model, ProviderFormat::Google)
-                .unwrap(),
-            vec![("google".to_string(), ProviderFormat::Google)]
+            resolved_aliases(&router, vertex_model, ProviderFormat::Google).unwrap(),
+            vec!["google".to_string()]
         );
     }
 
@@ -1114,7 +1179,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_aliases_returns_only_registered_available_providers() {
+    fn resolved_aliases_returns_only_registered_available_providers() {
         let model = "gpt-4o";
         let mut catalog = ModelCatalog::empty();
         catalog.insert(
@@ -1144,16 +1209,9 @@ mod tests {
             .build()
             .expect("router builds");
 
-        let aliases = router
-            .provider_aliases(model, ProviderFormat::ChatCompletions)
-            .expect("provider_aliases");
-        assert_eq!(
-            aliases,
-            vec![
-                ("openai".to_string(), ProviderFormat::ChatCompletions),
-                ("azure".to_string(), ProviderFormat::ChatCompletions),
-            ]
-        );
+        let aliases = resolved_aliases(&router, model, ProviderFormat::ChatCompletions)
+            .expect("resolved aliases");
+        assert_eq!(aliases, vec!["openai".to_string(), "azure".to_string()]);
     }
 
     #[test]
@@ -1186,11 +1244,9 @@ mod tests {
             "at least one route (unregistered openai falls back to format slot azure)"
         );
         assert_eq!(
-            router
-                .provider_aliases(model, ProviderFormat::ChatCompletions)
-                .unwrap(),
-            vec![("other_gpt".to_string(), ProviderFormat::ChatCompletions)],
-            "provider_aliases returns only registered providers from available_providers"
+            resolved_aliases(&router, model, ProviderFormat::ChatCompletions).unwrap(),
+            vec!["other_gpt".to_string()],
+            "resolving providers returns only registered aliases from available_providers"
         );
     }
 }

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -110,29 +110,48 @@ type ResolvedRoute<'a> = (
     RetryStrategy,
 );
 
+/// Metadata about how an incoming request was interpreted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouterMetadata {
+    /// The detected format of the incoming request payload.
+    ///
+    /// When the request was already in the target provider's format, this reflects
+    /// that format. When the payload was transformed, this is the source format
+    /// that was detected.
+    pub detected_input_format: ProviderFormat,
+}
+
 async fn prepare_provider_request(
     body: Bytes,
     spec: &ModelSpec,
     format: ProviderFormat,
     stream: bool,
-) -> Result<Bytes> {
+) -> Result<(Bytes, Option<ProviderFormat>)> {
     if requires_bedrock_request_preparation(format) {
-        return prepare_bedrock_request(body, spec, format).await;
+        let bytes = prepare_bedrock_request(body, spec, format).await?;
+        return Ok((bytes, Some(format)));
     }
 
-    let transformed = match lingua::transform_request(body.clone(), format, Some(&spec.model)) {
-        Ok(TransformResult::PassThrough(bytes)) => bytes,
-        Ok(TransformResult::Transformed { bytes, .. }) => bytes,
-        Err(TransformError::UnsupportedTargetFormat(_)) => body,
-        Err(err) => return Err(err.into()),
-    };
+    let (transformed, detected_format) =
+        match lingua::transform_request(body.clone(), format, Some(&spec.model)) {
+            Ok(TransformResult::PassThrough(bytes)) => (bytes, None),
+            Ok(TransformResult::Transformed {
+                bytes,
+                source_format,
+            }) => (bytes, Some(source_format)),
+            Err(TransformError::UnsupportedTargetFormat(_)) => (body, None),
+            Err(err) => return Err(err.into()),
+        };
 
     if stream {
         // TODO: Fold streaming intent into `lingua::transform_request` once we
         // are ready to update its Rust/WASM/Python/TS call sites together.
-        Ok(enable_streaming_payload(transformed, format))
+        Ok((
+            enable_streaming_payload(transformed, format),
+            detected_format,
+        ))
     } else {
-        Ok(transformed)
+        Ok((transformed, detected_format))
     }
 }
 
@@ -179,14 +198,16 @@ impl Router {
         model: &str,
         output_format: ProviderFormat,
         client_headers: &ClientHeaders,
-    ) -> Result<Bytes> {
+    ) -> Result<(Bytes, RouterMetadata)> {
         let routes = self.resolve_providers(model, output_format)?;
         // Choose the first provider
         let route = routes
             .first()
             .ok_or_else(|| Error::NoProvider(output_format))?;
         let (_, provider, auth, spec, format, strategy) = route;
-        let payload = prepare_provider_request(body, spec.as_ref(), *format, false).await?;
+        let (payload, detected_format) =
+            prepare_provider_request(body, spec.as_ref(), *format, false).await?;
+        let input_format = detected_format.unwrap_or(*format);
 
         let response_bytes = self
             .execute_with_retry(
@@ -207,7 +228,12 @@ impl Router {
             TransformResult::Transformed { bytes, .. } => bytes,
         };
 
-        Ok(response)
+        Ok((
+            response,
+            RouterMetadata {
+                detected_input_format: input_format,
+            },
+        ))
     }
 
     /// Execute a streaming completion request with the given body bytes.
@@ -235,20 +261,27 @@ impl Router {
         model: &str,
         output_format: ProviderFormat,
         client_headers: &ClientHeaders,
-    ) -> Result<ResponseStream> {
+    ) -> Result<(ResponseStream, RouterMetadata)> {
         let routes = self.resolve_providers(model, output_format)?;
         let route = routes
             .first()
             .ok_or_else(|| Error::NoProvider(output_format))?;
         let (_, provider, auth, spec, format, _) = route;
-        let payload = prepare_provider_request(body, spec.as_ref(), *format, true).await?;
+        let (payload, detected_format) =
+            prepare_provider_request(body, spec.as_ref(), *format, true).await?;
+        let input_format = detected_format.unwrap_or(*format);
 
         let raw_stream = provider
             .clone()
             .complete_stream(payload, auth, spec.as_ref(), *format, client_headers)
             .await?;
 
-        Ok(transform_stream(raw_stream, output_format))
+        Ok((
+            transform_stream(raw_stream, output_format),
+            RouterMetadata {
+                detected_input_format: input_format,
+            },
+        ))
     }
 
     /// Get the aliases of the providers that can handle the given model and output format.
@@ -736,9 +769,10 @@ mod tests {
         );
         let spec = openai_spec("gpt-5-mini", ModelFlavor::Chat);
 
-        let payload = prepare_provider_request(body, &spec, ProviderFormat::ChatCompletions, true)
-            .await
-            .expect("request prepares");
+        let (payload, _) =
+            prepare_provider_request(body, &spec, ProviderFormat::ChatCompletions, true)
+                .await
+                .expect("request prepares");
 
         let parsed: Value = serde_json::from_slice(&payload).expect("valid request json");
         assert_eq!(parsed.get("stream"), Some(&Value::Bool(true)));
@@ -753,9 +787,10 @@ mod tests {
         );
         let spec = openai_spec("gpt-5-mini", ModelFlavor::Chat);
 
-        let payload = prepare_provider_request(body, &spec, ProviderFormat::ChatCompletions, false)
-            .await
-            .expect("request prepares");
+        let (payload, _) =
+            prepare_provider_request(body, &spec, ProviderFormat::ChatCompletions, false)
+                .await
+                .expect("request prepares");
 
         let parsed: Value = serde_json::from_slice(&payload).expect("valid request json");
         assert_eq!(parsed.get("stream"), None);

--- a/crates/braintrust-llm-router/tests/router.rs
+++ b/crates/braintrust-llm-router/tests/router.rs
@@ -134,13 +134,12 @@ async fn router_routes_to_stub_provider() {
         ]
     }));
 
-    let (bytes, _): (Bytes, _) = router
-        .complete(
-            body,
-            model,
-            ProviderFormat::ChatCompletions,
-            &ClientHeaders::default(),
-        )
+    let (request, _metadata) = router
+        .create_request(body, model, ProviderFormat::ChatCompletions)
+        .await
+        .expect("create request");
+    let bytes: Bytes = router
+        .complete(request, &ClientHeaders::default())
         .await
         .expect("complete");
     // Parse bytes to Value using braintrust_llm_router's serde_json
@@ -154,7 +153,7 @@ async fn router_routes_to_stub_provider() {
 }
 
 #[tokio::test]
-async fn router_reports_provider_aliases_with_formats() {
+async fn router_resolves_provider_alias_in_metadata() {
     let mut catalog = ModelCatalog::empty();
     catalog.insert(
         "stub-model".into(),
@@ -193,14 +192,16 @@ async fn router_reports_provider_aliases_with_formats() {
         .build()
         .expect("router builds");
 
-    let routes = router
-        .provider_aliases("stub-model", ProviderFormat::ChatCompletions)
-        .expect("provider aliases lookup");
+    let body = to_body(json!({
+        "model": "stub-model",
+        "messages": [{"role": "user", "content": "Ping"}]
+    }));
+    let (_request, metadata) = router
+        .create_request(body, "stub-model", ProviderFormat::ChatCompletions)
+        .await
+        .expect("create request");
 
-    assert_eq!(
-        routes,
-        vec![("stub".to_string(), ProviderFormat::ChatCompletions)]
-    );
+    assert_eq!(metadata.provider_alias, "stub");
 }
 
 #[tokio::test]
@@ -249,13 +250,12 @@ async fn router_requires_auth_for_provider() {
         "messages": [{"role": "user", "content": "Ping"}]
     }));
 
-    let (bytes, _): (Bytes, _) = router
-        .complete(
-            body,
-            model,
-            ProviderFormat::ChatCompletions,
-            &ClientHeaders::default(),
-        )
+    let (request, _metadata) = router
+        .create_request(body, model, ProviderFormat::ChatCompletions)
+        .await
+        .expect("create request");
+    let bytes: Bytes = router
+        .complete(request, &ClientHeaders::default())
         .await
         .expect("complete succeeds when auth is configured");
     let response: Value =
@@ -301,15 +301,13 @@ async fn router_reports_missing_provider() {
         "messages": [{"role": "user", "content": "Ping"}]
     }));
 
-    let err = router
-        .complete(
-            body,
-            model,
-            ProviderFormat::ChatCompletions,
-            &ClientHeaders::default(),
-        )
+    let err = match router
+        .create_request(body, model, ProviderFormat::ChatCompletions)
         .await
-        .expect_err("missing provider");
+    {
+        Ok(_) => panic!("missing provider"),
+        Err(err) => err,
+    };
     assert!(matches!(
         err,
         Error::NoProvider(ProviderFormat::ChatCompletions)
@@ -338,15 +336,13 @@ async fn router_propagates_validation_errors() {
         "model": "",
         "messages": []
     }));
-    let err: braintrust_llm_router::Result<(Bytes, _)> = router
-        .complete(
-            body,
-            "",
-            ProviderFormat::ChatCompletions,
-            &ClientHeaders::default(),
-        )
+    let err: braintrust_llm_router::Result<_> = router
+        .create_request(body, "", ProviderFormat::ChatCompletions)
         .await;
-    let err = err.expect_err("validation");
+    let err = match err {
+        Ok(_) => panic!("validation"),
+        Err(err) => err,
+    };
     // Empty model is treated as unknown model, not invalid request
     assert!(matches!(err, Error::UnknownModel(_)));
 }
@@ -545,14 +541,12 @@ async fn router_retries_and_propagates_terminal_error() {
         "messages": [{"role": "user", "content": "Ping"}]
     }));
 
-    let err: braintrust_llm_router::Result<(Bytes, _)> = router
-        .complete(
-            body,
-            model,
-            ProviderFormat::ChatCompletions,
-            &ClientHeaders::default(),
-        )
-        .await;
+    let (request, _metadata) = router
+        .create_request(body, model, ProviderFormat::ChatCompletions)
+        .await
+        .expect("create request");
+    let err: braintrust_llm_router::Result<Bytes> =
+        router.complete(request, &ClientHeaders::default()).await;
     let err = err.expect_err("terminal error");
     assert!(matches!(err, Error::Timeout));
     assert_eq!(attempts.load(Ordering::SeqCst), 3);
@@ -589,13 +583,12 @@ async fn router_maps_terminal_http_errors_to_upstream_unavailable() {
         "messages": [{"role": "user", "content": "Ping"}]
     }));
 
+    let (request, _metadata) = router
+        .create_request(body, "retry-model", ProviderFormat::ChatCompletions)
+        .await
+        .expect("create request");
     let err = router
-        .complete(
-            body,
-            "retry-model",
-            ProviderFormat::ChatCompletions,
-            &ClientHeaders::default(),
-        )
+        .complete(request, &ClientHeaders::default())
         .await
         .expect_err("terminal error");
 
@@ -638,13 +631,12 @@ async fn router_maps_terminal_middleware_errors_to_upstream_unavailable() {
         "messages": [{"role": "user", "content": "Ping"}]
     }));
 
+    let (request, _metadata) = router
+        .create_request(body, "retry-model", ProviderFormat::ChatCompletions)
+        .await
+        .expect("create request");
     let err = router
-        .complete(
-            body,
-            "retry-model",
-            ProviderFormat::ChatCompletions,
-            &ClientHeaders::default(),
-        )
+        .complete(request, &ClientHeaders::default())
         .await
         .expect_err("terminal error");
 

--- a/crates/braintrust-llm-router/tests/router.rs
+++ b/crates/braintrust-llm-router/tests/router.rs
@@ -134,7 +134,7 @@ async fn router_routes_to_stub_provider() {
         ]
     }));
 
-    let bytes: Bytes = router
+    let (bytes, _): (Bytes, _) = router
         .complete(
             body,
             model,
@@ -249,7 +249,7 @@ async fn router_requires_auth_for_provider() {
         "messages": [{"role": "user", "content": "Ping"}]
     }));
 
-    let bytes: Bytes = router
+    let (bytes, _): (Bytes, _) = router
         .complete(
             body,
             model,
@@ -338,7 +338,7 @@ async fn router_propagates_validation_errors() {
         "model": "",
         "messages": []
     }));
-    let err: braintrust_llm_router::Result<Bytes> = router
+    let err: braintrust_llm_router::Result<(Bytes, _)> = router
         .complete(
             body,
             "",
@@ -545,7 +545,7 @@ async fn router_retries_and_propagates_terminal_error() {
         "messages": [{"role": "user", "content": "Ping"}]
     }));
 
-    let err: braintrust_llm_router::Result<Bytes> = router
+    let err: braintrust_llm_router::Result<(Bytes, _)> = router
         .complete(
             body,
             model,

--- a/crates/braintrust-llm-router/tests/router.rs
+++ b/crates/braintrust-llm-router/tests/router.rs
@@ -154,6 +154,56 @@ async fn router_routes_to_stub_provider() {
 }
 
 #[tokio::test]
+async fn router_reports_provider_aliases_with_formats() {
+    let mut catalog = ModelCatalog::empty();
+    catalog.insert(
+        "stub-model".into(),
+        ModelSpec {
+            model: "stub-model".into(),
+            format: ProviderFormat::ChatCompletions,
+            flavor: ModelFlavor::Chat,
+            display_name: None,
+            parent: None,
+            input_cost_per_mil_tokens: None,
+            output_cost_per_mil_tokens: None,
+            input_cache_read_cost_per_mil_tokens: None,
+            multimodal: None,
+            reasoning: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            supports_streaming: true,
+            extra: Default::default(),
+            available_providers: Default::default(),
+        },
+    );
+    let catalog = Arc::new(catalog);
+
+    let router = RouterBuilder::new()
+        .with_catalog(Arc::clone(&catalog))
+        .add_provider(
+            "stub",
+            StubProvider,
+            AuthConfig::ApiKey {
+                key: "test".into(),
+                header: Some("authorization".into()),
+                prefix: Some("Bearer".into()),
+            },
+            vec![ProviderFormat::ChatCompletions],
+        )
+        .build()
+        .expect("router builds");
+
+    let routes = router
+        .provider_aliases("stub-model", ProviderFormat::ChatCompletions)
+        .expect("provider aliases lookup");
+
+    assert_eq!(
+        routes,
+        vec![("stub".to_string(), ProviderFormat::ChatCompletions)]
+    );
+}
+
+#[tokio::test]
 async fn router_requires_auth_for_provider() {
     let mut catalog = ModelCatalog::empty();
     catalog.insert(


### PR DESCRIPTION
Split up the complete/complete_stream functions into create_request and complete.
The create_request returns some metadata that can be used for logging, regardless
of whether the provider request passes or fails. Include the detected input format,
provider alias, and provider format. Including this info here also removes the need
for the provider_aliases() function, so remove that. I never liked that clients used it
anyway because it's possible for it to diverge from what complete() actually does.