### PR TITLE
[bug] google to chat completions and google to responses

### DIFF
--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -655,6 +655,28 @@
       "reason": "Google code_execution is provider-specific and is not a lossless equivalent of Anthropic bash"
     },
     {
+      "testCase": "codeInterpreterToolParam",
+      "source": "Google",
+      "target": "ChatCompletions",
+      "fields": [
+        { "pattern": "params.tools", "reason": "Google code_execution has no OpenAI Chat Completions equivalent and is dropped" },
+        { "pattern": "messages[*].content.length", "reason": "Google executableCode/codeExecutionResult followup content does not roundtrip through Chat Completions" }
+      ]
+    },
+    {
+      "testCase": "codeInterpreterToolParam",
+      "source": "Google",
+      "target": "Responses",
+      "fields": [
+        { "pattern": "params.tools[*].builtin_type", "reason": "Google code_execution is canonicalized to the OpenAI Responses code_interpreter builtin type" },
+        { "pattern": "params.tools[*].name", "reason": "Google code_execution is canonicalized to the OpenAI Responses code_interpreter builtin name" },
+        { "pattern": "params.tools[*].provider", "reason": "Google code_execution is canonicalized from a Google builtin to a Responses builtin" },
+        { "pattern": "params.tools[*].config.type", "reason": "Google code_execution is normalized to OpenAI code_interpreter config" },
+        { "pattern": "params.tools[*].config.container", "reason": "Google code_execution is normalized to OpenAI code_interpreter container config" },
+        { "pattern": "messages[*].content[*].provider_options", "reason": "Google code execution metadata is not losslessly representable through Responses message content" }
+      ]
+    },
+    {
       "testCase": "toolChoiceRequiredWithReasoningParam",
       "source": "Google",
       "target": "Anthropic",

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -759,6 +759,70 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(feature = "openai", feature = "google"))]
+    fn test_google_code_execution_maps_to_responses_code_interpreter() {
+        let payload = json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "Execute Python code to generate a random number"}]
+            }],
+            "tools": [{
+                "codeExecution": {}
+            }]
+        });
+        let input = to_bytes(&payload);
+
+        let result =
+            transform_request(input, ProviderFormat::Responses, Some("gpt-5-nano")).unwrap();
+
+        assert!(!result.is_passthrough());
+        assert_eq!(result.source_format(), Some(ProviderFormat::Google));
+
+        let output: Value = crate::serde_json::from_slice(result.as_bytes()).unwrap();
+        assert_eq!(output.get("model").unwrap().as_str().unwrap(), "gpt-5-nano");
+        assert_eq!(
+            output.get("tools"),
+            Some(&json!([
+                {
+                    "type": "code_interpreter",
+                    "container": {
+                        "type": "auto"
+                    }
+                }
+            ])),
+            "Google codeExecution should map to Responses code_interpreter"
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "openai", feature = "google"))]
+    fn test_google_code_execution_is_stripped_for_chat_requests() {
+        let payload = json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "Execute Python code to generate a random number"}]
+            }],
+            "tools": [{
+                "codeExecution": {}
+            }]
+        });
+        let input = to_bytes(&payload);
+
+        let result =
+            transform_request(input, ProviderFormat::ChatCompletions, Some("gpt-5-nano")).unwrap();
+
+        assert!(!result.is_passthrough());
+        assert_eq!(result.source_format(), Some(ProviderFormat::Google));
+
+        let output: Value = crate::serde_json::from_slice(result.as_bytes()).unwrap();
+        assert_eq!(output.get("model").unwrap().as_str().unwrap(), "gpt-5-nano");
+        assert!(
+            output.get("tools").is_none(),
+            "Google codeExecution should be stripped for Chat Completions"
+        );
+    }
+
+    #[test]
     #[cfg(feature = "openai")]
     fn test_non_reasoning_model_still_passthroughs() {
         // Non-reasoning models should still passthrough for efficiency

--- a/crates/lingua/src/universal/tools.rs
+++ b/crates/lingua/src/universal/tools.rs
@@ -35,8 +35,8 @@ use crate::providers::anthropic::generated::{
 };
 use crate::providers::google::generated::GoogleSearch;
 use crate::providers::openai::generated::{
-    ApproximateLocation, Tool as OpenAIResponsesTool, UserLocationType as OpenAIUserLocationType,
-    WebSearchTool,
+    ApproximateLocation, CodeInterpreterTool, Tool as OpenAIResponsesTool,
+    UserLocationType as OpenAIUserLocationType, WebSearchTool,
 };
 use crate::serde_json::{self, json, Map, Value};
 
@@ -526,6 +526,28 @@ impl UniversalTool {
                         error: e.to_string(),
                     })
                 }
