### PR TITLE
translate anonymize-json.ts into rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anonymize"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json 1.0.143",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3450,6 +3458,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
+ "indexmap 2.11.0",
  "itoa",
  "memchr",
  "ryu",

--- a/crates/anonymize/Cargo.toml
+++ b/crates/anonymize/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "anonymize"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "JSON anonymization utilities for Lingua payloads"
+
+[dependencies]
+serde.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }

--- a/crates/anonymize/src/lib.rs
+++ b/crates/anonymize/src/lib.rs
@@ -1,0 +1,363 @@
+use serde_json::{Map, Value};
+use std::collections::{HashMap, HashSet};
+
+const DEFAULT_PRESERVE_KEYS: &[&str] = &["role", "type"];
+const DEFAULT_TOKEN_PREFIX: &str = "anon";
+
+/// Options controlling JSON anonymization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnonymizeOptions {
+    /// When true, anonymize every non-empty string except `metadata.model` paths.
+    pub all_strings: bool,
+    /// Keys whose string values are preserved when `all_strings` is false.
+    pub preserve_keys: HashSet<String>,
+    /// Prefix used when generating replacement tokens.
+    pub token_prefix: String,
+}
+
+impl Default for AnonymizeOptions {
+    fn default() -> Self {
+        Self {
+            all_strings: false,
+            preserve_keys: DEFAULT_PRESERVE_KEYS
+                .iter()
+                .map(|key| (*key).to_string())
+                .collect(),
+            token_prefix: DEFAULT_TOKEN_PREFIX.to_string(),
+        }
+    }
+}
+
+impl AnonymizeOptions {
+    /// Create default options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set whether every string should be anonymized.
+    pub fn with_all_strings(mut self, all_strings: bool) -> Self {
+        self.all_strings = all_strings;
+        self
+    }
+
+    /// Set keys whose string values should be preserved when `all_strings` is false.
+    pub fn with_preserve_keys<I, S>(mut self, preserve_keys: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.preserve_keys = preserve_keys.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set the token prefix.
+    pub fn with_token_prefix<S: Into<String>>(mut self, token_prefix: S) -> Self {
+        self.token_prefix = token_prefix.into();
+        self
+    }
+}
+
+/// Result returned by [`anonymize_json_value`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnonymizeResult {
+    pub value: Value,
+    pub replaced_string_count: usize,
+    pub unique_replacement_count: usize,
+}
+
+/// Identifies what is being passed to an anonymization filter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnonymizeFilterKind {
+    /// An object key. The filter receives the key as a JSON string value.
+    Key,
+    /// A JSON field value.
+    Value,
+}
+
+/// Context passed to an anonymization filter.
+#[derive(Debug, Clone, Copy)]
+pub struct AnonymizeFilterContext<'a> {
+    pub kind: AnonymizeFilterKind,
+    /// Path to the key or value in the original JSON tree.
+    pub path: &'a [String],
+    /// Current object key for value filters. For key filters, this is the key being filtered.
+    pub current_key: Option<&'a str>,
+}
+
+/// Optional extra anonymization filter.
+///
+/// The filter is called for keys and for field values that were not already anonymized by the
+/// built-in token replacement logic. Return `Some(value)` to replace the key or field, or `None` to
+/// keep it unchanged. Key replacements must be JSON strings; non-string key replacements are ignored.
+pub type AnonymizeFilter<'filter> =
+    dyn for<'a> FnMut(AnonymizeFilterContext<'a>, &'a Value) -> Option<Value> + 'filter;
+
+struct Walker<'filter> {
+    all_strings: bool,
+    preserve_keys: HashSet<String>,
+    token_prefix: String,
+    replacements: HashMap<String, String>,
+    next_token: usize,
+    replaced_string_count: usize,
+    filter: Option<&'filter mut AnonymizeFilter<'filter>>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct Scope {
+    within_content: bool,
+    within_metadata: bool,
+    within_context: bool,
+    within_output: bool,
+}
+
+/// Anonymize a JSON value using default options.
+pub fn anonymize_json_value(input: Value) -> AnonymizeResult {
+    anonymize_json_value_with_options(input, AnonymizeOptions::default())
+}
+
+/// Anonymize a JSON value using explicit options.
+pub fn anonymize_json_value_with_options(
+    input: Value,
+    options: AnonymizeOptions,
+) -> AnonymizeResult {
+    anonymize_json_value_with_options_and_filter(input, options, None)
+}
+
+/// Anonymize a JSON value using explicit options and an optional extra filter.
+pub fn anonymize_json_value_with_options_and_filter<'filter>(
+    input: Value,
+    options: AnonymizeOptions,
+    filter: Option<&'filter mut AnonymizeFilter<'filter>>,
+) -> AnonymizeResult {
+    let mut walker = Walker::new(options, filter);
+    let value = walker.walk(input, &mut Vec::new(), None, Scope::default());
+    AnonymizeResult {
+        value,
+        replaced_string_count: walker.replaced_string_count,
+        unique_replacement_count: walker.replacements.len(),
+    }
+}
+
+impl<'filter> Walker<'filter> {
+    fn new(
+        options: AnonymizeOptions,
+        filter: Option<&'filter mut AnonymizeFilter<'filter>>,
+    ) -> Self {
+        Self {
+            all_strings: options.all_strings,
+            preserve_keys: normalize_key_set(options.preserve_keys),
+            token_prefix: options.token_prefix,
+            replacements: HashMap::new(),
+            next_token: 1,
+            replaced_string_count: 0,
+            filter,
+        }
+    }
+
+    fn walk(
+        &mut self,
+        value: Value,
+        path: &mut Vec<String>,
+        current_key: Option<&str>,
+        scope: Scope,
+    ) -> Value {
+        match value {
+            Value::String(value) => self.walk_string(value, path, current_key, scope),
+            Value::Array(items) => Value::Array(
+                items
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, item)| {
+                        path.push(index.to_string());
+                        let anonymized = self.walk(item, path, current_key, scope);
+                        path.pop();
+                        anonymized
+                    })
+                    .collect(),
+            ),
+            Value::Object(object) => self.walk_object(object, path, scope),
+            other => self.filter_value(other, path, current_key),
+        }
+    }
+
+    fn walk_string(
+        &mut self,
+        value: String,
+        path: &[String],
+        current_key: Option<&str>,
+        scope: Scope,
+    ) -> Value {
+        if is_metadata_model_path(path) {
+            return self.filter_value(Value::String(value), path, current_key);
+        }
+
+        let is_tool_arguments = is_arguments_key(current_key);
+        if !self.all_strings
+            && !scope.within_content
+            && !scope.within_metadata
+            && !scope.within_context
+            && !scope.within_output
+            && !is_tool_arguments
+        {
+            return self.filter_value(Value::String(value), path, current_key);
+        }
+
+        if is_tool_arguments {
+            if let Some(parsed_arguments) = try_parse_json_string(&value) {
+                if parsed_arguments.is_array() || parsed_arguments.is_object() {
+                    let mut parsed_path = path.to_vec();
+                    parsed_path.push("<parsed_json>".to_string());
+                    let mut parsed_scope = scope;
+                    parsed_scope.within_content = true;
+                    let anonymized_arguments =
+                        self.walk(parsed_arguments, &mut parsed_path, None, parsed_scope);
+                    return Value::String(
+                        serde_json::to_string(&anonymized_arguments)
+                            .expect("serializing serde_json::Value to a string should not fail"),
+                    );
+                }
+            }
+        }
+
+        let (value, was_anonymized) = self.replace_string(value, current_key);
+        if was_anonymized {
+            Value::String(value)
+        } else {
+            self.filter_value(Value::String(value), path, current_key)
+        }
+    }
+
+    fn walk_object(
+        &mut self,
+        object: Map<String, Value>,
+        path: &mut Vec<String>,
+        scope: Scope,
+    ) -> Value {
+        let mut out = Map::new();
+
+        for (key, nested) in object {
+            let lower_key = key.to_lowercase();
+            let child_scope = Scope {
+                within_content: scope.within_content || lower_key == "content",
+                within_metadata: scope.within_metadata || lower_key.starts_with("metadata"),
+                within_context: scope.within_context || lower_key == "context",
+                within_output: scope.within_output || lower_key == "output",
+            };
+
+            // Remove metadata.prompt entirely: prompt key names/shape can leak sensitive context.
+            if child_scope.within_metadata && lower_key == "prompt" {
+                continue;
+            }
+
+            path.push(key.clone());
+            let filtered_key = self.filter_key(key.clone(), path);
+            let anonymized = self.walk(nested, path, Some(&key), child_scope);
+            path.pop();
+            out.insert(filtered_key, anonymized);
+        }
+
+        Value::Object(out)
+    }
+
+    fn replace_string(&mut self, value: String, current_key: Option<&str>) -> (String, bool) {
+        if value.is_empty() {
+            return (value, false);
+        }
+
+        if !self.all_strings {
+            if let Some(current_key) = current_key {
+                if self.preserve_keys.contains(&current_key.to_lowercase()) {
+                    return (value, false);
+                }
+            }
+        }
+
+        if let Some(token) = self.replacements.get(&value) {
+            self.replaced_string_count += 1;
+            return (token.clone(), true);
+        }
+
+        let token = format!("{}_{}", self.token_prefix, self.next_token);
+        self.next_token += 1;
+        self.replacements.insert(value, token.clone());
+        self.replaced_string_count += 1;
+        (token, true)
+    }
+
+    fn filter_key(&mut self, key: String, path: &[String]) -> String {
+        if is_generated_token(&key, &self.token_prefix) {
+            return key;
+        }
+
+        let key_value = Value::String(key.clone());
+        match self.apply_filter(
+            AnonymizeFilterContext {
+                kind: AnonymizeFilterKind::Key,
+                path,
+                current_key: Some(&key),
+            },
+            &key_value,
+        ) {
+            Some(Value::String(filtered_key)) => filtered_key,
+            _ => key,
+        }
+    }
+
+    fn filter_value(&mut self, value: Value, path: &[String], current_key: Option<&str>) -> Value {
+        if value
+            .as_str()
+            .is_some_and(|value| is_generated_token(value, &self.token_prefix))
+        {
+            return value;
+        }
+
+        self.apply_filter(
+            AnonymizeFilterContext {
+                kind: AnonymizeFilterKind::Value,
+                path,
+                current_key,
+            },
+            &value,
+        )
+        .unwrap_or(value)
+    }
+
+    fn apply_filter(
+        &mut self,
+        context: AnonymizeFilterContext<'_>,
+        value: &Value,
+    ) -> Option<Value> {
+        self.filter
+            .as_mut()
+            .and_then(|filter| filter(context, value))
+    }
+}
+
+fn is_metadata_model_path(path: &[String]) -> bool {
+    let n = path.len();
+    n >= 2
+        && path[n - 2].eq_ignore_ascii_case("metadata")
+        && path[n - 1].eq_ignore_ascii_case("model")
+}
+
+fn normalize_key_set(keys: HashSet<String>) -> HashSet<String> {
+    keys.into_iter().map(|key| key.to_lowercase()).collect()
+}
+
+fn is_arguments_key(current_key: Option<&str>) -> bool {
+    current_key.is_some_and(|key| key.eq_ignore_ascii_case("arguments"))
+}
+
+fn is_generated_token(value: &str, token_prefix: &str) -> bool {
+    let Some(suffix) = value.strip_prefix(token_prefix) else {
+        return false;
+    };
+    let Some(number) = suffix.strip_prefix('_') else {
+        return false;
+    };
+    !number.is_empty() && number.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn try_parse_json_string(value: &str) -> Option<Value> {
+    serde_json::from_str(value).ok()
+}

--- a/crates/anonymize/tests/anonymize_json.rs
+++ b/crates/anonymize/tests/anonymize_json.rs
@@ -1,0 +1,353 @@
+use anonymize::{
+    anonymize_json_value, anonymize_json_value_with_options,
+    anonymize_json_value_with_options_and_filter, AnonymizeFilterContext, AnonymizeFilterKind,
+    AnonymizeOptions,
+};
+use serde_json::json;
+
+#[test]
+fn anonymizes_content_and_metadata_strings_by_default() {
+    let input = json!({
+        "input": [
+            { "role": "user", "content": "hello world", "id": "user-1" },
+            {
+                "role": "assistant",
+                "content": [{ "type": "text", "text": "hello world" }],
+                "finish_reason": "stop"
+            }
+        ],
+        "metadata": "leave me alone"
+    });
+
+    let result = anonymize_json_value(input);
+    assert_eq!(
+        result.value,
+        json!({
+            "input": [
+                { "role": "user", "content": "anon_1", "id": "user-1" },
+                {
+                    "role": "assistant",
+                    "content": [{ "type": "text", "text": "anon_1" }],
+                    "finish_reason": "stop"
+                }
+            ],
+            "metadata": "anon_2"
+        })
+    );
+    assert_eq!(result.replaced_string_count, 3);
+    assert_eq!(result.unique_replacement_count, 2);
+}
+
+#[test]
+fn anonymizes_all_strings_when_all_strings_is_enabled() {
+    let input = json!({
+        "role": "user",
+        "content": "hello world",
+        "type": "text"
+    });
+
+    let result = anonymize_json_value_with_options(
+        input,
+        AnonymizeOptions::default().with_all_strings(true),
+    );
+    assert_eq!(
+        result.value,
+        json!({
+            "role": "anon_1",
+            "content": "anon_2",
+            "type": "anon_3"
+        })
+    );
+    assert_eq!(result.replaced_string_count, 3);
+    assert_eq!(result.unique_replacement_count, 3);
+}
+
+#[test]
+fn preserves_configured_keys_inside_content() {
+    let input = json!({
+        "content": [{ "toolName": "bash", "text": "run ls", "type": "text" }]
+    });
+
+    let result = anonymize_json_value_with_options(
+        input,
+        AnonymizeOptions::default().with_preserve_keys(["type", "toolName"]),
+    );
+    assert_eq!(
+        result.value,
+        json!({
+            "content": [{ "toolName": "bash", "text": "anon_1", "type": "text" }]
+        })
+    );
+    assert_eq!(result.replaced_string_count, 1);
+    assert_eq!(result.unique_replacement_count, 1);
+}
+
+#[test]
+fn anonymizes_all_metadata_strings() {
+    let input = json!({
+        "metadata": {
+            "model": "gpt-5.1-2025-11-13",
+            "trace_id": "trace-1",
+            "route": "base",
+            "tool_definitions": [
+                {
+                    "name": "fetch_weather",
+                    "description": "Get weather by city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": { "type": "string", "description": "City name" }
+                        }
+                    }
+                }
+            ]
+        }
+    });
+
+    let result = anonymize_json_value(input);
+    assert_eq!(
+        result.value,
+        json!({
+            "metadata": {
+                "model": "gpt-5.1-2025-11-13",
+                "trace_id": "anon_1",
+                "route": "anon_2",
+                "tool_definitions": [
+                    {
+                        "name": "anon_3",
+                        "description": "anon_4",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "city": { "type": "string", "description": "anon_5" }
+                            }
+                        }
+                    }
+                ]
+            }
+        })
+    );
+}
+
+#[test]
+fn anonymizes_metadata_variants_like_metadata2() {
+    let input = json!({
+        "metadata2": {
+            "chatChannel": "SOLO_TOLAN:usr_abc",
+            "chatID": "cht_123",
+            "isFirstMessage": false
+        }
+    });
+
+    let result = anonymize_json_value(input);
+    assert_eq!(
+        result.value,
+        json!({
+            "metadata2": {
+                "chatChannel": "anon_1",
+                "chatID": "anon_2",
+                "isFirstMessage": false
+            }
+        })
+    );
+}
+
+#[test]
+fn removes_metadata_prompt_subtree_entirely() {
+    let input = json!({
+        "metadata": {
+            "prompt": {
+                "id": "prm_123",
+                "key": "chat",
+                "variables": {
+                    "activeChatType": { "CONVERSATION_DEFAULT": true },
+                    "medium": "TEXT"
+                }
+            },
+            "route": "base"
+        }
+    });
+
+    let result = anonymize_json_value(input);
+    assert_eq!(
+        result.value,
+        json!({
+            "metadata": {
+                "route": "anon_1"
+            }
+        })
+    );
+}
+
+#[test]
+fn anonymizes_strings_under_context_and_output() {
+    let input = json!({
+        "context": {
+            "caller_filename": "file:///tmp/project/src/main.ts",
+            "caller_functionname": "runJob",
+            "caller_lineno": 42
+        },
+        "output": "Final assistant response text",
+        "model": "gpt-5.1-2025-11-13"
+    });
+
+    let result = anonymize_json_value(input);
+    assert_eq!(
+        result.value,
+        json!({
+            "context": {
+                "caller_filename": "anon_1",
+                "caller_functionname": "anon_2",
+                "caller_lineno": 42
+            },
+            "output": "anon_3",
+            "model": "gpt-5.1-2025-11-13"
+        })
+    );
+}
+
+#[test]
+fn anonymizes_json_encoded_tool_call_arguments_strings() {
+    let input = json!({
+        "input": [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "toolu_123",
+                        "type": "function",
+                        "function": {
+                            "name": "CreateTodoList",
+                            "arguments": "{\"items\":[\"task_alpha\",\"task_beta\"],\"status\":\"queued\"}"
+                        }
+                    }
+                ]
+            }
+        ]
+    });
+
+    let result = anonymize_json_value(input);
+    assert_eq!(
+        result.value,
+        json!({
+            "input": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_123",
+                            "type": "function",
+                            "function": {
+                                "name": "CreateTodoList",
+                                "arguments": "{\"items\":[\"anon_1\",\"anon_2\"],\"status\":\"anon_3\"}"
+                            }
+                        }
+                    ]
+                }
+            ]
+        })
+    );
+}
+
+#[test]
+fn anonymizes_non_json_tool_call_arguments_strings_as_plain_strings() {
+    let input = json!({
+        "input": [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "toolu_123",
+                        "type": "function",
+                        "function": {
+                            "name": "CreateTodoList",
+                            "arguments": "not-json-content"
+                        }
+                    }
+                ]
+            }
+        ]
+    });
+
+    let result = anonymize_json_value(input);
+    assert_eq!(
+        result.value,
+        json!({
+            "input": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_123",
+                            "type": "function",
+                            "function": {
+                                "name": "CreateTodoList",
+                                "arguments": "anon_1"
+                            }
+                        }
+                    ]
+                }
+            ]
+        })
+    );
+}
+
+#[test]
+fn filter_sees_every_unanonymized_key_and_field_in_json() {
+    let input = json!({
+        "userEmail": "person@example.com",
+        "count": 42,
+        "enabled": true,
+        "content": "sensitive content",
+        "items": [
+            { "name": "alpha", "qty": 2 },
+            { "name": "beta", "price": 12.5 }
+        ],
+        "details": {
+            "nullable": null,
+            "tags": ["x", "y"]
+        },
+        "output": "final response",
+        "role": "user"
+    });
+
+    let mut next = 1;
+    let mut filter = |context: AnonymizeFilterContext<'_>, _value: &serde_json::Value| {
+        let replacement = json!(format!("custom_{next}"));
+        next += 1;
+
+        match context.kind {
+            AnonymizeFilterKind::Key | AnonymizeFilterKind::Value => Some(replacement),
+        }
+    };
+
+    let result = anonymize_json_value_with_options_and_filter(
+        input,
+        AnonymizeOptions::default(),
+        Some(&mut filter),
+    );
+
+    assert_eq!(
+        result.value,
+        json!({
+            "custom_1": "custom_2",
+            "custom_3": "custom_4",
+            "custom_5": "custom_6",
+            "custom_7": "anon_1",
+            "custom_8": [
+                { "custom_9": "custom_10", "custom_11": "custom_12" },
+                { "custom_13": "custom_14", "custom_15": "custom_16" }
+            ],
+            "custom_17": {
+                "custom_18": "custom_19",
+                "custom_20": ["custom_21", "custom_22"]
+            },
+            "custom_23": "anon_2",
+            "custom_24": "custom_25"
+        })
+    );
+}


### PR DESCRIPTION
This was relatively straightforward for AI to translate, the code looks
basically the same. This allows callers to anonymize payloads for debugging use
cases.

This does add one extra thing - it allows passing a filter function that sees
every key/value that is NOT already anonymized by this class. This allows
layering other anonymizer functions on top of this class.