### PR TITLE
Route to /chat/completions endpoint if model_format is set to openai with anthropic provider

### DIFF
--- a/crates/braintrust-llm-router/src/providers/anthropic.rs
+++ b/crates/braintrust-llm-router/src/providers/anthropic.rs
@@ -9,7 +9,7 @@ use crate::streaming::{sse_stream, RawResponseStream};
 use async_trait::async_trait;
 use bytes::Bytes;
 use lingua::ProviderFormat;
-use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::Url;
 use reqwest_middleware::ClientWithMiddleware;
 
@@ -84,6 +84,13 @@ impl AnthropicProvider {
             .expect("join messages path")
     }
 
+    fn chat_completions_url(&self) -> Url {
+        self.config
+            .endpoint
+            .join("chat/completions")
+            .expect("join chat/completions path")
+    }
+
     fn build_headers(&self, client_headers: &ClientHeaders) -> HeaderMap {
         let mut headers = client_headers.to_json_headers();
 
@@ -111,7 +118,7 @@ impl crate::providers::Provider for AnthropicProvider {
     }
 
     fn provider_formats(&self) -> Vec<ProviderFormat> {
-        vec![ProviderFormat::Anthropic]
+        vec![ProviderFormat::Anthropic, ProviderFormat::ChatCompletions]
     }
 
     async fn complete(
@@ -119,13 +126,25 @@ impl crate::providers::Provider for AnthropicProvider {
         payload: Bytes,
         auth: &AuthConfig,
         _spec: &ModelSpec,
-        _format: ProviderFormat,
+        format: ProviderFormat,
         client_headers: &ClientHeaders,
     ) -> Result<Bytes> {
-        let url = self.messages_url();
-
-        let mut headers = self.build_headers(client_headers);
-        auth.apply_headers(&mut headers)?;
+        let (url, headers) = if format == ProviderFormat::ChatCompletions {
+            let mut h = client_headers.to_json_headers();
+            let key = auth.api_key().ok_or_else(|| {
+                Error::Auth("Anthropic /chat/completions requires an API key".to_string())
+            })?;
+            h.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {key}"))
+                    .map_err(|e| Error::Auth(format!("invalid auth header: {e}")))?,
+            );
+            (self.chat_completions_url(), h)
+        } else {
+            let mut h = self.build_headers(client_headers);
+            auth.apply_headers(&mut h)?;
+            (self.messages_url(), h)
+        };
 
         let response = self
             .client
@@ -176,10 +195,22 @@ impl crate::providers::Provider for AnthropicProvider {
         }
 
         // Router should have already added stream options to payload
-        let url = self.messages_url();
-
-        let mut headers = self.build_headers(client_headers);
-        auth.apply_headers(&mut headers)?;
+        let (url, headers) = if format == ProviderFormat::ChatCompletions {
+            let mut h = client_headers.to_json_headers();
+            let key = auth.api_key().ok_or_else(|| {
+                Error::Auth("Anthropic /chat/completions requires an API key".to_string())
+            })?;
+            h.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {key}"))
+                    .map_err(|e| Error::Auth(format!("invalid auth header: {e}")))?,
+            );
+            (self.chat_completions_url(), h)
+        } else {
+            let mut h = self.build_headers(client_headers);
+            auth.apply_headers(&mut h)?;
+            (self.messages_url(), h)
+        };
 
         let response = self
             .client

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -495,6 +495,16 @@ impl Router {
             // Anthropic on Azure only supports the messages format and isn’t
             // interchangeable with other APIs.
             ProviderFormat::Anthropic
+        } else if provider.id() == "anthropic" {
+            // Native Anthropic has two endpoints: /v1/messages (Anthropic format) and the
+            // OpenAI-compatible /v1/chat/completions (ChatCompletions format). Use
+            // /chat/completions only when the catalog entry was explicitly registered as
+            // OpenAI format; otherwise always use the native Messages API.
+            if catalog_format == ProviderFormat::ChatCompletions {
+                ProviderFormat::ChatCompletions
+            } else {
+                ProviderFormat::Anthropic
+            }
         } else if output_format != catalog_format && provider_formats.contains(&output_format) {
             output_format
         } else {

--- a/crates/braintrust-llm-router/tests/router.rs
+++ b/crates/braintrust-llm-router/tests/router.rs
@@ -1,12 +1,12 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use braintrust_llm_router::{
     serde_json::{json, Value},
     AuthConfig, ClientHeaders, Error, ModelCatalog, ModelFlavor, ModelSpec, Provider,
-    ProviderFormat, RawResponseStream, RetryPolicy, RouterBuilder,
+    ProviderFormat, RawResponseStream, RetryPolicy, Router, RouterBuilder,
 };
 use bytes::Bytes;
 
@@ -479,6 +479,179 @@ impl Provider for MiddlewareFailingProvider {
     async fn health_check(&self, _auth: &AuthConfig) -> braintrust_llm_router::Result<()> {
         Ok(())
     }
+}
+
+/// A stub that pretends to be the native Anthropic provider and records the format
+/// it was called with, so tests can assert on resolve_provider's format selection.
+#[derive(Clone)]
+struct CapturingAnthropicStub {
+    recorded_format: Arc<Mutex<Option<ProviderFormat>>>,
+}
+
+#[async_trait]
+impl Provider for CapturingAnthropicStub {
+    fn id(&self) -> &'static str {
+        "anthropic"
+    }
+
+    fn provider_formats(&self) -> Vec<ProviderFormat> {
+        vec![ProviderFormat::Anthropic, ProviderFormat::ChatCompletions]
+    }
+
+    async fn complete(
+        &self,
+        _payload: Bytes,
+        _auth: &AuthConfig,
+        _spec: &ModelSpec,
+        format: ProviderFormat,
+        _client_headers: &ClientHeaders,
+    ) -> braintrust_llm_router::Result<Bytes> {
+        *self.recorded_format.lock().unwrap() = Some(format);
+        let response = braintrust_llm_router::serde_json::json!({
+            "id": "stub",
+            "object": "chat.completion",
+            "model": "claude-test",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        });
+        Ok(Bytes::from(
+            braintrust_llm_router::serde_json::to_vec(&response).unwrap(),
+        ))
+    }
+
+    async fn complete_stream(
+        &self,
+        _payload: Bytes,
+        _auth: &AuthConfig,
+        _spec: &ModelSpec,
+        _format: ProviderFormat,
+        _client_headers: &ClientHeaders,
+    ) -> braintrust_llm_router::Result<RawResponseStream> {
+        Ok(Box::pin(tokio_stream::empty()))
+    }
+
+    async fn health_check(&self, _auth: &AuthConfig) -> braintrust_llm_router::Result<()> {
+        Ok(())
+    }
+}
+
+fn anthropic_router(catalog: Arc<ModelCatalog>) -> (Router, Arc<Mutex<Option<ProviderFormat>>>) {
+    let recorded_format = Arc::new(Mutex::new(None));
+    let stub = CapturingAnthropicStub {
+        recorded_format: Arc::clone(&recorded_format),
+    };
+    let router = RouterBuilder::new()
+        .with_catalog(catalog)
+        .add_provider(
+            "anthropic",
+            stub,
+            AuthConfig::ApiKey {
+                key: "test-key".into(),
+                header: Some("x-api-key".into()),
+                prefix: None,
+            },
+            vec![ProviderFormat::Anthropic, ProviderFormat::ChatCompletions],
+        )
+        .build()
+        .expect("router builds");
+    (router, recorded_format)
+}
+
+#[tokio::test]
+async fn anthropic_openai_catalog_format_resolves_to_chat_completions() {
+    let mut catalog = ModelCatalog::empty();
+    catalog.insert(
+        "my-openai-anthropic-model".into(),
+        ModelSpec {
+            model: "claude-haiku-4-5".into(),
+            format: ProviderFormat::ChatCompletions,
+            flavor: ModelFlavor::Chat,
+            display_name: None,
+            parent: None,
+            input_cost_per_mil_tokens: None,
+            output_cost_per_mil_tokens: None,
+            input_cache_read_cost_per_mil_tokens: None,
+            multimodal: None,
+            reasoning: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            supports_streaming: true,
+            extra: Default::default(),
+            available_providers: Default::default(),
+        },
+    );
+    let (router, recorded_format) = anthropic_router(Arc::new(catalog));
+
+    let body = to_body(braintrust_llm_router::serde_json::json!({
+        "model": "my-openai-anthropic-model",
+        "messages": [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "What is 1+1?"}
+        ]
+    }));
+    let (request, _metadata) = router
+        .create_request(
+            body,
+            "my-openai-anthropic-model",
+            ProviderFormat::ChatCompletions,
+        )
+        .await
+        .expect("create request");
+    router
+        .complete(request, &ClientHeaders::default())
+        .await
+        .expect("complete");
+
+    assert_eq!(
+        *recorded_format.lock().unwrap(),
+        Some(ProviderFormat::ChatCompletions),
+        "custom model with catalog_format=openai should use ChatCompletions to hit /chat/completions"
+    );
+}
+
+#[tokio::test]
+async fn anthropic_native_catalog_format_resolves_to_anthropic() {
+    let mut catalog = ModelCatalog::empty();
+    catalog.insert(
+        "claude-haiku-4-5".into(),
+        ModelSpec {
+            model: "claude-haiku-4-5".into(),
+            format: ProviderFormat::Anthropic,
+            flavor: ModelFlavor::Chat,
+            display_name: None,
+            parent: None,
+            input_cost_per_mil_tokens: None,
+            output_cost_per_mil_tokens: None,
+            input_cache_read_cost_per_mil_tokens: None,
+            multimodal: None,
+            reasoning: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            supports_streaming: true,
+            extra: Default::default(),
+            available_providers: Default::default(),
+        },
+    );
+    let (router, recorded_format) = anthropic_router(Arc::new(catalog));
+
+    let body = to_body(braintrust_llm_router::serde_json::json!({
+        "model": "claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "What is 1+1?"}]
+    }));
+    let (request, _metadata) = router
+        .create_request(body, "claude-haiku-4-5", ProviderFormat::ChatCompletions)
+        .await
+        .expect("create request");
+    router
+        .complete(request, &ClientHeaders::default())
+        .await
+        .expect("complete");
+
+    assert_eq!(
+        *recorded_format.lock().unwrap(),
+        Some(ProviderFormat::Anthropic),
+        "standard Anthropic model should still use Anthropic format to hit /v1/messages"
+    );
 }
 
 fn retry_model_catalog() -> Arc<ModelCatalog> {


### PR DESCRIPTION
Route requests to correct endpoint with anthropic if using openai formatted requests. This fixes a bug we saw ~100x yesterday in the gateway.

See internal PR for repro steps and detailed test information