+                BuiltinToolProvider::Google if builtin_type == "code_execution" => {
+                    let _google_config =
+                        config
+                            .clone()
+                            .ok_or_else(|| ConvertError::UnsupportedToolType {
+                                tool_name: self.name.clone(),
+                                tool_type: builtin_type.clone(),
+                                target_provider: ProviderFormat::Responses,
+                            })?;
+
+                    let tool = OpenAIResponsesTool::CodeInterpreter(CodeInterpreterTool {
+                        container: json!({ "type": "auto" }),
+                    });
+
+                    serde_json::to_value(tool).map_err(|e| ConvertError::JsonSerializationFailed {
+                        field: format!(
+                            "OpenAI responses Google code execution tool conversion for '{}'",
+                            self.name
+                        ),
+                        error: e.to_string(),
+                    })
+                }
                 BuiltinToolProvider::Anthropic
                 | BuiltinToolProvider::Converse
                 | BuiltinToolProvider::Google => Err(ConvertError::UnsupportedToolType {
@@ -558,7 +580,9 @@ pub fn tools_to_openai_chat_value(tools: &[UniversalTool]) -> Result<Option<Valu
                 tool_type,
                 target_provider: ProviderFormat::ChatCompletions,
                 ..
-            }) if tool_type == "web_search_20250305" || tool_type == "google_search" => {}
+            }) if tool_type == "web_search_20250305"
+                || tool_type == "google_search"
+                || tool_type == "code_execution" => {}
             Err(err) => return Err(err),
         }
     }
@@ -577,10 +601,12 @@ pub fn tools_to_responses_value(tools: &[UniversalTool]) -> Result<Option<Value>
     if tools.is_empty() {
         return Ok(None);
     }
-    let converted: Vec<Value> = tools
-        .iter()
-        .map(|t| t.to_responses_value())
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut converted = Vec::new();
+
+    for tool in tools {
+        converted.push(tool.to_responses_value()?);
+    }
+
     Ok(Some(Value::Array(converted)))
 }
 
@@ -927,6 +953,19 @@ mod tests {
     }
 
     #[test]
