### PR TITLE
[WIP] structured/safe parse failure logs

### DIFF
--- a/crates/braintrust-llm-router/src/error.rs
+++ b/crates/braintrust-llm-router/src/error.rs
@@ -197,7 +197,10 @@ mod tests {
         use lingua::TransformError;
 
         // Client errors
-        assert!(TransformError::UnableToDetectFormat.is_client_error());
+        assert!(TransformError::UnableToDetectFormat {
+            request_diagnostic: None
+        }
+        .is_client_error());
         assert!(TransformError::ValidationFailed {
             target: ProviderFormat::ChatCompletions,
             reason: "test".into()
@@ -228,7 +231,10 @@ mod tests {
         assert!(Error::UnknownModel("gpt-5".into()).is_client_error());
         assert!(Error::NoProvider(ProviderFormat::ChatCompletions).is_client_error());
         assert!(Error::InvalidRequest("bad".into()).is_client_error());
-        assert!(Error::Lingua(lingua::TransformError::UnableToDetectFormat).is_client_error());
+        assert!(Error::Lingua(lingua::TransformError::UnableToDetectFormat {
+            request_diagnostic: None,
+        })
+        .is_client_error());
 
         // Auth errors
         assert!(Error::NoAuth("openai".into()).is_auth_error());

--- a/crates/braintrust-llm-router/src/providers/bedrock.rs
+++ b/crates/braintrust-llm-router/src/providers/bedrock.rs
@@ -87,10 +87,15 @@ where
     let source_adapter = match adapters()
         .iter()
         .map(|adapter| adapter.as_ref())
-        .find(|adapter| adapter.detect_request(&payload))
+        .find(|adapter| adapter.detect_request(&payload).is_matched())
     {
         Some(adapter) => adapter,
-        None => return Err(TransformError::UnableToDetectFormat.into()),
+        None => {
+            return Err(TransformError::UnableToDetectFormat {
+                request_diagnostic: None,
+            }
+            .into())
+        }
     };
 
     if source_adapter.format() == format {

--- a/crates/braintrust-llm-router/src/streaming.rs
+++ b/crates/braintrust-llm-router/src/streaming.rs
@@ -106,7 +106,7 @@ impl Stream for SessionTransformStream {
                             }
                             continue;
                         }
-                        Err(lingua::TransformError::UnableToDetectFormat) => {
+                        Err(lingua::TransformError::UnableToDetectFormat { .. }) => {
                             return Poll::Ready(Some(Ok(chunk)));
                         }
                         Err(e) => {

--- a/crates/lingua/src/lib.rs
+++ b/crates/lingua/src/lib.rs
@@ -36,9 +36,10 @@ pub use capabilities::ProviderFormat;
 
 // Re-export key processing functions (bytes-based API)
 pub use processing::{
-    extract_model, parse_stream_event, response_to_universal, sanitize_payload, transform_request,
-    transform_response, transform_stream_chunk, ParsedStreamEvent, StreamOutputChunk,
-    StreamTransformSession, TransformError, TransformResult,
+    extract_model, json_value_kind, parse_stream_event, probe_shape, response_to_universal,
+    sanitize_payload, transform_request, transform_response, transform_stream_chunk, JsonValueKind,
+    ParsedStreamEvent, RequestFormatDiagnostic, StreamOutputChunk, StreamTransformSession,
+    TransformError, TransformResult,
 };
 
 // Re-export universal types

--- a/crates/lingua/src/processing/adapters.rs
+++ b/crates/lingua/src/processing/adapters.rs
@@ -15,9 +15,37 @@ provider-specific logic into a single interface.
 use std::sync::LazyLock;
 
 use crate::capabilities::ProviderFormat;
-use crate::processing::transform::TransformError;
+use crate::processing::transform::{RequestFormatDiagnostic, TransformError};
 use crate::serde_json::{Map, Number, Value};
 use crate::universal::{UniversalRequest, UniversalResponse, UniversalStreamChunk};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestDetectionResult {
+    Matched,
+    NotMatched,
+    Diagnostic(RequestFormatDiagnostic),
+}
+
+impl RequestDetectionResult {
+    pub const fn from_match(is_match: bool) -> Self {
+        if is_match {
+            Self::Matched
+        } else {
+            Self::NotMatched
+        }
+    }
+
+    pub const fn is_matched(&self) -> bool {
+        matches!(self, Self::Matched)
+    }
+
+    pub const fn request_diagnostic(&self) -> Option<&RequestFormatDiagnostic> {
+        match self {
+            Self::Diagnostic(diagnostic) => Some(diagnostic),
+            _ => None,
+        }
+    }
+}
 
 /// Trait for provider-specific request and response handling.
 ///
@@ -47,7 +75,7 @@ pub trait ProviderAdapter: Send + Sync {
     /// Checks if a payload matches this provider's request format.
     ///
     /// This should delegate to existing detection logic (e.g., `try_parse_*` functions).
-    fn detect_request(&self, payload: &Value) -> bool;
+    fn detect_request(&self, payload: &Value) -> RequestDetectionResult;
 
     /// Convert a provider-specific payload to universal request format.
     ///

--- a/crates/lingua/src/processing/json_shape.rs
+++ b/crates/lingua/src/processing/json_shape.rs
@@ -1,0 +1,170 @@
+use crate::serde_json::{self, Value};
+use serde::de::{self, DeserializeOwned, Deserializer, Visitor};
+use serde::Deserialize;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonValueKind {
+    Null,
+    Bool,
+    Number,
+    String,
+    Array,
+    Object,
+}
+
+impl JsonValueKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Null => "null",
+            Self::Bool => "bool",
+            Self::Number => "number",
+            Self::String => "string",
+            Self::Array => "array",
+            Self::Object => "object",
+        }
+    }
+}
+
+impl fmt::Display for JsonValueKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonValueKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct JsonValueKindVisitor;
+
+        impl<'de> Visitor<'de> for JsonValueKindVisitor {
+            type Value = JsonValueKind;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("any JSON value")
+            }
+
+            fn visit_bool<E>(self, _v: bool) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(JsonValueKind::Bool)
+            }
+
+            fn visit_i64<E>(self, _v: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(JsonValueKind::Number)
+            }
+
+            fn visit_u64<E>(self, _v: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(JsonValueKind::Number)
+            }
+
+            fn visit_f64<E>(self, _v: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(JsonValueKind::Number)
+            }
+
+            fn visit_str<E>(self, _v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(JsonValueKind::String)
+            }
+
+            fn visit_string<E>(self, _v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(JsonValueKind::String)
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(JsonValueKind::Null)
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(JsonValueKind::Null)
+            }
+
+            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                let mut seq = seq;
+                while seq.next_element::<de::IgnoredAny>()?.is_some() {}
+                Ok(JsonValueKind::Array)
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let mut map = map;
+                while map
+                    .next_entry::<de::IgnoredAny, de::IgnoredAny>()?
+                    .is_some()
+                {}
+                Ok(JsonValueKind::Object)
+            }
+        }
+
+        deserializer.deserialize_any(JsonValueKindVisitor)
+    }
+}
+
+pub fn json_value_kind(payload: &Value) -> JsonValueKind {
+    serde_json::from_value::<JsonValueKind>(payload.clone()).unwrap_or(JsonValueKind::Object)
+}
+
+pub fn probe_shape<T: DeserializeOwned>(payload: &Value) -> Option<T> {
+    serde_json::from_value::<T>(payload.clone()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_json::json;
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct Probe {
+        #[serde(default)]
+        input: Option<JsonValueKind>,
+    }
+
+    #[test]
+    fn json_value_kind_detects_top_level_shapes() {
+        assert_eq!(json_value_kind(&json!(null)), JsonValueKind::Null);
+        assert_eq!(json_value_kind(&json!(true)), JsonValueKind::Bool);
+        assert_eq!(json_value_kind(&json!(1)), JsonValueKind::Number);
+        assert_eq!(json_value_kind(&json!("x")), JsonValueKind::String);
+        assert_eq!(json_value_kind(&json!([])), JsonValueKind::Array);
+        assert_eq!(json_value_kind(&json!({})), JsonValueKind::Object);
+    }
+
+    #[test]
+    fn probe_shape_extracts_structural_field_types() {
+        let probe = probe_shape::<Probe>(&json!({"input": []})).unwrap();
+        assert_eq!(
+            probe,
+            Probe {
+                input: Some(JsonValueKind::Array),
+            }
+        );
+    }
+}

--- a/crates/lingua/src/processing/mod.rs
+++ b/crates/lingua/src/processing/mod.rs
@@ -1,6 +1,7 @@
 pub mod adapters;
 pub mod dedup;
 pub mod import;
+pub mod json_shape;
 pub mod stream;
 pub mod transform;
 
@@ -10,10 +11,11 @@ pub use adapters::{
 };
 pub use dedup::deduplicate_messages;
 pub use import::{import_and_deduplicate_messages, import_messages_from_spans, Span};
+pub use json_shape::{json_value_kind, probe_shape, JsonValueKind};
 pub use stream::{
     parse_stream_event, ParsedStreamEvent, StreamOutputChunk, StreamTransformSession,
 };
 pub use transform::{
     extract_model, response_to_universal, sanitize_payload, transform_request, transform_response,
-    transform_stream_chunk, TransformError, TransformResult,
+    transform_stream_chunk, RequestFormatDiagnostic, TransformError, TransformResult,
 };

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -15,7 +15,9 @@ use bytes::Bytes;
 
 use crate::capabilities::ProviderFormat;
 use crate::error::ConvertError;
-use crate::processing::adapters::{adapter_for_format, adapters, ProviderAdapter};
+use crate::processing::adapters::{
+    adapter_for_format, adapters, ProviderAdapter, RequestDetectionResult,
+};
 #[cfg(feature = "openai")]
 use crate::providers::openai::model_needs_transforms;
 use crate::serde_json::Value;
@@ -30,7 +32,9 @@ static EMPTY_JSON: Bytes = Bytes::from_static(b"{}");
 #[derive(Debug, Error)]
 pub enum TransformError {
     #[error("Unable to detect source format")]
-    UnableToDetectFormat,
+    UnableToDetectFormat {
+        request_diagnostic: Option<RequestFormatDiagnostic>,
+    },
 
     #[error("Validation failed for target format {target:?}: {reason}")]
     ValidationFailed {
@@ -61,6 +65,15 @@ pub enum TransformError {
 }
 
 impl TransformError {
+    pub fn request_format_diagnostic(&self) -> Option<&RequestFormatDiagnostic> {
+        match self {
+            TransformError::UnableToDetectFormat { request_diagnostic } => {
+                request_diagnostic.as_ref()
+            }
+            _ => None,
+        }
+    }
+
     /// Returns true if this is a client-side error (user's fault).
     ///
     /// Client errors indicate invalid input or unsupported configurations
@@ -70,7 +83,7 @@ impl TransformError {
     pub fn is_client_error(&self) -> bool {
         matches!(
             self,
-            TransformError::UnableToDetectFormat
+            TransformError::UnableToDetectFormat { .. }
                 | TransformError::ValidationFailed { .. }
                 | TransformError::DeserializationFailed(_)
                 | TransformError::UnsupportedTargetFormat(_)
@@ -84,6 +97,21 @@ impl TransformError {
 impl From<ConvertError> for TransformError {
     fn from(err: ConvertError) -> Self {
         TransformError::FromUniversalFailed(err.to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestFormatDiagnostic {
+    #[cfg(feature = "openai")]
+    OpenAIResponses(crate::providers::openai::ResponsesRequestDiagnosticView),
+}
+
+impl RequestFormatDiagnostic {
+    pub const fn candidate_format(&self) -> ProviderFormat {
+        match self {
+            #[cfg(feature = "openai")]
+            Self::OpenAIResponses(_) => ProviderFormat::Responses,
+        }
     }
 }
 
@@ -426,15 +454,28 @@ fn detect_adapter(
     payload: &Value,
     kind: DetectKind,
 ) -> Result<&'static dyn ProviderAdapter, TransformError> {
-    adapters()
-        .iter()
-        .find(|a| match kind {
-            DetectKind::Request => a.detect_request(payload),
-            DetectKind::Response => a.detect_response(payload),
-            DetectKind::Stream => a.detect_stream_response(payload),
-        })
-        .map(|a| a.as_ref())
-        .ok_or(TransformError::UnableToDetectFormat)
+    let mut request_diagnostic = None;
+
+    for adapter in adapters().iter() {
+        match kind {
+            DetectKind::Request => match adapter.detect_request(payload) {
+                RequestDetectionResult::Matched => return Ok(adapter.as_ref()),
+                RequestDetectionResult::Diagnostic(diagnostic) => {
+                    if request_diagnostic.is_none() {
+                        request_diagnostic = Some(diagnostic);
+                    }
+                }
+                RequestDetectionResult::NotMatched => {}
+            },
+            DetectKind::Response if adapter.detect_response(payload) => return Ok(adapter.as_ref()),
+            DetectKind::Stream if adapter.detect_stream_response(payload) => {
+                return Ok(adapter.as_ref())
+            }
+            _ => {}
+        }
+    }
+
+    Err(TransformError::UnableToDetectFormat { request_diagnostic })
 }
 
 /// Check if a request needs forced translation even when source == target format.
@@ -590,6 +631,28 @@ mod tests {
         assert!(matches!(
             result.unwrap_err(),
             TransformError::DeserializationFailed(_)
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
+    fn test_transform_request_reports_responses_request_diagnostic_on_detection_failure() {
+        let input = to_bytes(&json!({
+            "model": "gpt-5-mini",
+            "input": [],
+            "tools": {"type": "function"}
+        }));
+
+        let err = transform_request(input, ProviderFormat::ChatCompletions, None).unwrap_err();
+        let diagnostic = err.request_format_diagnostic();
+        assert!(matches!(
+            diagnostic,
+            Some(RequestFormatDiagnostic::OpenAIResponses(
+                crate::providers::openai::ResponsesRequestDiagnosticView {
+                    kind: crate::providers::openai::ResponsesRequestDiagnosticKind::ToolsWrongTopLevelType,
+                    ..
+                }
+            ))
         ));
     }
 

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -11,7 +11,7 @@ use std::convert::TryFrom;
 use crate::capabilities::ProviderFormat;
 use crate::error::ConvertError;
 use crate::processing::adapters::{
-    insert_opt_bool, insert_opt_f64, insert_opt_i64, ProviderAdapter,
+    insert_opt_bool, insert_opt_f64, insert_opt_i64, ProviderAdapter, RequestDetectionResult,
 };
 use crate::processing::transform::TransformError;
 use crate::providers::anthropic::capabilities;
@@ -131,8 +131,8 @@ impl ProviderAdapter for AnthropicAdapter {
         "Anthropic"
     }
 
-    fn detect_request(&self, payload: &Value) -> bool {
-        try_parse_anthropic(payload).is_ok()
+    fn detect_request(&self, payload: &Value) -> RequestDetectionResult {
+        RequestDetectionResult::from_match(try_parse_anthropic(payload).is_ok())
     }
 
     fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
@@ -1302,7 +1302,7 @@ mod tests {
             "max_tokens": 1024,
             "messages": [{"role": "user", "content": "Hello"}]
         });
-        assert!(adapter.detect_request(&payload));
+        assert!(adapter.detect_request(&payload).is_matched());
     }
 
     #[test]

--- a/crates/lingua/src/providers/bedrock/adapter.rs
+++ b/crates/lingua/src/providers/bedrock/adapter.rs
@@ -10,7 +10,7 @@ Bedrock's Converse API has some unique characteristics:
 
 use crate::capabilities::ProviderFormat;
 use crate::error::ConvertError;
-use crate::processing::adapters::ProviderAdapter;
+use crate::processing::adapters::{ProviderAdapter, RequestDetectionResult};
 use crate::processing::transform::TransformError;
 use crate::providers::anthropic::generated::Thinking;
 use crate::providers::bedrock::params::BedrockParams;
@@ -42,8 +42,8 @@ impl ProviderAdapter for BedrockAdapter {
         "Bedrock"
     }
 
-    fn detect_request(&self, payload: &Value) -> bool {
-        try_parse_bedrock(payload).is_ok()
+    fn detect_request(&self, payload: &Value) -> RequestDetectionResult {
+        RequestDetectionResult::from_match(try_parse_bedrock(payload).is_ok())
     }
 
     fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
@@ -558,7 +558,7 @@ mod tests {
                 "content": [{"text": "Hello"}]
             }]
         });
-        assert!(adapter.detect_request(&payload));
+        assert!(adapter.detect_request(&payload).is_matched());
     }
 
     #[test]

--- a/crates/lingua/src/providers/bedrock_anthropic/adapter.rs
+++ b/crates/lingua/src/providers/bedrock_anthropic/adapter.rs
@@ -1,5 +1,5 @@
 use crate::capabilities::ProviderFormat;
-use crate::processing::adapters::ProviderAdapter;
+use crate::processing::adapters::{ProviderAdapter, RequestDetectionResult};
 use crate::processing::transform::TransformError;
 use crate::providers::anthropic::AnthropicAdapter;
 use crate::serde_json::{self, Value};
@@ -75,11 +75,11 @@ impl ProviderAdapter for BedrockAnthropicAdapter {
         "Bedrock Anthropic"
     }
 
-    fn detect_request(&self, payload: &Value) -> bool {
+    fn detect_request(&self, payload: &Value) -> RequestDetectionResult {
         if !Self::is_raw_invoke_body(payload) {
-            return false;
+            return RequestDetectionResult::NotMatched;
         }
-        self.inner.request_to_universal(payload.clone()).is_ok()
+        RequestDetectionResult::from_match(self.inner.request_to_universal(payload.clone()).is_ok())
     }
 
     fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
@@ -209,17 +209,17 @@ mod tests {
             "max_tokens": 1024,
             "messages": [{"role": "user", "content": "Hello"}]
         });
-        assert!(adapter.detect_request(&valid));
+        assert!(adapter.detect_request(&valid).is_matched());
 
         let with_model = json!({
             "model": "claude-3-sonnet",
             "max_tokens": 1024,
             "messages": [{"role": "user", "content": "Hello"}]
         });
-        assert!(!adapter.detect_request(&with_model));
+        assert!(!adapter.detect_request(&with_model).is_matched());
 
         let envelope = json!({"modelId": "m", "body": {}});
-        assert!(!adapter.detect_request(&envelope));
+        assert!(!adapter.detect_request(&envelope).is_matched());
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -9,7 +9,7 @@ Google's API has some unique characteristics:
 */
 
 use crate::capabilities::ProviderFormat;
-use crate::processing::adapters::ProviderAdapter;
+use crate::processing::adapters::{ProviderAdapter, RequestDetectionResult};
 use crate::processing::transform::TransformError;
 use crate::providers::google::detect::try_parse_google;
 use crate::providers::google::generated::{
@@ -46,8 +46,8 @@ impl ProviderAdapter for GoogleAdapter {
         "Google"
     }
 
-    fn detect_request(&self, payload: &Value) -> bool {
-        try_parse_google(payload).is_ok()
+    fn detect_request(&self, payload: &Value) -> RequestDetectionResult {
+        RequestDetectionResult::from_match(try_parse_google(payload).is_ok())
     }
 
     fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
@@ -732,7 +732,7 @@ mod tests {
                 "parts": [{"text": "Hello"}]
             }]
         });
-        assert!(adapter.detect_request(&payload));
+        assert!(adapter.detect_request(&payload).is_matched());
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/adapter.rs
+++ b/crates/lingua/src/providers/openai/adapter.rs
@@ -11,6 +11,7 @@ use crate::error::ConvertError;
 
 use crate::processing::adapters::{
     insert_opt_bool, insert_opt_f64, insert_opt_i64, insert_opt_value, ProviderAdapter,
+    RequestDetectionResult,
 };
 use crate::processing::transform::TransformError;
 use crate::providers::openai::capabilities::{apply_model_transforms, model_needs_transforms};
@@ -66,8 +67,8 @@ impl ProviderAdapter for OpenAIAdapter {
         "ChatCompletions"
     }
 
-    fn detect_request(&self, payload: &Value) -> bool {
-        try_parse_openai(payload).is_ok()
+    fn detect_request(&self, payload: &Value) -> RequestDetectionResult {
+        RequestDetectionResult::from_match(try_parse_openai(payload).is_ok())
     }
 
     fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
@@ -709,7 +710,7 @@ mod tests {
             "model": "gpt-4",
             "messages": [{"role": "user", "content": "Hello"}]
         });
-        assert!(adapter.detect_request(&payload));
+        assert!(adapter.detect_request(&payload).is_matched());
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/detect.rs
+++ b/crates/lingua/src/providers/openai/detect.rs
@@ -6,15 +6,156 @@ OpenAI chat completion format by attempting to deserialize into
 the OpenAI struct types.
 */
 
+use crate::processing::{json_value_kind, probe_shape, JsonValueKind};
 use crate::providers::openai::generated::{CreateChatCompletionRequestClass, CreateResponseClass};
 use crate::serde_json::{self, Value};
+use serde::Deserialize;
+use std::fmt;
 use thiserror::Error;
 
 /// Error type for OpenAI payload detection
 #[derive(Debug, Error)]
 pub enum DetectionError {
-    #[error("Deserialization failed: {0}")]
-    DeserializationFailed(String),
+    #[error("typed deserialization failed")]
+    DeserializationFailed,
+
+    #[error("invalid OpenAI Responses request shape: {0}")]
+    ResponsesRequestDiagnostic(ResponsesRequestDiagnosticView),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponsesRequestDiagnosticKind {
+    TopLevelNotObject,
+    MissingInput,
+    InputAndMessagesBothPresent,
+    InputWrongTopLevelType,
+    ToolsWrongTopLevelType,
+    TypedRequestShapeMismatch,
+}
+
+impl ResponsesRequestDiagnosticKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TopLevelNotObject => "top_level_not_object",
+            Self::MissingInput => "missing_input",
+            Self::InputAndMessagesBothPresent => "input_and_messages_both_present",
+            Self::InputWrongTopLevelType => "input_wrong_top_level_type",
+            Self::ToolsWrongTopLevelType => "tools_wrong_top_level_type",
+            Self::TypedRequestShapeMismatch => "typed_request_shape_mismatch",
+        }
+    }
+}
+
+impl fmt::Display for ResponsesRequestDiagnosticKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResponsesRequestDiagnosticView {
+    pub kind: ResponsesRequestDiagnosticKind,
+    pub top_level_type: JsonValueKind,
+    pub input_type: Option<JsonValueKind>,
+    pub tools_type: Option<JsonValueKind>,
+    pub messages_present: bool,
+}
+
+impl fmt::Display for ResponsesRequestDiagnosticView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.kind)?;
+        write!(f, " (top_level_type={}", self.top_level_type)?;
+        if let Some(input_type) = self.input_type {
+            write!(f, ", input_type={input_type}")?;
+        }
+        if let Some(tools_type) = self.tools_type {
+            write!(f, ", tools_type={tools_type}")?;
+        }
+        write!(f, ", messages_present={})", self.messages_present)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponsesRequestDiagnosticProbe {
+    #[serde(default)]
+    input: Option<JsonValueKind>,
+    #[serde(default)]
+    messages: Option<JsonValueKind>,
+    #[serde(default)]
+    tools: Option<JsonValueKind>,
+}
+
+pub fn responses_request_diagnostic(payload: &Value) -> ResponsesRequestDiagnosticView {
+    let top_level_type = json_value_kind(payload);
+    if top_level_type != JsonValueKind::Object {
+        return ResponsesRequestDiagnosticView {
+            kind: ResponsesRequestDiagnosticKind::TopLevelNotObject,
+            top_level_type,
+            input_type: None,
+            tools_type: None,
+            messages_present: false,
+        };
+    }
+
+    let probe = probe_shape::<ResponsesRequestDiagnosticProbe>(payload).unwrap_or(
+        ResponsesRequestDiagnosticProbe {
+            input: None,
+            messages: None,
+            tools: None,
+        },
+    );
+    let messages_present = probe.messages.is_some();
+
+    if probe.input.is_none() {
+        return ResponsesRequestDiagnosticView {
+            kind: ResponsesRequestDiagnosticKind::MissingInput,
+            top_level_type,
+            input_type: None,
+            tools_type: probe.tools,
+            messages_present,
+        };
+    }
+
+    if messages_present {
+        return ResponsesRequestDiagnosticView {
+            kind: ResponsesRequestDiagnosticKind::InputAndMessagesBothPresent,
+            top_level_type,
+            input_type: probe.input,
+            tools_type: probe.tools,
+            messages_present,
+        };
+    }
+
+    if !matches!(
+        probe.input,
+        Some(JsonValueKind::String) | Some(JsonValueKind::Array)
+    ) {
+        return ResponsesRequestDiagnosticView {
+            kind: ResponsesRequestDiagnosticKind::InputWrongTopLevelType,
+            top_level_type,
+            input_type: probe.input,
+            tools_type: probe.tools,
+            messages_present,
+        };
+    }
+
+    if !matches!(probe.tools, None | Some(JsonValueKind::Array)) {
+        return ResponsesRequestDiagnosticView {
+            kind: ResponsesRequestDiagnosticKind::ToolsWrongTopLevelType,
+            top_level_type,
+            input_type: probe.input,
+            tools_type: probe.tools,
+            messages_present,
+        };
+    }
+
+    ResponsesRequestDiagnosticView {
+        kind: ResponsesRequestDiagnosticKind::TypedRequestShapeMismatch,
+        top_level_type,
+        input_type: probe.input,
+        tools_type: probe.tools,
+        messages_present,
+    }
 }
 
 /// Attempt to parse a JSON Value as OpenAI CreateChatCompletionRequestClass.
@@ -38,8 +179,7 @@ pub enum DetectionError {
 pub fn try_parse_openai(
     payload: &Value,
 ) -> Result<CreateChatCompletionRequestClass, DetectionError> {
-    serde_json::from_value(payload.clone())
-        .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))
+    serde_json::from_value(payload.clone()).map_err(|_e| DetectionError::DeserializationFailed)
 }
 
 /// Attempt to parse a JSON Value as OpenAI Responses API CreateResponseClass.
@@ -50,22 +190,17 @@ pub fn try_parse_openai(
 /// The key distinguishing feature is the `input` field (array of InputItem or string)
 /// instead of the `messages` field used by Chat Completions.
 pub fn try_parse_responses(payload: &Value) -> Result<CreateResponseClass, DetectionError> {
-    // First check for Responses-specific indicators
-    // Responses API uses "input" field (not "messages" like Chat Completions)
-    let has_input = payload.get("input").is_some();
-
-    // Also check it doesn't have Chat Completions indicators
-    let has_messages = payload.get("messages").is_some();
-
-    if !has_input || has_messages {
-        return Err(DetectionError::DeserializationFailed(
-            "Not a Responses API payload: missing 'input' field or has 'messages' field"
-                .to_string(),
-        ));
+    let diagnostic = responses_request_diagnostic(payload);
+    if diagnostic.kind != ResponsesRequestDiagnosticKind::TypedRequestShapeMismatch {
+        return Err(DetectionError::ResponsesRequestDiagnostic(diagnostic));
     }
 
-    serde_json::from_value(payload.clone())
-        .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))
+    serde_json::from_value(payload.clone()).map_err(|_err| {
+        DetectionError::ResponsesRequestDiagnostic(ResponsesRequestDiagnosticView {
+            kind: ResponsesRequestDiagnosticKind::TypedRequestShapeMismatch,
+            ..diagnostic
+        })
+    })
 }
 
 #[cfg(test)]
@@ -319,5 +454,90 @@ mod tests {
         let result = try_parse_openai(&payload);
         // Note: Due to OpenAI's permissive schema, this may pass
         let _ = result;
+    }
+
+    #[test]
+    fn test_responses_request_diagnostic_missing_input() {
+        let payload = json!({
+            "model": "gpt-5-mini",
+            "tools": []
+        });
+
+        let diagnostic = responses_request_diagnostic(&payload);
+        assert_eq!(
+            diagnostic.kind,
+            ResponsesRequestDiagnosticKind::MissingInput
+        );
+        assert_eq!(diagnostic.top_level_type, JsonValueKind::Object);
+        assert_eq!(diagnostic.input_type, None);
+        assert_eq!(diagnostic.tools_type, Some(JsonValueKind::Array));
+        assert!(!diagnostic.messages_present);
+    }
+
+    #[test]
+    fn test_responses_request_diagnostic_input_and_messages_both_present() {
+        let payload = json!({
+            "model": "gpt-5-mini",
+            "input": [],
+            "messages": []
+        });
+
+        let diagnostic = responses_request_diagnostic(&payload);
+        assert_eq!(
+            diagnostic.kind,
+            ResponsesRequestDiagnosticKind::InputAndMessagesBothPresent
+        );
+        assert_eq!(diagnostic.input_type, Some(JsonValueKind::Array));
+        assert!(diagnostic.messages_present);
+    }
+
+    #[test]
+    fn test_responses_request_diagnostic_input_wrong_top_level_type() {
+        let payload = json!({
+            "model": "gpt-5-mini",
+            "input": {"role": "user"}
+        });
+
+        let diagnostic = responses_request_diagnostic(&payload);
+        assert_eq!(
+            diagnostic.kind,
+            ResponsesRequestDiagnosticKind::InputWrongTopLevelType
+        );
+        assert_eq!(diagnostic.input_type, Some(JsonValueKind::Object));
+    }
+
+    #[test]
+    fn test_responses_request_diagnostic_tools_wrong_top_level_type() {
+        let payload = json!({
+            "model": "gpt-5-mini",
+            "input": [],
+            "tools": {"type": "function"}
+        });
+
+        let diagnostic = responses_request_diagnostic(&payload);
+        assert_eq!(
+            diagnostic.kind,
+            ResponsesRequestDiagnosticKind::ToolsWrongTopLevelType
+        );
+        assert_eq!(diagnostic.input_type, Some(JsonValueKind::Array));
+        assert_eq!(diagnostic.tools_type, Some(JsonValueKind::Object));
+    }
+
+    #[test]
+    fn test_try_parse_responses_returns_safe_diagnostic() {
+        let payload = json!({
+            "model": "gpt-5-mini",
+            "input": [],
+            "tools": {"type": "function"}
+        });
+
+        let err = try_parse_responses(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            DetectionError::ResponsesRequestDiagnostic(ResponsesRequestDiagnosticView {
+                kind: ResponsesRequestDiagnosticKind::ToolsWrongTopLevelType,
+                ..
+            })
+        ));
     }
 }

--- a/crates/lingua/src/providers/openai/mod.rs
+++ b/crates/lingua/src/providers/openai/mod.rs
@@ -26,7 +26,11 @@ pub mod test_responses;
 pub mod test_chat_completions;
 
 // Re-export detection functions
-pub use detect::{try_parse_openai, try_parse_responses, DetectionError};
+pub use crate::processing::JsonValueKind;
+pub use detect::{
+    responses_request_diagnostic, try_parse_openai, try_parse_responses, DetectionError,
+    ResponsesRequestDiagnosticKind, ResponsesRequestDiagnosticView,
+};
 
 // Re-export capability functions
 pub use capabilities::model_needs_transforms;

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -9,7 +9,7 @@ use crate::capabilities::ProviderFormat;
 
 use crate::error::ConvertError;
 use crate::processing::adapters::{
-    insert_opt_bool, insert_opt_f64, insert_opt_i64, ProviderAdapter,
+    insert_opt_bool, insert_opt_f64, insert_opt_i64, ProviderAdapter, RequestDetectionResult,
 };
 use crate::processing::transform::TransformError;
 use crate::providers::openai::capabilities::apply_model_transforms;
@@ -95,8 +95,18 @@ impl ProviderAdapter for ResponsesAdapter {
         "Responses"
     }
 
-    fn detect_request(&self, payload: &Value) -> bool {
-        try_parse_responses(payload).is_ok()
+    fn detect_request(&self, payload: &Value) -> RequestDetectionResult {
+        match try_parse_responses(payload) {
+            Ok(_) => RequestDetectionResult::Matched,
+            Err(crate::providers::openai::DetectionError::ResponsesRequestDiagnostic(view)) => {
+                RequestDetectionResult::Diagnostic(
+                    crate::processing::transform::RequestFormatDiagnostic::OpenAIResponses(view),
+                )
+            }
+            Err(crate::providers::openai::DetectionError::DeserializationFailed) => {
+                RequestDetectionResult::NotMatched
+            }
+        }
     }
 
     fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
@@ -956,7 +966,7 @@ mod tests {
             "model": "o1",
             "input": [{"role": "user", "content": "Hello"}]
         });
-        assert!(adapter.detect_request(&payload));
+        assert!(adapter.detect_request(&payload).is_matched());
     }
 
     /// When transforming an Anthropic response to the Responses API format, every output

--- a/crates/lingua/src/providers/vertex_anthropic/adapter.rs
+++ b/crates/lingua/src/providers/vertex_anthropic/adapter.rs
@@ -1,5 +1,5 @@
 use crate::capabilities::ProviderFormat;
-use crate::processing::adapters::ProviderAdapter;
+use crate::processing::adapters::{ProviderAdapter, RequestDetectionResult};
 use crate::processing::transform::TransformError;
 use crate::providers::anthropic::AnthropicAdapter;
 use crate::serde_json::Value;
@@ -81,11 +81,11 @@ impl ProviderAdapter for VertexAnthropicAdapter {
         "Vertex Anthropic"
     }
 
-    fn detect_request(&self, payload: &Value) -> bool {
+    fn detect_request(&self, payload: &Value) -> RequestDetectionResult {
         if !Self::is_raw_vertex_body(payload) {
-            return false;
+            return RequestDetectionResult::NotMatched;
         }
-        self.inner.request_to_universal(payload.clone()).is_ok()
+        RequestDetectionResult::from_match(self.inner.request_to_universal(payload.clone()).is_ok())
     }
 
     fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
@@ -151,21 +151,21 @@ mod tests {
             "max_tokens": 1024,
             "messages": [{"role": "user", "content": "Hello"}]
         });
-        assert!(adapter.detect_request(&valid));
+        assert!(adapter.detect_request(&valid).is_matched());
 
         let with_model = json!({
             "model": "claude-3-sonnet",
             "max_tokens": 1024,
             "messages": [{"role": "user", "content": "Hello"}]
         });
-        assert!(!adapter.detect_request(&with_model));
+        assert!(!adapter.detect_request(&with_model).is_matched());
 
         let bedrock_version = json!({
             "anthropic_version": "bedrock-2023-05-31",
             "max_tokens": 1024,
             "messages": [{"role": "user", "content": "Hello"}]
         });
-        assert!(!adapter.detect_request(&bedrock_version));
+        assert!(!adapter.detect_request(&bedrock_version).is_matched());
     }
 
     #[test]


### PR DESCRIPTION
### DO NOT MERGE ME!

Safer request-detection diagnostics path for lingua, starting with OpenAI Responses payloads.

Instead of only failing with a generic “unable to detect format,” adapters can now return a typed, log-safe structural diagnostic when a payload looks close to a known format but doesn’t match. Detection still keeps scanning other adapters, and only surfaces the diagnostic if nothing matches.

For the current Responses prototype, that means gateway logs can now show bounded categories like missing input, both input and messages, wrong top-level input type, or wrong top-level tools type, without logging any message content, tool args, metadata values, raw payload fragments, or raw parse errors.