### PR TITLE
update retry policy

### DIFF
--- a/crates/braintrust-llm-router/src/client.rs
+++ b/crates/braintrust-llm-router/src/client.rs
@@ -33,7 +33,7 @@ impl Default for ClientSettings {
     fn default() -> Self {
         Self {
             connect_timeout: Duration::from_secs(10),
-            request_timeout: Duration::from_secs(300),
+            request_timeout: Duration::from_secs(600),
             pool_idle_timeout: Duration::from_secs(90),
             pool_max_idle_per_host: 16,
             user_agent: format!("braintrust-llm-router/{}", env!("CARGO_PKG_VERSION")),
@@ -132,6 +132,10 @@ fn build_retrying_middleware_client(client: Client) -> ClientWithMiddleware {
 }
 
 fn retryable_transport_failure(err: &reqwest_middleware::Error) -> Option<Retryable> {
+    if is_request_timeout(err) {
+        return None;
+    }
+
     let retryable = match default_on_request_failure(err) {
         Some(Retryable::Transient) => Some(Retryable::Transient),
         default_retryability => match err {
@@ -153,6 +157,17 @@ fn retryable_transport_failure(err: &reqwest_middleware::Error) -> Option<Retrya
     }
 
     retryable
+}
+
+fn is_request_timeout(err: &reqwest_middleware::Error) -> bool {
+    match err {
+        reqwest_middleware::Error::Reqwest(err) => err.is_timeout() && !err.is_connect(),
+        reqwest_middleware::Error::Middleware(err) => err.chain().any(|source| {
+            source
+                .downcast_ref::<reqwest::Error>()
+                .is_some_and(|err| err.is_timeout() && !err.is_connect())
+        }),
+    }
 }
 
 fn chain_has_connection_io_error(err: &(dyn StdError + 'static)) -> bool {
@@ -218,6 +233,10 @@ fn cached_client_count() -> usize {
 mod tests {
     use super::*;
     use serial_test::serial;
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
 
     #[test]
     #[serial]
@@ -258,5 +277,36 @@ mod tests {
         build_middleware_client(&second_settings).expect("second client");
 
         assert_eq!(cached_client_count(), 2);
+    }
+
+    #[test]
+    fn default_request_timeout_is_600_seconds() {
+        assert_eq!(
+            ClientSettings::default().request_timeout,
+            Duration::from_secs(600)
+        );
+    }
+
+    #[tokio::test]
+    async fn request_timeout_is_not_retryable_transport_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/slow"))
+            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_millis(100)))
+            .mount(&server)
+            .await;
+
+        let client = ClientBuilder::new()
+            .timeout(Duration::from_millis(10))
+            .build()
+            .expect("client");
+        let err = client
+            .get(format!("{}/slow", server.uri()))
+            .send()
+            .await
+            .expect_err("request should time out");
+
+        assert!(err.is_timeout());
+        assert!(retryable_transport_failure(&reqwest_middleware::Error::Reqwest(err)).is_none());
     }
 }

--- a/crates/braintrust-llm-router/src/error.rs
+++ b/crates/braintrust-llm-router/src/error.rs
@@ -108,11 +108,10 @@ impl Error {
     pub fn is_retryable(&self) -> bool {
         // Router-level retries are reserved for errors that originate outside the
         // provider HTTP wrapper's connection-retry path, such as raw reqwest
-        // errors, middleware errors, explicit Retry-After responses, or timeouts.
+        // errors, middleware errors, or explicit Retry-After responses.
         matches!(self, Error::Http(err) if is_reqwest_retryable(err))
             || matches!(self, Error::Middleware(err) if is_middleware_retryable(err))
             || matches!(self, Error::Provider { retry_after, .. } if retry_after.is_some())
-            || matches!(self, Error::Timeout)
     }
 
     pub fn retry_after(&self) -> Option<Duration> {
@@ -150,15 +149,21 @@ impl Error {
 }
 
 fn is_reqwest_retryable(err: &reqwest::Error) -> bool {
-    err.is_timeout()
-        || err.is_connect()
+    if err.is_timeout() {
+        return false;
+    }
+
+    err.is_connect()
         || err.is_request()
         || err.status().map(|c| c.is_server_error()).unwrap_or(false)
 }
 
 fn is_middleware_retryable(err: &reqwest_middleware::Error) -> bool {
-    err.is_timeout()
-        || err.is_request()
+    if err.is_timeout() {
+        return false;
+    }
+
+    err.is_request()
         || {
             #[cfg(not(target_arch = "wasm32"))]
             {
@@ -266,5 +271,10 @@ mod tests {
             http: None,
         };
         assert!(!non_upstream_err.is_upstream_error());
+    }
+
+    #[test]
+    fn timeout_error_is_not_retryable() {
+        assert!(!Error::Timeout.is_retryable());
     }
 }

--- a/crates/braintrust-llm-router/src/retry.rs
+++ b/crates/braintrust-llm-router/src/retry.rs
@@ -95,15 +95,25 @@ mod tests {
         }
     }
 
-    #[test]
-    fn retryable_error_uses_exponential_backoff() {
+    async fn connect_error() -> Error {
+        let err = reqwest::Client::new()
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .expect_err("connection failure");
+        Error::Http(err)
+    }
+
+    #[tokio::test]
+    async fn retryable_error_uses_exponential_backoff() {
         let policy = base_policy();
         let mut strategy = policy.strategy();
+        let err = connect_error().await;
 
-        let delay1 = strategy.next_delay(&Error::Timeout).expect("first retry");
-        let delay2 = strategy.next_delay(&Error::Timeout).expect("second retry");
-        let delay3 = strategy.next_delay(&Error::Timeout).expect("third retry");
-        let delay4 = strategy.next_delay(&Error::Timeout);
+        let delay1 = strategy.next_delay(&err).expect("first retry");
+        let delay2 = strategy.next_delay(&err).expect("second retry");
+        let delay3 = strategy.next_delay(&err).expect("third retry");
+        let delay4 = strategy.next_delay(&err);
 
         assert_eq!(delay1, Duration::from_millis(200));
         assert_eq!(delay2, Duration::from_millis(400));
@@ -140,13 +150,14 @@ mod tests {
         assert_eq!(delay, Duration::from_secs(1));
     }
 
-    #[test]
-    fn jitter_stays_within_expected_bounds() {
+    #[tokio::test]
+    async fn jitter_stays_within_expected_bounds() {
         let mut policy = base_policy();
         policy.jitter = true;
         let mut strategy = policy.strategy();
+        let err = connect_error().await;
 
-        let delay = strategy.next_delay(&Error::Timeout).expect("jitter delay");
+        let delay = strategy.next_delay(&err).expect("jitter delay");
         assert!(delay >= Duration::from_millis(100));
         assert!(delay <= Duration::from_millis(300));
     }

--- a/crates/braintrust-llm-router/tests/router.rs
+++ b/crates/braintrust-llm-router/tests/router.rs
@@ -507,7 +507,7 @@ fn retry_model_catalog() -> Arc<ModelCatalog> {
 }
 
 #[tokio::test]
-async fn router_retries_and_propagates_terminal_error() {
+async fn router_does_not_retry_timeout_errors() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let retry_policy = RetryPolicy {
         max_attempts: 2,
@@ -549,7 +549,7 @@ async fn router_retries_and_propagates_terminal_error() {
         router.complete(request, &ClientHeaders::default()).await;
     let err = err.expect_err("terminal error");
     assert!(matches!(err, Error::Timeout));
-    assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
some llm providers like baseten timeout synchronously in 10 minutes -> https://docs.baseten.co/deployment/autoscaling/request-lifecycle#timeouts

so we need to bump the request timeout parameter by default.

i also changed the logic to not retry timeout errors.