+    fn test_batch_conversion_to_openai_chat_drops_google_code_execution() {
+        let tools = vec![UniversalTool::builtin(
+            "code_execution",
+            BuiltinToolProvider::Google,
+            "code_execution",
+            Some(json!({})),
+        )];
+
+        let result = tools_to_openai_chat_value(&tools).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
     fn test_anthropic_web_search_to_openai_chat_is_unsupported_without_filters() {
         let tool = UniversalTool::builtin(
             "web_search",
@@ -1096,6 +1135,48 @@ mod tests {
             }
             other => panic!("expected web_search tool, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_google_code_execution_to_responses() {
+        let tool = UniversalTool::builtin(
+            "code_execution",
+            BuiltinToolProvider::Google,
+            "code_execution",
+            Some(json!({})),
+        );
+
+        let typed: OpenAIResponsesTool =
+            serde_json::from_value(tool.to_responses_value().unwrap()).unwrap();
+        match typed {
+            OpenAIResponsesTool::CodeInterpreter(code_interpreter) => {
+                assert_eq!(code_interpreter.container, json!({ "type": "auto" }));
+            }
+            other => panic!("expected code_interpreter tool, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_batch_conversion_to_responses_maps_google_code_execution() {
+        let tools = vec![UniversalTool::builtin(
+            "code_execution",
+            BuiltinToolProvider::Google,
+            "code_execution",
+            Some(json!({})),
+        )];
+
+        let value = tools_to_responses_value(&tools).unwrap();
+        assert_eq!(
+            value,
+            Some(json!([
+                {
+                    "type": "code_interpreter",
+                    "container": {
+                        "type": "auto"
+                    }
+                }
+            ]))
+        );
     }
 
     #[test]

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -16277,12 +16277,32 @@ exports[`google → chat-completions > codeInterpreterToolParam > response 1`] =
       "content": {
         "parts": [
           {
-            "text": "I can suggest Python code for generating a random number, but I cannot execute it in this chat response.
+            "text": "I can’t run Python code directly in this chat, but I can give you ready-to-run snippets and help you generate a number.
 
-\`\`\`python
-import random
-print(random.random())
-\`\`\`",
+What range and type do you want?
+- Integer between a and b (inclusive)
+- Float between a and b (inclusive of endpoints or exclusive, typically inclusive)
+
+Examples you can run:
+
+- Random integer between 1 and 100 (inclusive):
+  import random
+  print(random.randint(1, 100))
+
+- One-liner you can run in a shell:
+  python -c "import random; print(random.randint(1, 100))"
+
+- Random float in [0.0, 1.0):
+  import random
+  print(random.random())
+
+- Random float in [a, b):
+  import random
+  a = 5.0
+  b = 10.0
+  print(random.uniform(a, b))
+
+If you tell me the exact range and integer vs float, I’ll tailor a snippet for you. I can also provide a single sample number here if you just want a quick value (without executing code).",
           },
         ],
         "role": "model",
@@ -16294,9 +16314,10 @@ print(random.random())
   "modelVersion": "gpt-5-nano-2025-08-07",
   "usageMetadata": {
     "cachedContentTokenCount": 0,
-    "candidatesTokenCount": 61,
+    "candidatesTokenCount": 231,
     "promptTokenCount": 14,
-    "totalTokenCount": 75,
+    "thoughtsTokenCount": 1408,
+    "totalTokenCount": 1653,
   },
 }
 `;
@@ -18452,14 +18473,12 @@ exports[`google → responses > codeInterpreterToolParam > response 1`] = `
             "functionCall": {
               "args": {
                 "code": "import random
-val = random.random()
-val
-",
-                "container_id": "cntr_69ec2ada23d08190aa60e3af906fa1110e79a52f36f0f4bb",
+random.randint(1,100)",
+                "container_id": "cntr_69efdd6ed1c48193898cda163efe14440982887c1fad39fd",
                 "outputs": null,
                 "status": "completed",
               },
-              "id": "ci_02faa4f1e3de41e60069ec2add8fc081959827ab14d0d248dc",
+              "id": "ci_04778756f10776c40069efdd72ec0c8197b3e93a0f6c322ff5",
               "name": "code_interpreter",
             },
           },
@@ -18486,12 +18505,9 @@ val
       "content": {
         "parts": [
           {
-            "text": "Here’s a randomly generated number (between 0 and 1): 0.5171688153286212
+            "text": "Here’s a random number (1–100): 73
 
-Would you like:
-- a random integer in a specific range (e.g., 1 to 100), or
-- a random float in another range (e.g., 5.0 to 10.0), or
-- something else?",
+If you want a different range or a float, tell me the specifics.",
           },
         ],
         "role": "model",
@@ -18503,10 +18519,10 @@ Would you like:
   "modelVersion": "gpt-5-nano-2025-08-07",
   "usageMetadata": {
     "cachedContentTokenCount": 0,
-    "candidatesTokenCount": 165,
-    "promptTokenCount": 996,
-    "thoughtsTokenCount": 384,
-    "totalTokenCount": 1545,
+    "candidatesTokenCount": 118,
+    "promptTokenCount": 1108,
+    "thoughtsTokenCount": 448,
+    "totalTokenCount": 1674,
   },
 }
 `;

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -16258,6 +16258,49 @@ exports[`google → anthropic > webSearchToolParam > response 1`] = `
 }
 `;
 
+exports[`google → chat-completions > codeInterpreterToolParam > request 1`] = `
+{
+  "messages": [
+    {
+      "content": "Execute Python code to generate a random number",
+      "role": "user",
+    },
+  ],
+  "model": "gpt-5-nano",
+}
+`;
+
+exports[`google → chat-completions > codeInterpreterToolParam > response 1`] = `
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "I can suggest Python code for generating a random number, but I cannot execute it in this chat response.
+
+\`\`\`python
+import random
+print(random.random())
+\`\`\`",
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 0,
+    },
+  ],
+  "modelVersion": "gpt-5-nano-2025-08-07",
+  "usageMetadata": {
+    "cachedContentTokenCount": 0,
+    "candidatesTokenCount": 61,
+    "promptTokenCount": 14,
+    "totalTokenCount": 75,
+  },
+}
+`;
+
 exports[`google → chat-completions > complexReasoningRequest > request 1`] = `
 {
   "max_completion_tokens": 20000,
@@ -18362,6 +18405,108 @@ If you want, I can also prepare a short, current-news brief for you once you pas
     "promptTokenCount": 10,
     "thoughtsTokenCount": 1344,
     "totalTokenCount": 1612,
+  },
+}
+`;
+
+exports[`google → responses > codeInterpreterToolParam > request 1`] = `
+{
+  "input": [
+    {
+      "content": "Execute Python code to generate a random number",
+      "role": "user",
+    },
+  ],
+  "model": "gpt-5-nano",
+  "tools": [
+    {
+      "container": {
+        "type": "auto",
+      },
+      "type": "code_interpreter",
+    },
+  ],
+}
+`;
+
+exports[`google → responses > codeInterpreterToolParam > response 1`] = `
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "",
+            "thought": true,
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 0,
+    },
+    {
+      "content": {
+        "parts": [
+          {
+            "functionCall": {
+              "args": {
+                "code": "import random
+val = random.random()
+val
+",
+                "container_id": "cntr_69ec2ada23d08190aa60e3af906fa1110e79a52f36f0f4bb",
+                "outputs": null,
+                "status": "completed",
+              },
+              "id": "ci_02faa4f1e3de41e60069ec2add8fc081959827ab14d0d248dc",
+              "name": "code_interpreter",
+            },
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 1,
+    },
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "",
+            "thought": true,
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 2,
+    },
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Here’s a randomly generated number (between 0 and 1): 0.5171688153286212
+
+Would you like:
+- a random integer in a specific range (e.g., 1 to 100), or
+- a random float in another range (e.g., 5.0 to 10.0), or
+- something else?",
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 3,
+    },
+  ],
+  "modelVersion": "gpt-5-nano-2025-08-07",
+  "usageMetadata": {
+    "cachedContentTokenCount": 0,
+    "candidatesTokenCount": 165,
+    "promptTokenCount": 996,
+    "thoughtsTokenCount": 384,
+    "totalTokenCount": 1545,
   },
 }
 `;

--- a/payloads/transforms/google_to_chat-completions/codeInterpreterToolParam.json
+++ b/payloads/transforms/google_to_chat-completions/codeInterpreterToolParam.json
@@ -1,3 +1,35 @@
 {
-  "error": "Conversion from universal format failed: Tool 'code_execution' of type 'code_execution' is not supported by openai"
+  "id": "chatcmpl-DYNgZ34uNCJGVpbVN75ytfsb2pCoL",
+  "object": "chat.completion",
+  "created": 1777086571,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "I can’t execute code here, but I can give you ready-to-run Python snippets. Tell me the range and whether you want an integer or a float, and I’ll tailor it.\n\nIf you want a quick start:\n\n- Random integer between a and b (inclusive):\n  import random\n  a = 1  # replace with your min\n  b = 100  # replace with your max\n  print(random.randint(a, b))\n\n- Random float in [0.0, 1.0):\n  import random\n  print(random.random())\n\n- Random integer with a fixed seed (reproducible results):\n  import random\n  random.seed(42)\n  print(random.randint(1, 100))\n\nLet me know your preferred range and type (int or float), and I’ll provide a precise snippet.",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 14,
+    "completion_tokens": 1394,
+    "total_tokens": 1408,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 1216,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
 }

--- a/payloads/transforms/google_to_chat-completions/codeInterpreterToolParam.json
+++ b/payloads/transforms/google_to_chat-completions/codeInterpreterToolParam.json
@@ -1,14 +1,14 @@
 {
-  "id": "chatcmpl-DYNgZ34uNCJGVpbVN75ytfsb2pCoL",
+  "id": "chatcmpl-DZOLedMxb7fii49QX0rAavlTmuwYj",
   "object": "chat.completion",
-  "created": 1777086571,
+  "created": 1777327446,
   "model": "gpt-5-nano-2025-08-07",
   "choices": [
     {
       "index": 0,
       "message": {
         "role": "assistant",
-        "content": "I can’t execute code here, but I can give you ready-to-run Python snippets. Tell me the range and whether you want an integer or a float, and I’ll tailor it.\n\nIf you want a quick start:\n\n- Random integer between a and b (inclusive):\n  import random\n  a = 1  # replace with your min\n  b = 100  # replace with your max\n  print(random.randint(a, b))\n\n- Random float in [0.0, 1.0):\n  import random\n  print(random.random())\n\n- Random integer with a fixed seed (reproducible results):\n  import random\n  random.seed(42)\n  print(random.randint(1, 100))\n\nLet me know your preferred range and type (int or float), and I’ll provide a precise snippet.",
+        "content": "I can’t run Python code directly in this chat, but I can give you ready-to-run snippets and help you generate a number.\n\nWhat range and type do you want?\n- Integer between a and b (inclusive)\n- Float between a and b (inclusive of endpoints or exclusive, typically inclusive)\n\nExamples you can run:\n\n- Random integer between 1 and 100 (inclusive):\n  import random\n  print(random.randint(1, 100))\n\n- One-liner you can run in a shell:\n  python -c \"import random; print(random.randint(1, 100))\"\n\n- Random float in [0.0, 1.0):\n  import random\n  print(random.random())\n\n- Random float in [a, b):\n  import random\n  a = 5.0\n  b = 10.0\n  print(random.uniform(a, b))\n\nIf you tell me the exact range and integer vs float, I’ll tailor a snippet for you. I can also provide a single sample number here if you just want a quick value (without executing code).",
         "refusal": null,
         "annotations": []
       },
@@ -17,14 +17,14 @@
   ],
   "usage": {
     "prompt_tokens": 14,
-    "completion_tokens": 1394,
-    "total_tokens": 1408,
+    "completion_tokens": 1639,
+    "total_tokens": 1653,
     "prompt_tokens_details": {
       "cached_tokens": 0,
       "audio_tokens": 0
     },
     "completion_tokens_details": {
-      "reasoning_tokens": 1216,
+      "reasoning_tokens": 1408,
       "audio_tokens": 0,
       "accepted_prediction_tokens": 0,
       "rejected_prediction_tokens": 0

--- a/payloads/transforms/google_to_responses/codeInterpreterToolParam.json
+++ b/payloads/transforms/google_to_responses/codeInterpreterToolParam.json
@@ -1,13 +1,13 @@
 {
-  "id": "resp_0fca1b80d60caed70069ec305f0fa081a0b26a1853dfc2c87e",
+  "id": "resp_04778756f10776c40069efdd6e4a7481979c516db84c2f8a4b",
   "object": "response",
-  "created_at": 1777086559,
+  "created_at": 1777327470,
   "status": "completed",
   "background": false,
   "billing": {
     "payer": "developer"
   },
-  "completed_at": 1777086566,
+  "completed_at": 1777327478,
   "error": null,
   "frequency_penalty": 0,
   "incomplete_details": null,
@@ -18,25 +18,25 @@
   "moderation": null,
   "output": [
     {
-      "id": "rs_0fca1b80d60caed70069ec305f8c9081a08fbdf9be184e603f",
+      "id": "rs_04778756f10776c40069efdd6f67348197a06b062cc5888207",
       "type": "reasoning",
       "summary": []
     },
     {
-      "id": "ci_0fca1b80d60caed70069ec3061d91081a09de5a32586f89505",
+      "id": "ci_04778756f10776c40069efdd72ec0c8197b3e93a0f6c322ff5",
       "type": "code_interpreter_call",
       "status": "completed",
-      "code": "import random\nprint(random.random())",
-      "container_id": "cntr_69ec305f24d0819196b7d99df176545b02fe14b6d68cfbb3",
+      "code": "import random\r\nrandom.randint(1,100)",
+      "container_id": "cntr_69efdd6ed1c48193898cda163efe14440982887c1fad39fd",
       "outputs": null
     },
     {
-      "id": "rs_0fca1b80d60caed70069ec3063970c81a083cacaa0bffc1b02",
+      "id": "rs_04778756f10776c40069efdd74e11481979c606f9d10db60ee",
       "type": "reasoning",
       "summary": []
     },
     {
-      "id": "msg_0fca1b80d60caed70069ec3065b84081a08b260442fcaa732f",
+      "id": "msg_04778756f10776c40069efdd75a03881978efacc6051b44247",
       "type": "message",
       "status": "completed",
       "content": [
@@ -44,7 +44,7 @@
           "type": "output_text",
           "annotations": [],
           "logprobs": [],
-          "text": "Here is a random number between 0 and 1: 0.27269563460293\n\nWant a number in a different range (e.g., 1-100) or an integer?"
+          "text": "Here’s a random number (1–100): 73\n\nIf you want a different range or a float, tell me the specifics."
         }
       ],
       "role": "assistant"
@@ -82,17 +82,17 @@
   "top_p": 1,
   "truncation": "disabled",
   "usage": {
-    "input_tokens": 992,
+    "input_tokens": 1108,
     "input_tokens_details": {
       "cached_tokens": 0
     },
-    "output_tokens": 609,
+    "output_tokens": 566,
     "output_tokens_details": {
-      "reasoning_tokens": 512
+      "reasoning_tokens": 448
     },
-    "total_tokens": 1601
+    "total_tokens": 1674
   },
   "user": null,
   "metadata": {},
-  "output_text": "Here is a random number between 0 and 1: 0.27269563460293\n\nWant a number in a different range (e.g., 1-100) or an integer?"
+  "output_text": "Here’s a random number (1–100): 73\n\nIf you want a different range or a float, tell me the specifics."
 }

--- a/payloads/transforms/google_to_responses/codeInterpreterToolParam.json
+++ b/payloads/transforms/google_to_responses/codeInterpreterToolParam.json
@@ -1,3 +1,98 @@
 {
-  "error": "Conversion from universal format failed: Tool 'code_execution' of type 'code_execution' is not supported by responses"
+  "id": "resp_0fca1b80d60caed70069ec305f0fa081a0b26a1853dfc2c87e",
+  "object": "response",
+  "created_at": 1777086559,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1777086566,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "moderation": null,
+  "output": [
+    {
+      "id": "rs_0fca1b80d60caed70069ec305f8c9081a08fbdf9be184e603f",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "ci_0fca1b80d60caed70069ec3061d91081a09de5a32586f89505",
+      "type": "code_interpreter_call",
+      "status": "completed",
+      "code": "import random\nprint(random.random())",
+      "container_id": "cntr_69ec305f24d0819196b7d99df176545b02fe14b6d68cfbb3",
+      "outputs": null
+    },
+    {
+      "id": "rs_0fca1b80d60caed70069ec3063970c81a083cacaa0bffc1b02",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0fca1b80d60caed70069ec3065b84081a08b260442fcaa732f",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Here is a random number between 0 and 1: 0.27269563460293\n\nWant a number in a different range (e.g., 1-100) or an integer?"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "code_interpreter",
+      "container": {
+        "type": "auto"
+      }
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 992,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 609,
+    "output_tokens_details": {
+      "reasoning_tokens": 512
+    },
+    "total_tokens": 1601
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Here is a random number between 0 and 1: 0.27269563460293\n\nWant a number in a different range (e.g., 1-100) or an integer?"
 }

--- a/payloads/transforms/transform_errors.json
+++ b/payloads/transforms/transform_errors.json
@@ -33,11 +33,9 @@
     "reasoningEffortLowParam": "Anthropic requires max_tokens > budget_tokens; min budget (1024) exceeds max_tokens (100)"
   },
   "google_to_chat-completions": {
-    "codeInterpreterToolParam": "Expected: Google code_execution is provider-specific and is not supported by OpenAI Chat Completions",
     "urlContextToolParam": "Tool 'url_context' of type 'url_context' is not supported by openai"
   },
   "google_to_responses": {
-    "codeInterpreterToolParam": "Expected: Google code_execution is provider-specific and is not a lossless equivalent of OpenAI Responses code_interpreter",
     "urlContextToolParam": "Tool 'url_context' of type 'url_context' is not supported by responses"
   }
 }


### PR DESCRIPTION
Made this small change to fix a parsing error. I believe the right location to fix this is in tools but I also noticed some changes in adapters and it is unclear to me where this change should appropriately live.


For google to open ai responses set code_interpreter property for codeExecution google property.
For google to open ai chat completions strip out the code_interpreter property as there appears to be no equivalent.

Fix the existing tests and remove the transform errors.