### PR TITLE
google fixes

### DIFF
--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -261,6 +261,46 @@
       ]
     },
     {
+      "testCase": "googleToolCallThoughtSignatureReplayParam",
+      "source": "ChatCompletions",
+      "target": "Responses",
+      "fields": [
+        { "pattern": "messages[*].content[*].encrypted_content", "reason": "ChatCompletions reasoning_signature is an extension used for Google thoughtSignature replay; Responses requests cannot carry it on function_call items" }
+      ]
+    },
+    {
+      "testCase": "googleToolCallThoughtSignatureReplayParam",
+      "source": "ChatCompletions",
+      "target": "Anthropic",
+      "fields": [
+        { "pattern": "messages[*].content[*].encrypted_content", "reason": "ChatCompletions reasoning_signature is an extension used for Google thoughtSignature replay; Anthropic tool_use blocks cannot carry it" }
+      ]
+    },
+    {
+      "testCase": "googleToolCallThoughtSignatureReplayParam",
+      "source": "ChatCompletions",
+      "target": "Bedrock Anthropic",
+      "fields": [
+        { "pattern": "messages[*].content[*].encrypted_content", "reason": "ChatCompletions reasoning_signature is an extension used for Google thoughtSignature replay; Bedrock Anthropic tool_use blocks cannot carry it" }
+      ]
+    },
+    {
+      "testCase": "googleToolCallThoughtSignatureReplayParam",
+      "source": "ChatCompletions",
+      "target": "Vertex Anthropic",
+      "fields": [
+        { "pattern": "messages[*].content[*].encrypted_content", "reason": "ChatCompletions reasoning_signature is an extension used for Google thoughtSignature replay; Vertex Anthropic tool_use blocks cannot carry it" }
+      ]
+    },
+    {
+      "testCase": "googleToolCallThoughtSignatureReplayParam",
+      "source": "Google",
+      "target": "Google",
+      "fields": [
+        { "pattern": "messages[*].content[*].tool_call_id", "reason": "Google omits synthetic call IDs with the call_ prefix on export, then regenerates positional synthetic IDs on re-parse" }
+      ]
+    },
+    {
       "testCase": "imageUrlMimeTypeFallbackParam",
       "source": "*",
       "target": "Bedrock",

--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -293,14 +293,6 @@
       ]
     },
     {
-      "testCase": "googleToolCallThoughtSignatureReplayParam",
-      "source": "Google",
-      "target": "Google",
-      "fields": [
-        { "pattern": "messages[*].content[*].tool_call_id", "reason": "Google omits synthetic call IDs with the call_ prefix on export, then regenerates positional synthetic IDs on re-parse" }
-      ]
-    },
-    {
       "testCase": "imageUrlMimeTypeFallbackParam",
       "source": "*",
       "target": "Bedrock",

--- a/crates/coverage-report/src/responses_expected_differences.json
+++ b/crates/coverage-report/src/responses_expected_differences.json
@@ -389,14 +389,6 @@
       ]
     },
     {
-      "testCase": "toolChoiceRequiredWithReasoningParam",
-      "source": "Google",
-      "target": "ChatCompletions",
-      "errors": [
-        { "pattern": "mixes signed and unsigned tool/reasoning parts", "reason": "ChatCompletions has one top-level reasoning_signature and cannot represent Google responses that mix signed reasoning with unsigned tool calls without smearing the signature onto replayed tool calls" }
-      ]
-    },
-    {
       "testCase": "responseModalitiesAudioParam",
       "source": "Google",
       "target": "Anthropic",

--- a/crates/coverage-report/src/responses_expected_differences.json
+++ b/crates/coverage-report/src/responses_expected_differences.json
@@ -389,6 +389,14 @@
       ]
     },
     {
+      "testCase": "toolChoiceRequiredWithReasoningParam",
+      "source": "Google",
+      "target": "ChatCompletions",
+      "errors": [
+        { "pattern": "mixes signed and unsigned tool/reasoning parts", "reason": "ChatCompletions has one top-level reasoning_signature and cannot represent Google responses that mix signed reasoning with unsigned tool calls without smearing the signature onto replayed tool calls" }
+      ]
+    },
+    {
       "testCase": "responseModalitiesAudioParam",
       "source": "Google",
       "target": "Anthropic",

--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -98,6 +98,26 @@ fn input_item_output_to_output(output: Option<openai::Output>) -> Option<openai:
     })
 }
 
+fn merge_reasoning_signature(
+    current: &mut Option<String>,
+    next: &Option<String>,
+) -> Result<(), ConvertError> {
+    let Some(next) = next else {
+        return Ok(());
+    };
+
+    match current {
+        Some(current) if current != next => Err(ConvertError::ContentConversionFailed {
+            reason: "OpenAI Chat Completions response messages only support one reasoning_signature, but the assistant content contains multiple distinct encrypted tool/reasoning signatures".to_string(),
+        }),
+        Some(_) => Ok(()),
+        None => {
+            *current = Some(next.clone());
+            Ok(())
+        }
+    }
+}
+
 /// Extended ChatCompletionRequest/ResponseMessage with reasoning support.
 ///
 /// The official OpenAI Chat Completions API doesn't include a `reasoning` field on messages.`                                         
@@ -3761,40 +3781,33 @@ impl TryFromLLM<&Message> for ChatCompletionResponseMessageExt {
                             } = part
                             {
                                 reasonings.push(text.clone());
-                                // Take the first signature if multiple reasoning blocks exist
-                                if signature.is_none() {
-                                    signature = encrypted_content.clone();
-                                }
+                                merge_reasoning_signature(&mut signature, encrypted_content)?;
                             }
                         }
 
                         // Extract tool calls from parts
-                        let tool_calls: Vec<openai::ToolCall> = parts
-                            .iter()
-                            .filter_map(|part| match part {
-                                AssistantContentPart::ToolCall {
-                                    tool_call_id,
-                                    tool_name,
-                                    arguments,
-                                    encrypted_content,
-                                    ..
-                                } => {
-                                    if signature.is_none() {
-                                        signature = encrypted_content.clone();
-                                    }
-                                    Some(openai::ToolCall {
-                                        id: tool_call_id.clone(),
-                                        tool_call_type: openai::FluffyType::Function,
-                                        function: Some(openai::PurpleFunction {
-                                            name: tool_name.clone(),
-                                            arguments: arguments.to_string(),
-                                        }),
-                                        custom: None,
-                                    })
-                                }
-                                _ => None,
-                            })
-                            .collect();
+                        let mut tool_calls: Vec<openai::ToolCall> = Vec::new();
+                        for part in parts {
+                            if let AssistantContentPart::ToolCall {
+                                tool_call_id,
+                                tool_name,
+                                arguments,
+                                encrypted_content,
+                                ..
+                            } = part
+                            {
+                                merge_reasoning_signature(&mut signature, encrypted_content)?;
+                                tool_calls.push(openai::ToolCall {
+                                    id: tool_call_id.clone(),
+                                    tool_call_type: openai::FluffyType::Function,
+                                    function: Some(openai::PurpleFunction {
+                                        name: tool_name.clone(),
+                                        arguments: arguments.to_string(),
+                                    }),
+                                    custom: None,
+                                });
+                            }
+                        }
 
                         let content_text = if texts.is_empty() {
                             None
@@ -3941,14 +3954,49 @@ mod tests {
             Some("dGhvdWdodF9zaWduYXR1cmVfMTIz")
         );
         assert_eq!(
-            converted
-                .base
-                .tool_calls
-                .as_ref()
-                .and_then(|tool_calls| tool_calls.first())
-                .map(|tool_call| tool_call.id.as_str()),
-            Some("call_123")
+            converted.base.tool_calls,
+            Some(vec![openai::ToolCall {
+                id: "call_123".to_string(),
+                tool_call_type: openai::FluffyType::Function,
+                function: Some(openai::PurpleFunction {
+                    name: "list_collections".to_string(),
+                    arguments: r#"{"database":"mydb"}"#.to_string(),
+                }),
+                custom: None,
+            }])
         );
+    }
+
+    #[test]
+    fn response_message_rejects_distinct_tool_call_signatures() {
+        let message = Message::Assistant {
+            content: AssistantContent::Array(vec![
+                AssistantContentPart::ToolCall {
+                    tool_call_id: "call_1".to_string(),
+                    tool_name: "first_tool".to_string(),
+                    arguments: ToolCallArguments::from("{}".to_string()),
+                    encrypted_content: Some("signature_one".to_string()),
+                    provider_options: None,
+                    provider_executed: None,
+                },
+                AssistantContentPart::ToolCall {
+                    tool_call_id: "call_2".to_string(),
+                    tool_name: "second_tool".to_string(),
+                    arguments: ToolCallArguments::from("{}".to_string()),
+                    encrypted_content: Some("signature_two".to_string()),
+                    provider_options: None,
+                    provider_executed: None,
+                },
+            ]),
+            id: None,
+        };
+
+        let error = <ChatCompletionResponseMessageExt as TryFromLLM<&Message>>::try_from(&message)
+            .expect_err("distinct per-call signatures should not be collapsed");
+
+        assert!(error
+            .to_string()
+            .contains("multiple distinct encrypted tool/reasoning signatures"));
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -99,22 +99,38 @@ fn input_item_output_to_output(output: Option<openai::Output>) -> Option<openai:
 }
 
 fn merge_reasoning_signature(
-    current: &mut Option<String>,
+    current: &mut Option<Option<String>>,
     next: &Option<String>,
 ) -> Result<(), ConvertError> {
-    let Some(next) = next else {
-        return Ok(());
-    };
-
-    match current {
-        Some(current) if current != next => Err(ConvertError::ContentConversionFailed {
-            reason: "OpenAI Chat Completions response messages only support one reasoning_signature, but the assistant content contains multiple distinct encrypted tool/reasoning signatures".to_string(),
-        }),
-        Some(_) => Ok(()),
-        None => {
-            *current = Some(next.clone());
+    match (current.as_ref(), next) {
+        (Some(Some(current)), Some(next)) if current != next => {
+            Err(ConvertError::ContentConversionFailed {
+                reason: "OpenAI Chat Completions response messages only support one reasoning_signature, but the assistant content contains multiple distinct encrypted tool/reasoning signatures".to_string(),
+            })
+        }
+        (Some(Some(_)), None) | (Some(None), Some(_)) => {
+            Err(ConvertError::ContentConversionFailed {
+                reason: "OpenAI Chat Completions response messages only support one reasoning_signature, but the assistant content mixes signed and unsigned tool/reasoning parts".to_string(),
+            })
+        }
+        (Some(_), _) => Ok(()),
+        (None, Some(next)) => {
+            *current = Some(Some(next.clone()));
             Ok(())
         }
+        (None, None) => {
+            *current = Some(None);
+            Ok(())
+        }
+    }
+}
+
+fn reasoning_signature_value(
+    signature: Option<Option<String>>,
+) -> Result<Option<String>, ConvertError> {
+    match signature {
+        Some(Some(signature)) => Ok(Some(signature)),
+        Some(None) | None => Ok(None),
     }
 }
 
@@ -3773,7 +3789,7 @@ impl TryFromLLM<&Message> for ChatCompletionResponseMessageExt {
 
                         // Extract reasoning from parts and concatenate, also capture signature
                         let mut reasonings: Vec<String> = Vec::new();
-                        let mut signature: Option<String> = None;
+                        let mut signature: Option<Option<String>> = None;
                         for part in parts {
                             if let AssistantContentPart::Reasoning {
                                 text,
@@ -3827,7 +3843,12 @@ impl TryFromLLM<&Message> for ChatCompletionResponseMessageExt {
                             Some(tool_calls)
                         };
 
-                        (content_text, tool_calls_option, reasoning, signature)
+                        (
+                            content_text,
+                            tool_calls_option,
+                            reasoning,
+                            reasoning_signature_value(signature)?,
+                        )
                     }
                 };
 
@@ -3997,6 +4018,38 @@ mod tests {
         assert!(error
             .to_string()
             .contains("multiple distinct encrypted tool/reasoning signatures"));
+    }
+
+    #[test]
+    fn response_message_rejects_mixed_signed_and_unsigned_tool_calls() {
+        let message = Message::Assistant {
+            content: AssistantContent::Array(vec![
+                AssistantContentPart::ToolCall {
+                    tool_call_id: "call_1".to_string(),
+                    tool_name: "first_tool".to_string(),
+                    arguments: ToolCallArguments::from("{}".to_string()),
+                    encrypted_content: Some("signature_one".to_string()),
+                    provider_options: None,
+                    provider_executed: None,
+                },
+                AssistantContentPart::ToolCall {
+                    tool_call_id: "call_2".to_string(),
+                    tool_name: "second_tool".to_string(),
+                    arguments: ToolCallArguments::from("{}".to_string()),
+                    encrypted_content: None,
+                    provider_options: None,
+                    provider_executed: None,
+                },
+            ]),
+            id: None,
+        };
+
+        let error = <ChatCompletionResponseMessageExt as TryFromLLM<&Message>>::try_from(&message)
+            .expect_err("mixed signed and unsigned tool calls should not be collapsed");
+
+        assert!(error
+            .to_string()
+            .contains("mixes signed and unsigned tool/reasoning parts"));
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -99,38 +99,22 @@ fn input_item_output_to_output(output: Option<openai::Output>) -> Option<openai:
 }
 
 fn merge_reasoning_signature(
-    current: &mut Option<Option<String>>,
+    current: &mut Option<String>,
     next: &Option<String>,
 ) -> Result<(), ConvertError> {
-    match (current.as_ref(), next) {
-        (Some(Some(current)), Some(next)) if current != next => {
-            Err(ConvertError::ContentConversionFailed {
-                reason: "OpenAI Chat Completions response messages only support one reasoning_signature, but the assistant content contains multiple distinct encrypted tool/reasoning signatures".to_string(),
-            })
-        }
-        (Some(Some(_)), None) | (Some(None), Some(_)) => {
-            Err(ConvertError::ContentConversionFailed {
-                reason: "OpenAI Chat Completions response messages only support one reasoning_signature, but the assistant content mixes signed and unsigned tool/reasoning parts".to_string(),
-            })
-        }
-        (Some(_), _) => Ok(()),
-        (None, Some(next)) => {
-            *current = Some(Some(next.clone()));
-            Ok(())
-        }
-        (None, None) => {
-            *current = Some(None);
-            Ok(())
-        }
-    }
-}
+    let Some(next) = next else {
+        return Ok(());
+    };
 
-fn reasoning_signature_value(
-    signature: Option<Option<String>>,
-) -> Result<Option<String>, ConvertError> {
-    match signature {
-        Some(Some(signature)) => Ok(Some(signature)),
-        Some(None) | None => Ok(None),
+    match current {
+        Some(current) if current != next => Err(ConvertError::ContentConversionFailed {
+            reason: "OpenAI Chat Completions response messages only support one reasoning_signature, but the assistant content contains multiple distinct encrypted tool/reasoning signatures".to_string(),
+        }),
+        Some(_) => Ok(()),
+        None => {
+            *current = Some(next.clone());
+            Ok(())
+        }
     }
 }
 
@@ -3789,7 +3773,7 @@ impl TryFromLLM<&Message> for ChatCompletionResponseMessageExt {
 
                         // Extract reasoning from parts and concatenate, also capture signature
                         let mut reasonings: Vec<String> = Vec::new();
-                        let mut signature: Option<Option<String>> = None;
+                        let mut signature: Option<String> = None;
                         for part in parts {
                             if let AssistantContentPart::Reasoning {
                                 text,
@@ -3843,12 +3827,7 @@ impl TryFromLLM<&Message> for ChatCompletionResponseMessageExt {
                             Some(tool_calls)
                         };
 
-                        (
-                            content_text,
-                            tool_calls_option,
-                            reasoning,
-                            reasoning_signature_value(signature)?,
-                        )
+                        (content_text, tool_calls_option, reasoning, signature)
                     }
                 };
 
@@ -4018,38 +3997,6 @@ mod tests {
         assert!(error
             .to_string()
             .contains("multiple distinct encrypted tool/reasoning signatures"));
-    }
-
-    #[test]
-    fn response_message_rejects_mixed_signed_and_unsigned_tool_calls() {
-        let message = Message::Assistant {
-            content: AssistantContent::Array(vec![
-                AssistantContentPart::ToolCall {
-                    tool_call_id: "call_1".to_string(),
-                    tool_name: "first_tool".to_string(),
-                    arguments: ToolCallArguments::from("{}".to_string()),
-                    encrypted_content: Some("signature_one".to_string()),
-                    provider_options: None,
-                    provider_executed: None,
-                },
-                AssistantContentPart::ToolCall {
-                    tool_call_id: "call_2".to_string(),
-                    tool_name: "second_tool".to_string(),
-                    arguments: ToolCallArguments::from("{}".to_string()),
-                    encrypted_content: None,
-                    provider_options: None,
-                    provider_executed: None,
-                },
-            ]),
-            id: None,
-        };
-
-        let error = <ChatCompletionResponseMessageExt as TryFromLLM<&Message>>::try_from(&message)
-            .expect_err("mixed signed and unsigned tool calls should not be collapsed");
-
-        assert!(error
-            .to_string()
-            .contains("mixes signed and unsigned tool/reasoning parts"));
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -3776,16 +3776,22 @@ impl TryFromLLM<&Message> for ChatCompletionResponseMessageExt {
                                     tool_call_id,
                                     tool_name,
                                     arguments,
+                                    encrypted_content,
                                     ..
-                                } => Some(openai::ToolCall {
-                                    id: tool_call_id.clone(),
-                                    tool_call_type: openai::FluffyType::Function,
-                                    function: Some(openai::PurpleFunction {
-                                        name: tool_name.clone(),
-                                        arguments: arguments.to_string(),
-                                    }),
-                                    custom: None,
-                                }),
+                                } => {
+                                    if signature.is_none() {
+                                        signature = encrypted_content.clone();
+                                    }
+                                    Some(openai::ToolCall {
+                                        id: tool_call_id.clone(),
+                                        tool_call_type: openai::FluffyType::Function,
+                                        function: Some(openai::PurpleFunction {
+                                            name: tool_name.clone(),
+                                            arguments: arguments.to_string(),
+                                        }),
+                                        custom: None,
+                                    })
+                                }
                                 _ => None,
                             })
                             .collect();
@@ -3910,6 +3916,39 @@ mod tests {
             .expect("tool call should be present");
 
         assert_eq!(tool_call.as_deref(), Some("thought_signature_123"));
+    }
+
+    #[test]
+    fn response_message_tool_call_signature_becomes_reasoning_signature() {
+        let message = Message::Assistant {
+            content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
+                tool_call_id: "call_123".to_string(),
+                tool_name: "list_collections".to_string(),
+                arguments: ToolCallArguments::from(r#"{"database":"mydb"}"#.to_string()),
+                encrypted_content: Some("dGhvdWdodF9zaWduYXR1cmVfMTIz".to_string()),
+                provider_options: None,
+                provider_executed: None,
+            }]),
+            id: None,
+        };
+
+        let converted =
+            <ChatCompletionResponseMessageExt as TryFromLLM<&Message>>::try_from(&message)
+                .expect("message should convert");
+
+        assert_eq!(
+            converted.reasoning_signature.as_deref(),
+            Some("dGhvdWdodF9zaWduYXR1cmVfMTIz")
+        );
+        assert_eq!(
+            converted
+                .base
+                .tool_calls
+                .as_ref()
+                .and_then(|tool_calls| tool_calls.first())
+                .map(|tool_call| tool_call.id.as_str()),
+            Some("call_123")
+        );
     }
 
     #[test]

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -1178,6 +1178,108 @@ export const paramsCases: TestCaseCollection = {
     bedrock: null,
   },
 
+  googleToolCallThoughtSignatureReplayParam: {
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [
+        {
+          role: "user",
+          content: "List the collections in the mydb database.",
+        },
+        {
+          role: "assistant",
+          content: null,
+          reasoning_signature: "dGhvdWdodF9zaWduYXR1cmVfMTIz",
+          tool_calls: [
+            {
+              id: "call_123",
+              type: "function",
+              function: {
+                name: "list_collections",
+                arguments: JSON.stringify({ database: "mydb" }),
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_123",
+          content: JSON.stringify(["movies", "users"]),
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "list_collections",
+            description: "List the collections in a MongoDB database.",
+            parameters: {
+              type: "object",
+              properties: {
+                database: { type: "string" },
+              },
+              required: ["database"],
+            },
+          },
+        },
+      ],
+      tool_choice: "auto",
+    },
+    responses: null,
+    anthropic: null,
+    google: {
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "List the collections in the mydb database." }],
+        },
+        {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                id: "call_123",
+                name: "list_collections",
+                args: { database: "mydb" },
+              },
+              thoughtSignature: "dGhvdWdodF9zaWduYXR1cmVfMTIz",
+            },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                id: "call_123",
+                name: "list_collections",
+                response: { output: ["movies", "users"] },
+              },
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: "list_collections",
+              description: "List the collections in a MongoDB database.",
+              parameters: {
+                type: Type.OBJECT,
+                properties: {
+                  database: { type: Type.STRING },
+                },
+                required: ["database"],
+              },
+            },
+          ],
+        },
+      ],
+    },
+    bedrock: null,
+  },
+
   parallelToolCallsDisabledParam: {
     "chat-completions": {
       model: OPENAI_CHAT_COMPLETIONS_MODEL,

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -1238,7 +1238,6 @@ export const paramsCases: TestCaseCollection = {
           parts: [
             {
               functionCall: {
-                id: "call_123",
                 name: "list_collections",
                 args: { database: "mydb" },
               },
@@ -1251,7 +1250,6 @@ export const paramsCases: TestCaseCollection = {
           parts: [
             {
               functionResponse: {
-                id: "call_123",
                 name: "list_collections",
                 response: { output: ["movies", "users"] },
               },

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -4643,6 +4643,30 @@ data: [DONE]
 "
 `;
 
+exports[`streaming: chat-completions → bedrock > googleToolCallThoughtSignatureReplayParam > streaming 1`] = `
+"data: {"choices":[],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"The **","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"mydb** database contains the","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" following collections:\\n\\n1. **movies","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"**","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"\\n2. **users**","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[],"object":"chat.completion.chunk","usage":{"completion_tokens":25,"prompt_tokens":639,"total_tokens":664}}
+
+data: [DONE]
+
+"
+`;
+
 exports[`streaming: chat-completions → bedrock > instructionsParam > streaming 1`] = `
 "data: {"choices":[],"object":"chat.completion.chunk"}
 

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -4646,13 +4646,15 @@ data: [DONE]
 exports[`streaming: chat-completions → bedrock > googleToolCallThoughtSignatureReplayParam > streaming 1`] = `
 "data: {"choices":[],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"The **","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"The","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"mydb** database contains the","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" collections","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" following collections:\\n\\n1. **movies","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" in the **","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"**","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"mydb** database are:","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"\\n\\n1. **movies**","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
 data: {"choices":[{"delta":{"content":"\\n2. **users**","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -7032,6 +7032,93 @@ exports[`chat-completions → anthropic > functionToolsWithReasoningEffortParam 
 }
 `;
 
+exports[`chat-completions → anthropic > googleToolCallThoughtSignatureReplayParam > request 1`] = `
+{
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "List the collections in the mydb database.",
+      "role": "user",
+    },
+    {
+      "content": [
+        {
+          "id": "call_123",
+          "input": {
+            "database": "mydb",
+          },
+          "name": "list_collections",
+          "type": "tool_use",
+        },
+      ],
+      "role": "assistant",
+    },
+    {
+      "content": [
+        {
+          "content": "["movies","users"]",
+          "tool_use_id": "call_123",
+          "type": "tool_result",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "model": "claude-sonnet-4-5-20250929",
+  "tool_choice": {
+    "type": "auto",
+  },
+  "tools": [
+    {
+      "description": "List the collections in a MongoDB database.",
+      "input_schema": {
+        "properties": {
+          "database": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "database",
+        ],
+        "type": "object",
+      },
+      "name": "list_collections",
+    },
+  ],
+}
+`;
+
+exports[`chat-completions → anthropic > googleToolCallThoughtSignatureReplayParam > response 1`] = `
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "The collections in the **mydb** database are:
+
+1. **movies**
+2. **users**",
+        "role": "assistant",
+      },
+    },
+  ],
+  "created": 0,
+  "id": "chatcmpl-015LQHcNzXwfqPkWxys7rTWo",
+  "model": "claude-sonnet-4-5-20250929",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 26,
+    "prompt_tokens": 639,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+    },
+    "total_tokens": 665,
+  },
+}
+`;
+
 exports[`chat-completions → anthropic > imageUrlMimeTypeFallbackParam > request 1`] = `
 {
   "max_tokens": 4096,
@@ -9692,6 +9779,105 @@ exports[`chat-completions → bedrock > functionToolsWithReasoningEffortParam > 
       "cached_tokens": 0,
     },
     "total_tokens": 690,
+  },
+}
+`;
+
+exports[`chat-completions → bedrock > googleToolCallThoughtSignatureReplayParam > request 1`] = `
+{
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "List the collections in the mydb database.",
+        },
+      ],
+      "role": "user",
+    },
+    {
+      "content": [
+        {
+          "toolUse": {
+            "input": {
+              "database": "mydb",
+            },
+            "name": "list_collections",
+            "toolUseId": "call_123",
+          },
+        },
+      ],
+      "role": "assistant",
+    },
+    {
+      "content": [
+        {
+          "toolResult": {
+            "content": [
+              {
+                "text": "["movies","users"]",
+              },
+            ],
+            "toolUseId": "call_123",
+          },
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "modelId": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "toolConfig": {
+    "tools": [
+      {
+        "toolSpec": {
+          "description": "List the collections in a MongoDB database.",
+          "inputSchema": {
+            "json": {
+              "properties": {
+                "database": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "database",
+              ],
+              "type": "object",
+            },
+          },
+          "name": "list_collections",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`chat-completions → bedrock > googleToolCallThoughtSignatureReplayParam > response 1`] = `
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "The collections in the **mydb** database are:
+
+1. **movies**
+2. **users**",
+        "role": "assistant",
+      },
+    },
+  ],
+  "created": 0,
+  "id": "chatcmpl-transformed",
+  "model": "transformed",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 26,
+    "prompt_tokens": 639,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+    },
+    "total_tokens": 665,
   },
 }
 `;
@@ -12388,6 +12574,7 @@ exports[`chat-completions → google > functionToolsWithReasoningEffortParam > r
 
 Okay, so the user wants to know the weather in Tokyo. That's straightforward enough. I know I have a \`get_weather\` tool at my disposal, and that tool is designed specifically for retrieving weather information based on a given location. Therefore, my next logical step is to utilize this tool. I need to call \`get_weather\` with the input "Tokyo." That should give me the weather data the user is seeking. It's a simple request, and I can fulfill it directly using the appropriate function.
 ",
+        "reasoning_signature": "CucBAQw51sf3ly4/NPgf7Ek2GW7TFKExYspWKxo1FDh0SEd3bhvkBUsqj/hKTP/t5K52qzd+94aqzwD0qEtQmndHMjheAavUlU8wNTaJlyMxYPLgyr6njdSASQT19OGN6CvTdhikTvvHCeuYoQ5cLTTX/cQmaU35dmDsq+jQww4KejnIzuiA0S//0DXztUy5K+uiGDu/ghNOOePgNJbKNbGGChP7qnCbSgi5lb3GRIJBRhQPbiRHG0Hh6gVrWWHw4jOqBcDOZaYgSslwDeWZQZebPhxPMlDq4GUcR7l+0Kjh38Aoctmx4RVn",
         "role": "assistant",
         "tool_calls": [
           {
@@ -12413,6 +12600,105 @@ Okay, so the user wants to know the weather in Tokyo. That's straightforward eno
     },
     "prompt_tokens": 37,
     "total_tokens": 98,
+  },
+}
+`;
+
+exports[`chat-completions → google > googleToolCallThoughtSignatureReplayParam > request 1`] = `
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "List the collections in the mydb database.",
+        },
+      ],
+      "role": "user",
+    },
+    {
+      "parts": [
+        {
+          "functionCall": {
+            "args": {
+              "database": "mydb",
+            },
+            "name": "list_collections",
+          },
+          "thoughtSignature": "dGhvdWdodF9zaWduYXR1cmVfMTIz",
+        },
+      ],
+      "role": "model",
+    },
+    {
+      "parts": [
+        {
+          "functionResponse": {
+            "name": "list_collections",
+            "response": {
+              "output": [
+                "movies",
+                "users",
+              ],
+            },
+          },
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "model": "gemini-2.5-flash",
+  "toolConfig": {
+    "functionCallingConfig": {
+      "mode": "AUTO",
+    },
+  },
+  "tools": [
+    {
+      "functionDeclarations": [
+        {
+          "description": "List the collections in a MongoDB database.",
+          "name": "list_collections",
+          "parameters": null,
+          "parametersJsonSchema": {
+            "properties": {
+              "database": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "database",
+            ],
+            "type": "object",
+          },
+          "response": null,
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`chat-completions → google > googleToolCallThoughtSignatureReplayParam > response 1`] = `
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "The \`mydb\` database has two collections: \`movies\` and \`users\`.",
+        "role": "assistant",
+      },
+    },
+  ],
+  "created": 0,
+  "id": "chatcmpl-transformed",
+  "model": "gemini-2.5-flash",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 16,
+    "prompt_tokens": 83,
+    "total_tokens": 99,
   },
 }
 `;
@@ -13185,6 +13471,7 @@ exports[`chat-completions → google > parallelToolCallsDisabledParam > response
       "index": 0,
       "message": {
         "annotations": [],
+        "reasoning_signature": "CoQCAb4+9vsZLZBZClmxBgaHNtTauUi3lKai7dwaC7SSTYxuGDJBT95LEogTdUW2OacVT9P8kv0p5U1O2/FL3ue1kRlg0Y9i7UdNtDBRVo0vYANrHAqDZv70t7fRUPMwYWnLgPYGb478EimjKH0q5eRfBBj1V95//TOZ/Y6ENK9fWpmzDgp0mBiuIsFzLHyDjYc3w/jnwAUDKJ6n/cipjq2PxN0Ml7DJnA2sXwy1TV2uUzB8ElTpcyqMuVXicrgeTKjbnFhapiJTOoG2iNE8uX8I7v6g19LW62L4EqxM79pJorubztmFVNQNk5NO7MWdyCL83jAC1bIE69ojOPakz3zwstgO3u4=",
         "role": "assistant",
         "tool_calls": [
           {
@@ -14837,6 +15124,7 @@ exports[`chat-completions → google > toolCallRequest > response 1`] = `
       "index": 0,
       "message": {
         "annotations": [],
+        "reasoning_signature": "Eo4DCosDAQw51scBWT4vkiVr013+EFv8M/dPtDJ/ro0rBk5a2H7rgnIeSGwQumwOPiXDyMXQ3H59equt90wNc0MWs6TuCSTeRSQVGG7NJKSQ3vdK8EZdqZkf76/SZxpSuOkKru/FXet38iTRTA19XdOTEFqdZKvQ3PHvIfh1mIQDdOCeKCe+urFniCXqZUU6MKZ8HxnqECbW0dDmYNNFvZTQBzjZwzaO9iQK0zm24ABsmghGC0MTLzk2R0vpBnESCip9j2gNm8+5y0vvMsdJ9Focej7nw4PnnBDEpLtGZUKORQKWiOFsNw0MUqPPMbSJaPwEaPUYShUhUcjDmd9ZUH/fzzLHfspHvaZp1BrGx/kAVLOeIZwR3rFCMvvJnCelT19fcYqhqZCy5s+23Pewh98khfqnAB42+P0+V5uIfB5IUirMnVVTq0H0YiDlzzJkOFH9/Ofnl+kGMVvyuAwvfaQDp6p1sk/SMp4eVdRIy9pj5MV56wBZkB9uDmJ02SCEFhxjiXfvmfL9usc+hV346XE=",
         "role": "assistant",
         "tool_calls": [
           {
@@ -14922,6 +15210,7 @@ exports[`chat-completions → google > toolChoiceRequiredParam > response 1`] = 
       "index": 0,
       "message": {
         "annotations": [],
+        "reasoning_signature": "CucBAb4+9vs+L8b5DWxZLf3YrtyE8jaiRvH3+WfoYiFe+3UsTHFrh6yby+drplwgFn9zcIL7y6DA1G/RT7Xdo489paNL+GTgzaqw0vV0Xj0wdOOsrVkgGfJLhdGpxtFTsaCC3XD+Py7LoBV2qQ14IZmtfdXvHvyQISbziF3U9el7zQj7ksoPMudDWHE7tA6aCsU63lJbAoEtvdIyImcxvT9ikCONlFXlNKi1fhKgmqlaiSthawjVpRH3yNNQRWsfILjR09Z4F6noiN5v4m25/GoVOxwGfo5QaqtF1vXeVHD1fa5NMyLlTsHy",
         "role": "assistant",
         "tool_calls": [
           {
@@ -15018,6 +15307,7 @@ exports[`chat-completions → google > toolChoiceRequiredWithReasoningParam > re
 
 Okay, here's the situation: the user needs the weather for Tokyo. Thankfully, I have the \`get_weather\` tool at my disposal! This tool is specifically designed to provide weather information, and it takes a location as input. So, the path forward is clear. I need to call the \`get_weather\` tool. The key piece of information needed to get the job done is "Tokyo." I'll feed "Tokyo" to the \`get_weather\` tool, and hopefully, I'll return the user with the meteorological insights they require.
 ",
+        "reasoning_signature": "CvUBAb4+9vvbHYYDxRU+GMpl6jV1aX39BlEBVrnr13g03xCinYCWIH9Y0VT1bdLVQIRGR0fylIRuhSQ670AxC+5nVEoPUWm9lQ2qf88khbkpAJjKU1e1fVZlKqx2Zyt/2vjX8da5CC3pRLDG+GW7/3JxZmQiZMsmgyiOSrJw3gM4LN983UyoKFDR19zVywnySpo30MZGToMDR+/CKXddu43tqpE/5Hwxy92pUEjGX/sFIoKqR2oiI7Y9ThytQBxvHnIORZzO8+vEg1VZWq1dOour0qbyuOfVJTIpfDVrU1AFJiGLlU3q/f7m8RKvqQM3kD1RX3IY2l8=",
         "role": "assistant",
         "tool_calls": [
           {
@@ -15429,6 +15719,89 @@ exports[`chat-completions → responses > functionToolsWithReasoningEffortParam 
       "cached_tokens": 0,
     },
     "total_tokens": 93,
+  },
+}
+`;
+
+exports[`chat-completions → responses > googleToolCallThoughtSignatureReplayParam > request 1`] = `
+{
+  "input": [
+    {
+      "content": "List the collections in the mydb database.",
+      "role": "user",
+    },
+    {
+      "arguments": "{"database":"mydb"}",
+      "call_id": "call_123",
+      "name": "list_collections",
+      "status": "completed",
+      "type": "function_call",
+    },
+    {
+      "call_id": "call_123",
+      "output": "["movies","users"]",
+      "type": "function_call_output",
+    },
+  ],
+  "model": "gpt-5-nano",
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "description": "List the collections in a MongoDB database.",
+      "name": "list_collections",
+      "parameters": {
+        "properties": {
+          "database": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "database",
+        ],
+        "type": "object",
+      },
+      "type": "function",
+    },
+  ],
+}
+`;
+
+exports[`chat-completions → responses > googleToolCallThoughtSignatureReplayParam > response 1`] = `
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "reasoning": "",
+        "role": "assistant",
+      },
+    },
+    {
+      "finish_reason": "stop",
+      "index": 1,
+      "message": {
+        "annotations": [],
+        "content": "The collections in mydb are: movies and users. If you’d like, I can show document counts or sample documents from either collection.",
+        "role": "assistant",
+      },
+    },
+  ],
+  "created": 0,
+  "id": "chatcmpl-065e504389243eaa006a1e853c8b70819aaa433808cf406cba",
+  "model": "gpt-5-nano-2025-08-07",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 174,
+    "completion_tokens_details": {
+      "reasoning_tokens": 128,
+    },
+    "prompt_tokens": 89,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+    },
+    "total_tokens": 263,
   },
 }
 `;
@@ -18334,6 +18707,88 @@ exports[`google → anthropic > googleResponseSchemaPropertyOrderingParam > resp
 }
 `;
 
+exports[`google → anthropic > googleToolCallThoughtSignatureReplayParam > request 1`] = `
+{
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "List the collections in the mydb database.",
+      "role": "user",
+    },
+    {
+      "content": [
+        {
+          "id": "call_123",
+          "input": {
+            "database": "mydb",
+          },
+          "name": "list_collections",
+          "type": "tool_use",
+        },
+      ],
+      "role": "assistant",
+    },
+    {
+      "content": [
+        {
+          "content": "{"output":["movies","users"]}",
+          "tool_use_id": "call_123",
+          "type": "tool_result",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "model": "claude-sonnet-4-5-20250929",
+  "tools": [
+    {
+      "description": "List the collections in a MongoDB database.",
+      "input_schema": {
+        "properties": {
+          "database": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "database",
+        ],
+        "type": "object",
+      },
+      "name": "list_collections",
+    },
+  ],
+}
+`;
+
+exports[`google → anthropic > googleToolCallThoughtSignatureReplayParam > response 1`] = `
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The collections in the **mydb** database are:
+
+1. **movies**
+2. **users**",
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 0,
+    },
+  ],
+  "modelVersion": "claude-sonnet-4-5-20250929",
+  "usageMetadata": {
+    "cachedContentTokenCount": 0,
+    "candidatesTokenCount": 26,
+    "promptTokenCount": 642,
+    "totalTokenCount": 668,
+  },
+}
+`;
+
 exports[`google → anthropic > googleToolSchemaNumericInt64Param > request 1`] = `
 {
   "max_tokens": 4096,
@@ -20861,6 +21316,86 @@ exports[`google → chat-completions > googleResponseSchemaPropertyOrderingParam
 }
 `;
 
+exports[`google → chat-completions > googleToolCallThoughtSignatureReplayParam > request 1`] = `
+{
+  "messages": [
+    {
+      "content": "List the collections in the mydb database.",
+      "role": "user",
+    },
+    {
+      "reasoning_signature": "dGhvdWdodF9zaWduYXR1cmVfMTIz",
+      "role": "assistant",
+      "tool_calls": [
+        {
+          "function": {
+            "arguments": "{"database":"mydb"}",
+            "name": "list_collections",
+          },
+          "id": "call_123",
+          "type": "function",
+        },
+      ],
+    },
+    {
+      "content": "{"output":["movies","users"]}",
+      "role": "tool",
+      "tool_call_id": "call_123",
+    },
+  ],
+  "model": "gpt-5-nano",
+  "tools": [
+    {
+      "function": {
+        "description": "List the collections in a MongoDB database.",
+        "name": "list_collections",
+        "parameters": {
+          "properties": {
+            "database": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "database",
+          ],
+          "type": "object",
+        },
+      },
+      "type": "function",
+    },
+  ],
+}
+`;
+
+exports[`google → chat-completions > googleToolCallThoughtSignatureReplayParam > response 1`] = `
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The mydb database contains 2 collections:
+- movies
+- users",
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 0,
+    },
+  ],
+  "modelVersion": "gpt-5-nano-2025-08-07",
+  "usageMetadata": {
+    "cachedContentTokenCount": 0,
+    "candidatesTokenCount": 23,
+    "promptTokenCount": 176,
+    "thoughtsTokenCount": 128,
+    "totalTokenCount": 327,
+  },
+}
+`;
+
 exports[`google → chat-completions > googleToolSchemaNumericInt64Param > request 1`] = `
 {
   "messages": [
@@ -23233,6 +23768,89 @@ exports[`google → responses > googleResponseSchemaPropertyOrderingParam > resp
     "promptTokenCount": 42,
     "thoughtsTokenCount": 128,
     "totalTokenCount": 170,
+  },
+}
+`;
+
+exports[`google → responses > googleToolCallThoughtSignatureReplayParam > request 1`] = `
+{
+  "input": [
+    {
+      "content": "List the collections in the mydb database.",
+      "role": "user",
+    },
+    {
+      "arguments": "{"database":"mydb"}",
+      "call_id": "call_123",
+      "name": "list_collections",
+      "status": "completed",
+      "type": "function_call",
+    },
+    {
+      "call_id": "call_123",
+      "name": "list_collections",
+      "output": "{"output":["movies","users"]}",
+      "type": "function_call_output",
+    },
+  ],
+  "model": "gpt-5-nano",
+  "tools": [
+    {
+      "description": "List the collections in a MongoDB database.",
+      "name": "list_collections",
+      "parameters": {
+        "properties": {
+          "database": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "database",
+        ],
+        "type": "object",
+      },
+      "type": "function",
+    },
+  ],
+}
+`;
+
+exports[`google → responses > googleToolCallThoughtSignatureReplayParam > response 1`] = `
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "",
+            "thought": true,
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 0,
+    },
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The collections in mydb are: movies and users.",
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 1,
+    },
+  ],
+  "modelVersion": "gpt-5-nano-2025-08-07",
+  "usageMetadata": {
+    "cachedContentTokenCount": 0,
+    "candidatesTokenCount": 59,
+    "promptTokenCount": 92,
+    "thoughtsTokenCount": 128,
+    "totalTokenCount": 279,
   },
 }
 `;

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -7105,7 +7105,7 @@ exports[`chat-completions → anthropic > googleToolCallThoughtSignatureReplayPa
     },
   ],
   "created": 0,
-  "id": "chatcmpl-015LQHcNzXwfqPkWxys7rTWo",
+  "id": "chatcmpl-01S9JLYYZe4k5uctkuMhmrhv",
   "model": "claude-sonnet-4-5-20250929",
   "object": "chat.completion",
   "usage": {
@@ -12686,7 +12686,7 @@ exports[`chat-completions → google > googleToolCallThoughtSignatureReplayParam
       "index": 0,
       "message": {
         "annotations": [],
-        "content": "The \`mydb\` database has two collections: \`movies\` and \`users\`.",
+        "content": "The collections in the \`mydb\` database are \`movies\` and \`users\`.",
         "role": "assistant",
       },
     },
@@ -15783,17 +15783,21 @@ exports[`chat-completions → responses > googleToolCallThoughtSignatureReplayPa
       "index": 1,
       "message": {
         "annotations": [],
-        "content": "The collections in mydb are: movies and users. If you’d like, I can show document counts or sample documents from either collection.",
+        "content": "The collections in the mydb database are:
+- movies
+- users
+
+Would you like to see document counts or sample documents from any of these?",
         "role": "assistant",
       },
     },
   ],
   "created": 0,
-  "id": "chatcmpl-065e504389243eaa006a1e853c8b70819aaa433808cf406cba",
+  "id": "chatcmpl-0b84110d340c2d3c006a1f332124ac8199b234ca6f6df198ba",
   "model": "gpt-5-nano-2025-08-07",
   "object": "chat.completion",
   "usage": {
-    "completion_tokens": 174,
+    "completion_tokens": 222,
     "completion_tokens_details": {
       "reasoning_tokens": 128,
     },
@@ -15801,7 +15805,7 @@ exports[`chat-completions → responses > googleToolCallThoughtSignatureReplayPa
     "prompt_tokens_details": {
       "cached_tokens": 0,
     },
-    "total_tokens": 263,
+    "total_tokens": 311,
   },
 }
 `;
@@ -18718,7 +18722,7 @@ exports[`google → anthropic > googleToolCallThoughtSignatureReplayParam > requ
     {
       "content": [
         {
-          "id": "call_123",
+          "id": "call_0",
           "input": {
             "database": "mydb",
           },
@@ -18732,7 +18736,7 @@ exports[`google → anthropic > googleToolCallThoughtSignatureReplayParam > requ
       "content": [
         {
           "content": "{"output":["movies","users"]}",
-          "tool_use_id": "call_123",
+          "tool_use_id": "call_0",
           "type": "tool_result",
         },
       ],
@@ -21332,7 +21336,7 @@ exports[`google → chat-completions > googleToolCallThoughtSignatureReplayParam
             "arguments": "{"database":"mydb"}",
             "name": "list_collections",
           },
-          "id": "call_123",
+          "id": "call_0",
           "type": "function",
         },
       ],
@@ -21340,7 +21344,7 @@ exports[`google → chat-completions > googleToolCallThoughtSignatureReplayParam
     {
       "content": "{"output":["movies","users"]}",
       "role": "tool",
-      "tool_call_id": "call_123",
+      "tool_call_id": "call_0",
     },
   ],
   "model": "gpt-5-nano",
@@ -21374,7 +21378,7 @@ exports[`google → chat-completions > googleToolCallThoughtSignatureReplayParam
       "content": {
         "parts": [
           {
-            "text": "The mydb database contains 2 collections:
+            "text": "The collections in the mydb database are:
 - movies
 - users",
           },
@@ -23781,13 +23785,13 @@ exports[`google → responses > googleToolCallThoughtSignatureReplayParam > requ
     },
     {
       "arguments": "{"database":"mydb"}",
-      "call_id": "call_123",
+      "call_id": "call_0",
       "name": "list_collections",
       "status": "completed",
       "type": "function_call",
     },
     {
-      "call_id": "call_123",
+      "call_id": "call_0",
       "name": "list_collections",
       "output": "{"output":["movies","users"]}",
       "type": "function_call_output",
@@ -23835,7 +23839,11 @@ exports[`google → responses > googleToolCallThoughtSignatureReplayParam > resp
       "content": {
         "parts": [
           {
-            "text": "The collections in mydb are: movies and users.",
+            "text": "The collections in mydb are:
+- movies
+- users
+
+Would you like any details from these collections (e.g., document counts or sample documents)?",
           },
         ],
         "role": "model",
@@ -23847,10 +23855,10 @@ exports[`google → responses > googleToolCallThoughtSignatureReplayParam > resp
   "modelVersion": "gpt-5-nano-2025-08-07",
   "usageMetadata": {
     "cachedContentTokenCount": 0,
-    "candidatesTokenCount": 59,
+    "candidatesTokenCount": 41,
     "promptTokenCount": 92,
-    "thoughtsTokenCount": 128,
-    "totalTokenCount": 279,
+    "thoughtsTokenCount": 192,
+    "totalTokenCount": 325,
   },
 }
 `;

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/followup-request.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/followup-request.json
@@ -1,0 +1,60 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "List the collections in the mydb database."
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "reasoning_signature": "dGhvdWdodF9zaWduYXR1cmVfMTIz",
+      "tool_calls": [
+        {
+          "id": "call_123",
+          "type": "function",
+          "function": {
+            "name": "list_collections",
+            "arguments": "{\"database\":\"mydb\"}"
+          }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_123",
+      "content": "[\"movies\",\"users\"]"
+    },
+    {
+      "role": "assistant",
+      "content": "The collections in the mydb database are:\n- movies\n- users",
+      "refusal": null,
+      "annotations": []
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "list_collections",
+        "description": "List the collections in a MongoDB database.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "database": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "database"
+          ]
+        }
+      }
+    }
+  ],
+  "tool_choice": "auto"
+}

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/followup-response-streaming.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/followup-response-streaming.json
@@ -1,0 +1,8822 @@
+[
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "role": "assistant",
+          "content": "",
+          "refusal": null
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "IN"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Nice"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " work"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ALw0oNLsQV9u73j"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "vno"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " You"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "’ve"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "s"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " got"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " two"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " collections"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "sGN9iezR"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9Jd"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "zLZtS9wJ0vtMs"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "KA39KBcWfH2v4K"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "TRR"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Here"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "qOEb5MCDx8iN6y6"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " are"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " some"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3jjSrkbftZO84k9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " good"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "iRXGm0TCrtdJaO0"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " next"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "x3mspbCtZHEeHnE"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " steps"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DAxcB22vNccRbW"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " depending"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4AxVJnCq9b"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " on"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "t"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " what"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "oYVLW7gDEGbEdyV"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " want"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9KmCfNNXfEt1VKn"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " to"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "H"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " accomplish"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Fzy5KUb8H"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Nfc"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Pick"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "MtGVqsoiCkU6Nti"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " any"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ZMy"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " I"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8i"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " can"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " help"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7NJh6dWPDEfMXqj"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " with"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hC4XlfVNEnTBhxc"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " concrete"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "JPoPoyGrrDD"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " commands"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WhJpVkJuuZx"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " plans"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "KmqPZnOXxuwMOY"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "yi7Y1Q7DZrnpw6O"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Hoo"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Quick"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "PUyDWTQVC970NU"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " data"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "li6HegryqF66lDO"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " exploration"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "e74anfzX"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "g2"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "U6v"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "NM"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " See"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " sample"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "kk4zxgohYjdtZ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " documents"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "bAcn7rkNH3"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "B"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "zv"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Mongo"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "yBm050aQohe0iP"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " shell"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4Sox9ZpDwoJp9q"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ckM"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "o"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Do1RCwtqj7Slo"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4HCh8q6vKj7jrYv"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "y"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "limit"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WyEtmZ4B4yqJTmX"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Hjz"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "5"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "TTQ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ")\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "X"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "g"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Wv"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Mongo"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0dGdePoSQ2G12Y"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " shell"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "bLd3UIlJOmnjjI"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "J6E"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "f"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "i8ZknP2uBevxzh"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "gj5e0mZHQNQogjq"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "S"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "limit"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "GJm5PyE90C3ut28"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "QeT"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "5"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "jAg"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ")\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "v"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Mcb"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "C1"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Inspect"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "gIfOL6DlZxgc"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7B"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " single"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "v3saoI6ubUmY3"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " document"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "bEMMuUJsDR2"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " to"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "N"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " understand"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "80vJC3gw9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " fields"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "JqUspGklFmDjn"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "h"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "K"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "uU"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "c"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WUzm82TpqLJrh"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "62mK4UXDlbIqzFa"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "One"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "f"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "QU"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "2"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DKMqSl8NgfPjkd"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7Q7zGWIcWYNYHNH"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "One"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "K"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "OXt"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Lo"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Check"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "P1gqMRwvaDAbOM"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " counts"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "NdaiyibXrKvW2"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "a"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "W"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "zQ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "E"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3Vxcv2qp1L0Av"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".count"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "xigFghDB9tY6Sk"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Documents"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "dYMGz7tZOtQ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({})\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1IA1oZVA0BLivJ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "x"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "tN"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "y"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8JsMHHVmaFUtSt"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".count"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nCiwH7uyU6XvBk"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Documents"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Vrpair3UQmV"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Kj"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "})\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "CG6dsw7mvIvdL9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "zwK"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Understand"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "uvUpoMsud"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " schema"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "LDr0AVPL3ncTF"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " data"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "t2knWokarLelaVx"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " quality"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "qek8mBG4odZ5"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "HO"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "gmt"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Mc"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Identify"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "OEUeOL5PdJE"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " field"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DBCShpkVtxZiaI"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " names"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "26vxQaQGiVzPsA"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " types"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7gsdSigYRKbozm"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " from"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ytImpaoqxB3fLLm"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "js"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " sample"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8RAo9V3g7gO67"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "N"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "W"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "qC"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "E"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "X8BQuKDpRAbS9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "f689lxlUjp0sPQm"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "One"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "F"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "EY9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "l5"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Look"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "QLCn0jbsFPEwY8q"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " for"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " missing"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "05S2RAby3tOg"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " unusual"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ZO5GO8m5L36u"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " fields"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "a90VAhahc4dTt"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " duplicates"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "xVrwBrrWg"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "2k"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Ws2"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8k"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Validate"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "x7AXs8bX2SL"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " data"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ZWT1QEBvrRxvFzH"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " quality"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hSUIGTDJi7ff"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " consistency"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "CNJreF6G"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "mi4"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Index"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rzyUJZC9waHWqh"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "ing"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "5"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " performance"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "XTlNBxgr"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6T"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1JX"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "xG"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " See"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " existing"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "AKztpX6ZvQO"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " indexes"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "diACNsuVPuMl"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "y"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "K"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Gr"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "u"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DXHJN45z6UgDV"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".get"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Indexes"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "VWbqMJugQiZ63"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "f"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "c6"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "v"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "gcT8OsYD0kLpi2"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".get"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Indexes"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "13m0Qu4GaGk91"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rbg"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "AS"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Suggested"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "W9YjTRc4qg"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " indexes"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9kEK014LCQYW"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "xp"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "adjust"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9maCKQO6QeqSVQ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " to"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Z"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " your"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hDjBl1zvfO2Dgej"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " queries"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "GVFythj3QvYS"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "):\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Jj"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "OdUuKA2RYbJLw"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "OES"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " on"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "l"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " title"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "etajtqOQAu63Sd"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Rw"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "1"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "R8k"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "),"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "FU"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " year"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Aa0yERzqJy5BC9p"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Vp"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "1"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "wYz"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "),"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1G"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " genre"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ML2r0iF0THDdDY"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Ul"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "1"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "60K"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ")\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "V"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "w"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0V"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "wodzHlCmfxqB1r"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7FM"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " on"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " email"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "b2Qq7izjSK2stB"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Xl"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "unique"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "TWryKnj64MsOSx"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "),"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "qN"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " username"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "H75IiR1rzrM"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "13"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "optional"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "41zaKarUTPHN"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ")\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "l"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "FSc"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "fU"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Create"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "FdhMirwQ84B2X"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " an"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "z"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " index"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "LguZVhLIuGZSaV"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " example"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9aW5vWkuh36i"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "J"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "n"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hS"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Y"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8GbmH5t65Akvx"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".create"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0zTMV9txN65Xd"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Index"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "wOFsANnCZaLJ7Ef"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "90"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " title"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "F4H6z8Pjm2Mr76"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ugm"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "BYz"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "1"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4ql"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "dIg"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " year"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "CN7jbDmB05gbnKJ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Isi"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6r"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "1"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "N6d"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " })\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "oDtvHhG0MMAUdVY"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "2"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "me"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "GkgNbjyUlJvxDv"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".create"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "kcTmiqlXw5hDp"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Index"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "K4Qwz1sdoFMOxiZ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "c7"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " email"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "uHiU7uGA2j4RkJ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "13t"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "5pW"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "1"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "s7v"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " },"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Q"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " {"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "oL"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " unique"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "EdUtKbEohQbnG"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "fqw"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " true"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WsdRG4xEVUeQybv"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " })\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "JLuc4WSCNRwM4"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ZuR"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Data"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4IO4pNStCXCFw8f"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " modeling"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "PnM6cf5gJqR"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " validation"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "2rfPaIS9r"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4F"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "YV8"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "dv"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Consider"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6Vi7u1B3Kii"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " adding"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nw9iRhENIedus"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " schema"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WxgD8Uo3QbzVK"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " validation"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "myDSHCPox"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " for"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " new"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " data"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "glEryYWitv688UC"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Zf"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "   "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "x"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8U"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Example"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "L8ykbcxg1tn7"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Mn"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "simpl"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "XWva8pp9ZExrRgN"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "ified"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "lLWewO1ib2s5fUP"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "):\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "     "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Pa06Wvv0sDr2XU7"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "HO"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " For"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "k0uuc0T020dm6"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "KM4"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " required"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "pFiDnQ0aMjx"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " fields"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ffJ7IC63y8erv"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " like"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "NwutPdK9zAdQZEk"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " title"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "N54LAylL7YsBb0"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " year"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "a4QpYc2kSs5NyKC"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3O"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "     "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4EQGrLpztESXEMc"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "HY"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " For"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "RDiCW4Op46NbgM"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "boz"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " required"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "MLBws5SUjO9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " fields"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "5f88lGbUDG2Sl"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " like"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "TssEUdugcnRKNht"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " email"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6L6YNGUn7WO7K8"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " password"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "bFbvMWlmhRo"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " hash"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "M8OMPSyP8oSCDvu"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rU"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Lbs"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "B3"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Decide"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hF2rH54TGdV0h"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " if"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "P"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " want"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "29kbNDdb4WU6s5H"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Z3"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " normalized"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "65Hw36Zhf"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " vs"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "B"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4Wz"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " den"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "ormal"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "5kHoi0mWsJZIfA9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "ized"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " structure"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rBzO1W22nm"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " plan"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "amoKnxOtHxANO8O"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " any"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " migrations"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "14Kl0awbn"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8c2"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Data"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "SUzYwgPtZxCWZ7n"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " manipulation"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "VeAHsxw"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " workflows"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ZzXFZNwh6v"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Cy"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "QC8"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6g"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Insert"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Q1Fh5sV5pvN9g"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Fz"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " new"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " user"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "5kDyzuKWLLwMVw9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "i"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " movie"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0FOAEfUwNWkUXb"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "pS"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "BdX"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6M"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Update"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "fXYaC5O8RhQyY"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " existing"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "wnWGcCBt4xq"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " documents"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WfwJGWK6Ve"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Ol"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "bML"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Ho"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Delete"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "94ki7NktPeoW5"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " test"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "NuwkMQg8tU8fuUI"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " data"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nuRSsLT6mhNDyso"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " don"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "’t"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "sf"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " need"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "UZPGa2jPMbU1sMi"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Vp"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "r5n"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "st"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Typical"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "PKp7FNIEHmA0"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " queries"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9ur7tQpWabH4"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "’ll"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "l"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " likely"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "tiYUvLo04vyjV"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " run"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hC"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "adjust"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ot5MPAoxLQnp6B"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " to"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "O"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " your"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "T7fjE5IFCLoMDyd"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " needs"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rrdNDxPfxFVvP8"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ")\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "H0ptdTWsvGLgtmE"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WcO"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Back"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "eUj6hLY5gRVU4cV"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "ups"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "v"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " export"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "HfqSx9G67Xx6n"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Y9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "2Kf"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "v9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Export"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "srDE78f9vBws3"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " data"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "LBHgSgP89GlSki8"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " to"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "D"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " JSON"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DKYyrD61FQhyadk"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "/"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "xEO"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "CSV"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "K"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " if"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "x"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " need"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "u59wR9XGI8vPn9k"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " to"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " share"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "MUcLMGcnRmcEwO"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "O"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " migrate"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "oqY22IL0iBsO"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "wg"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "XEg"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "dm"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Plan"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "n4yLpSRRO2Q4jhr"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " regular"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WXgQPSGpulLl"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " backups"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "roQSnXFaw3Ip"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "What"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " would"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "su45XzLuUBmxXI"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " like"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "t4qNRKeuQcGBLMi"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " to"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "y"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " do"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "C"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " first"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "xrYif1xjvoNuX1"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "?"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "IzL"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " I"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rS"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " can"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " provide"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "tsjeNydk4ZTK"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " exact"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "2JO3UD4jcFIz53"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " commands"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "LdYvoILwog7"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "W"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "78"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " small"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "GItY04ejq7agld"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " script"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1bvb80qbwXDHQ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " for"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " any"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " of"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Q"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " the"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " above"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "GFOHQ0sPJET78l"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6n"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "e"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Uc7"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".g"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9u"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".,"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "qw"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " show"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "gjHBdpR8Rg1avhH"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " me"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "U"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " sample"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Qt4Vx3Ixqw7p9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " docs"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ov4oR0X4fhfzkRO"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "kJb"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " set"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " up"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " indexes"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "JDyJrLfl6EEb"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "2yt"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "H"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " create"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hdON7HRwSJFi3"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4q"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " validation"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "B9qfzZJ1P"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " rule"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nnzlCD2vuMuKr8h"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ")."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "JJ"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " If"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "k"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " tell"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nz9Oo6FKNLFFOk1"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " me"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "o"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " your"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "cKUypVgdjY9M5mH"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " goal"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ByHzxPeJk4JRmV2"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "PN"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "e"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "cP6"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".g"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "FG"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".,"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "VO"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " “"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1H"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "im"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "HC"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "prove"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "reqcUFcwuVCju2a"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " search"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "AU8iRpFcKKtrd"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " for"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "UkGNGAUGFH8Ty"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " by"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "J"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " title"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "H3oUQ8u5PoPbOb"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ",”"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "IL"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Z"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " “"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7N"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DU"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " user"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "H4lzFZX9PK5Pdst"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " by"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "O"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " email"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nJQkpAPLJdLa1A"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "”),"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " I"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "L8"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "’ll"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "f"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " tailor"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "N2J8P2sTzzYNf"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " the"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " steps"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "u4sS6Kyo8lMLrF"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " commands"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9phFyfHSFPp"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Sca"
+  },
+  {
+    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "object": "chat.completion.chunk",
+    "created": 1780385073,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {},
+        "finish_reason": "stop"
+      }
+    ],
+    "obfuscation": "vFPSgEiocrYaGV"
+  }
+]

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/followup-response-streaming.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/followup-response-streaming.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -17,12 +17,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "IN"
+    "obfuscation": "cZ"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -30,7 +30,43 @@
       {
         "index": 0,
         "delta": {
-          "content": "Nice"
+          "content": "Great"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "JJLgqOHiARkWZb7"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " —"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Fr"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
         },
         "finish_reason": null
       }
@@ -38,63 +74,9 @@
     "obfuscation": ""
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " work"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ALw0oNLsQV9u73j"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "."
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "vno"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " You"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -107,12 +89,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "s"
+    "obfuscation": "r"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -128,9 +110,9 @@
     "obfuscation": ""
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -146,9 +128,9 @@
     "obfuscation": ""
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -161,12 +143,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "sGN9iezR"
+    "obfuscation": "qlOBeOVx"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -179,12 +161,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "9Jd"
+    "obfuscation": "1QK"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -197,12 +179,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "zLZtS9wJ0vtMs"
+    "obfuscation": "QXuXKpz0TpNLn"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -218,9 +200,9 @@
     "obfuscation": ""
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -233,12 +215,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "KA39KBcWfH2v4K"
+    "obfuscation": "sCXVpvo2X0UJjP"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -251,12 +233,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "TRR"
+    "obfuscation": "rZ9"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -269,12 +251,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "qOEb5MCDx8iN6y6"
+    "obfuscation": "JguVgy9XppMwgCw"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -290,9 +272,9 @@
     "obfuscation": ""
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -305,12 +287,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "3jjSrkbftZO84k9"
+    "obfuscation": "oHC1VIzYO3jKEOz"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -318,17 +300,17 @@
       {
         "index": 0,
         "delta": {
-          "content": " good"
+          "content": " common"
         },
         "finish_reason": null
       }
     ],
-    "obfuscation": "iRXGm0TCrtdJaO0"
+    "obfuscation": "kZbplDjHTwexd"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -341,12 +323,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "x3mspbCtZHEeHnE"
+    "obfuscation": "QsLWVSLWHSocFQv"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -359,138 +341,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "DAxcB22vNccRbW"
+    "obfuscation": "sFh9ANGoDP7EDE"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " depending"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "4AxVJnCq9b"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " on"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "t"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " what"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "oYVLW7gDEGbEdyV"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " you"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " want"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "9KmCfNNXfEt1VKn"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " to"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "H"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " accomplish"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Fzy5KUb8H"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -503,12 +359,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "Nfc"
+    "obfuscation": "9u9"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -516,17 +372,17 @@
       {
         "index": 0,
         "delta": {
-          "content": " Pick"
+          "content": " Tell"
         },
         "finish_reason": null
       }
     ],
-    "obfuscation": "MtGVqsoiCkU6Nti"
+    "obfuscation": "Zf6zxOSM7C1GBvi"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -534,637 +390,7 @@
       {
         "index": 0,
         "delta": {
-          "content": " any"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ","
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ZMy"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " I"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "8i"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " can"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " help"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "7NJh6dWPDEfMXqj"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " with"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "hC4XlfVNEnTBhxc"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " concrete"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "JPoPoyGrrDD"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " commands"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "WhJpVkJuuZx"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " or"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "3"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " plans"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "KmqPZnOXxuwMOY"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".\n\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "yi7Y1Q7DZrnpw6O"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "-"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Hoo"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Quick"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "PUyDWTQVC970NU"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " data"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "li6HegryqF66lDO"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " exploration"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "e74anfzX"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "g2"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "U6v"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "NM"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " See"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " sample"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "kk4zxgohYjdtZ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " documents"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "bAcn7rkNH3"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "B"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "8"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "zv"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Mongo"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "yBm050aQohe0iP"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " shell"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "4Sox9ZpDwoJp9q"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ckM"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "o"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".movies"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Do1RCwtqj7Slo"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".find"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "4HCh8q6vKj7jrYv"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "()."
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "y"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "limit"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "WyEtmZ4B4yqJTmX"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Hjz"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "5"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "TTQ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ")\n"
+          "content": " me"
         },
         "finish_reason": null
       }
@@ -1172,9 +398,9 @@
     "obfuscation": "X"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -1182,17 +408,17 @@
       {
         "index": 0,
         "delta": {
-          "content": "   "
+          "content": " which"
         },
         "finish_reason": null
       }
     ],
-    "obfuscation": "g"
+    "obfuscation": "1WpXgKufqYKzAv"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -1200,17 +426,17 @@
       {
         "index": 0,
         "delta": {
-          "content": " -"
+          "content": " you"
         },
         "finish_reason": null
       }
     ],
-    "obfuscation": "Wv"
+    "obfuscation": ""
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -1218,17 +444,17 @@
       {
         "index": 0,
         "delta": {
-          "content": " Mongo"
+          "content": "’d"
         },
         "finish_reason": null
       }
     ],
-    "obfuscation": "0dGdePoSQ2G12Y"
+    "obfuscation": "Uh"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -1236,287 +462,17 @@
       {
         "index": 0,
         "delta": {
-          "content": " shell"
+          "content": " like"
         },
         "finish_reason": null
       }
     ],
-    "obfuscation": "bLd3UIlJOmnjjI"
+    "obfuscation": "OSbceFJdUwJs3tl"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "J6E"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "f"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".users"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "i8ZknP2uBevxzh"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".find"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "gj5e0mZHQNQogjq"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "()."
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "S"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "limit"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "GJm5PyE90C3ut28"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "QeT"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "5"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "jAg"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ")\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "v"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Mcb"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "C1"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Inspect"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "gIfOL6DlZxgc"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " a"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "7B"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " single"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "v3saoI6ubUmY3"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " document"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "bEMMuUJsDR2"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -1532,6003 +488,9 @@
     "obfuscation": "N"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " understand"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "80vJC3gw9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " fields"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "JqUspGklFmDjn"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "h"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "K"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "uU"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "c"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".movies"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "WUzm82TpqLJrh"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".find"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "62mK4UXDlbIqzFa"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "One"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "0"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "()\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "f"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "QU"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "2"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".users"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "DKMqSl8NgfPjkd"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".find"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "7Q7zGWIcWYNYHNH"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "One"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "K"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "()\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "OXt"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Lo"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Check"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "P1gqMRwvaDAbOM"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " counts"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "NdaiyibXrKvW2"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "a"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "W"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "zQ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "E"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".movies"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "3Vxcv2qp1L0Av"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".count"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "xigFghDB9tY6Sk"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "Documents"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "dYMGz7tZOtQ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "({})\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "1IA1oZVA0BLivJ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "x"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "tN"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "y"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".users"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "8JsMHHVmaFUtSt"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".count"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "nCiwH7uyU6XvBk"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "Documents"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Vrpair3UQmV"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "({"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Kj"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "})\n\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "CG6dsw7mvIvdL9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "-"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "zwK"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Understand"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "uvUpoMsud"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " schema"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "LDr0AVPL3ncTF"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " data"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "t2knWokarLelaVx"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " quality"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "qek8mBG4odZ5"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "HO"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "gmt"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Mc"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Identify"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "OEUeOL5PdJE"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " field"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "DBCShpkVtxZiaI"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " names"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "26vxQaQGiVzPsA"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " types"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "7gsdSigYRKbozm"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " from"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ytImpaoqxB3fLLm"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " a"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "js"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " sample"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "8RAo9V3g7gO67"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "N"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "W"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "qC"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "E"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".movies"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "X8BQuKDpRAbS9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".find"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "f689lxlUjp0sPQm"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "One"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "F"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "()\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "EY9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "l5"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Look"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "QLCn0jbsFPEwY8q"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " for"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " missing"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "05S2RAby3tOg"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " or"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "7"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " unusual"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ZO5GO8m5L36u"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " fields"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "a90VAhahc4dTt"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " duplicates"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "xVrwBrrWg"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "2k"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Ws2"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "8k"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Validate"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "x7AXs8bX2SL"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " data"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ZWT1QEBvrRxvFzH"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " quality"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "hSUIGTDJi7ff"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " consistency"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "CNJreF6G"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "-"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "mi4"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Index"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "rzyUJZC9waHWqh"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "ing"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "5"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " performance"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "XTlNBxgr"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "6T"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "1JX"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "xG"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " See"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " existing"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "AKztpX6ZvQO"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " indexes"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "diACNsuVPuMl"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "y"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "K"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Gr"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "u"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".movies"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "DXHJN45z6UgDV"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".get"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "Indexes"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "VWbqMJugQiZ63"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "()\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "f"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "c6"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "v"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".users"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "gcT8OsYD0kLpi2"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".get"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "Indexes"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "13m0Qu4GaGk91"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "()\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "rbg"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "AS"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Suggested"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "W9YjTRc4qg"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " indexes"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "9kEK014LCQYW"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " ("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "xp"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "adjust"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "9maCKQO6QeqSVQ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " to"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Z"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " your"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "hDjBl1zvfO2Dgej"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " queries"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "GVFythj3QvYS"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "):\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "1"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Jj"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Movies"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "OdUuKA2RYbJLw"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "OES"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " on"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "l"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " title"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "etajtqOQAu63Sd"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " ("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Rw"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "1"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "R8k"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "),"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "FU"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " year"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Aa0yERzqJy5BC9p"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " ("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Vp"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "1"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "wYz"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "),"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "1G"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " genre"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ML2r0iF0THDdDY"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " ("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Ul"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "1"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "60K"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ")\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "V"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "w"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "0V"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Users"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "wodzHlCmfxqB1r"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "7FM"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " on"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "3"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " email"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "b2Qq7izjSK2stB"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " ("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Xl"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "unique"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "TWryKnj64MsOSx"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "),"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "qN"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " username"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "H75IiR1rzrM"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " ("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "13"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "optional"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "41zaKarUTPHN"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ")\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "l"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "FSc"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "fU"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Create"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "FdhMirwQ84B2X"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " an"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "z"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " index"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "LguZVhLIuGZSaV"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " example"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "9aW5vWkuh36i"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "J"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "n"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "hS"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Y"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".movies"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "8GbmH5t65Akvx"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".create"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "0zTMV9txN65Xd"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "Index"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "wOFsANnCZaLJ7Ef"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "({"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "90"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " title"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "F4H6z8Pjm2Mr76"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ugm"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "BYz"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "1"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "4ql"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ","
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "dIg"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " year"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "CN7jbDmB05gbnKJ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Isi"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "6r"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "1"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "N6d"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " })\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "oDtvHhG0MMAUdVY"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "2"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "me"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " db"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "0"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".users"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "GkgNbjyUlJvxDv"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".create"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "kcTmiqlXw5hDp"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "Index"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "K4Qwz1sdoFMOxiZ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "({"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "c7"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " email"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "uHiU7uGA2j4RkJ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "13t"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "5pW"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "1"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "s7v"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " },"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Q"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " {"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "oL"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " unique"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "EdUtKbEohQbnG"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "fqw"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " true"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "WsdRG4xEVUeQybv"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " })\n\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "JLuc4WSCNRwM4"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "-"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ZuR"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Data"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "4IO4pNStCXCFw8f"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " modeling"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "PnM6cf5gJqR"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " validation"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "2rfPaIS9r"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "4F"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "YV8"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "dv"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Consider"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "6Vi7u1B3Kii"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " adding"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "nw9iRhENIedus"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " schema"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "WxgD8Uo3QbzVK"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " validation"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "myDSHCPox"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " for"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " new"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " data"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "glEryYWitv688UC"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Zf"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "   "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "x"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "8U"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Example"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "L8ykbcxg1tn7"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " ("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Mn"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "simpl"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "XWva8pp9ZExrRgN"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "ified"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "lLWewO1ib2s5fUP"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "):\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "     "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Pa06Wvv0sDr2XU7"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "HO"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " For"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " movies"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "k0uuc0T020dm6"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "KM4"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " required"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "pFiDnQ0aMjx"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " fields"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ffJ7IC63y8erv"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " like"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "NwutPdK9zAdQZEk"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " title"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "N54LAylL7YsBb0"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " year"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "a4QpYc2kSs5NyKC"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "3O"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "     "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "4EQGrLpztESXEMc"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "HY"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " For"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " users"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "RDiCW4Op46NbgM"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ":"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "boz"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " required"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "MLBws5SUjO9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " fields"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "5f88lGbUDG2Sl"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " like"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "TssEUdugcnRKNht"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " email"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "6L6YNGUn7WO7K8"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " password"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "bFbvMWlmhRo"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " hash"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "M8OMPSyP8oSCDvu"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "rU"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Lbs"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "B3"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Decide"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "hF2rH54TGdV0h"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " if"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "P"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " you"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " want"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "29kbNDdb4WU6s5H"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " a"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Z3"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " normalized"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "65Hw36Zhf"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " vs"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "B"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "."
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "4Wz"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " den"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "ormal"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "5kHoi0mWsJZIfA9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "ized"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " structure"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "rBzO1W22nm"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " plan"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "amoKnxOtHxANO8O"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " any"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " migrations"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "14Kl0awbn"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "-"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "8c2"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Data"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "SUzYwgPtZxCWZ7n"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " manipulation"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "VeAHsxw"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " workflows"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ZzXFZNwh6v"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Cy"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "QC8"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "6g"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Insert"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Q1Fh5sV5pvN9g"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " a"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Fz"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " new"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " user"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "5kDyzuKWLLwMVw9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " or"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "i"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " movie"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "0FOAEfUwNWkUXb"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "pS"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "BdX"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "6M"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Update"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "fXYaC5O8RhQyY"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " existing"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "wnWGcCBt4xq"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " documents"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "WfwJGWK6Ve"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Ol"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "bML"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Ho"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Delete"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "94ki7NktPeoW5"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " test"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "NuwkMQg8tU8fuUI"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " data"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "nuRSsLT6mhNDyso"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " you"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " don"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "’t"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "sf"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " need"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "UZPGa2jPMbU1sMi"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Vp"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "r5n"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "st"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Typical"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "PKp7FNIEHmA0"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " queries"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "9ur7tQpWabH4"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " you"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "’ll"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "l"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " likely"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "tiYUvLo04vyjV"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " run"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " ("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "hC"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "adjust"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ot5MPAoxLQnp6B"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " to"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "O"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " your"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "T7fjE5IFCLoMDyd"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " needs"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "rrdNDxPfxFVvP8"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ")\n\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "H0ptdTWsvGLgtmE"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "-"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "WcO"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Back"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "eUj6hLY5gRVU4cV"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "ups"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "v"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " and"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " export"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "HfqSx9G67Xx6n"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Y9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "2Kf"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "v9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Export"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "srDE78f9vBws3"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " data"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "LBHgSgP89GlSki8"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " to"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "D"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " JSON"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "DKYyrD61FQhyadk"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "/"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "xEO"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "CSV"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "K"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " if"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "x"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " you"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " need"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "u59wR9XGI8vPn9k"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " to"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "7"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " share"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "MUcLMGcnRmcEwO"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " or"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "O"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " migrate"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "oqY22IL0iBsO"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "wg"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " "
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "XEg"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " -"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "dm"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " Plan"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "n4yLpSRRO2Q4jhr"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " regular"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "WXgQPSGpulLl"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " backups"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "roQSnXFaw3Ip"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "What"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " would"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "su45XzLuUBmxXI"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " you"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " like"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "t4qNRKeuQcGBLMi"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " to"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "y"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -7541,444 +503,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "C"
+    "obfuscation": "Y"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " first"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "xrYif1xjvoNuX1"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "?"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "IzL"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " I"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "rS"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " can"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " provide"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "tsjeNydk4ZTK"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " exact"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "2JO3UD4jcFIz53"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " commands"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "LdYvoILwog7"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " or"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "W"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " a"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "78"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " small"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "GItY04ejq7agld"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " script"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "1bvb80qbwXDHQ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " for"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " any"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " of"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Q"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " the"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " above"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "GFOHQ0sPJET78l"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " ("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "6n"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "e"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Uc7"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".g"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "9u"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".,"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "qw"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " show"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "gjHBdpR8Rg1avhH"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " me"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "U"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " sample"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Qt4Vx3Ixqw7p9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " docs"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ov4oR0X4fhfzkRO"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -7991,768 +521,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "kJb"
+    "obfuscation": "WGs"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " set"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " up"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "7"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " indexes"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "JDyJrLfl6EEb"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ","
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "2yt"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " or"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "H"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " create"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "hdON7HRwSJFi3"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " a"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "4q"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " validation"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "B9qfzZJ1P"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " rule"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "nnzlCD2vuMuKr8h"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ")."
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "JJ"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " If"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "k"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " you"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " tell"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "nz9Oo6FKNLFFOk1"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " me"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "o"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " your"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "cKUypVgdjY9M5mH"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " goal"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ByHzxPeJk4JRmV2"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " ("
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "PN"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "e"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "cP6"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".g"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "FG"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ".,"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "VO"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " “"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "1H"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "im"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "HC"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "prove"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "reqcUFcwuVCju2a"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " search"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "AU8iRpFcKKtrd"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " for"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " movies"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "UkGNGAUGFH8Ty"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " by"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "J"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " title"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "H3oUQ8u5PoPbOb"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ",”"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "IL"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " or"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Z"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " “"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "7N"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "find"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " a"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "DU"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " user"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "H4lzFZX9PK5Pdst"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " by"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "O"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " email"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "nJQkpAPLJdLa1A"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "”),"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "9"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " I"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "L8"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "’ll"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "f"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " tailor"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "N2J8P2sTzzYNf"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " the"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " steps"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "u4sS6Kyo8lMLrF"
-  },
-  {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
-    "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -8768,9 +542,9 @@
     "obfuscation": ""
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -8778,17 +552,5291 @@
       {
         "index": 0,
         "delta": {
-          "content": " commands"
+          "content": " I"
         },
         "finish_reason": null
       }
     ],
-    "obfuscation": "9phFyfHSFPp"
+    "obfuscation": "82"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " can"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " guide"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "R8iqAJG4JDz53v"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " through"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ggpVOSYnPf1Y"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " it"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "H"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "w"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " simulate"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ZFp0j3heImQ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " the"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " results"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "36SnhPFydH0Y"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nZuPKCbZKpBvv7d"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "37a"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Peek"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "qbsINkL0GpgkCtN"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " at"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "I"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " sample"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0JdZ0XkLeCTZE"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " data"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "cWZzeGQnf8oHzIr"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "JL"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "YCK"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "v1"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "yvhRIRebiG9UW"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "epU"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "T"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "iiChTNLWWjCtq"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "czyKYLOrIEZwMco"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "limit"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1JUsC0RV2T3ILRI"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4Xc"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "5"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "YOG"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ")\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "O"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WeX"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8G"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DkO60Bd10WEPwB"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "SMZ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "m"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DflVMhM98pKTnA"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "KyFmSMF8ul6n6UZ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "limit"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "IaS4xQNYpMDMKit"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hWG"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "5"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "tHE"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ")\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DntZSKdtnrswYfD"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "mgH"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Get"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " counts"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "b8ehG77WZYTqJ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nt"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7Ff"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "az"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "JfaphG0zcrDo9"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " count"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "w7tN1PEANoEv4D"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "m0M"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "V"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "kdYZzlVPWlboJ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".count"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "28Oo38PWi2ZwuW"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Documents"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "NJxezpWPehi"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9SX"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Ft"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "D6XkxaO2QJqzBI"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " count"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0eP3awrjWNbdB5"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "omp"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "5"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "yLygkthUcjRFni"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".count"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "HtEcmAQuPxA2Bl"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Documents"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0kRRCZbRgdb"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "iij7co2DrSrDz1"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1Qy"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Inspect"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6mpQBMpqi4Zv"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Fb"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " single"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "YyyFuuN61ZHrr"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " document"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "dTcriWRpbCd"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " to"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "w"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " understand"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "kGK4HP1hn"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " the"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " schema"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1cgLDhN77Ffps"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "dK"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "KiL"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0f"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "2"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8IaWg6x2KeNoF"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "88O9Et1H2f6pGy9"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "One"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "c"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "bvb"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Ij"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "e"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "zyqyyhIVfZ54P4"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WIwPmaVa1ivKwJI"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "One"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "P"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "tosYyXr8vHWWxy"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WX0"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Explore"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "RyWKCL9LRck6"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "j"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " refine"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hBqSosVqHOuGd"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " queries"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rJfIXtudE0qU"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "xa"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "n9L"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "y5"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "KGIVDb2c0D2GA2X"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "le8fgCZDt3qXU"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " with"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "sU2Ts4Zf6IWyXqf"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " high"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "eHuyaSsy81A7Tkm"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " rating"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "TvupN45tNsYmk"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "k5R"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "T"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "CP9AIajWCcWeW"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ApiKTAEe0WR5MTw"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7C"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " rating"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9hLYxyHe7pnep"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "djI"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " {"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ze"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " $"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "44"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "gt"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "oo"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "O7f"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3Qr"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "8"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "jPe"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " }"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "g8"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " })."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "limit"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4EkppgHvjhPRQV5"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6I7"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "10"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "xZ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ")\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "F"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "BqT"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "fe"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ljgp7dKWWK1hmzg"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "qcxTOuMlndqUTt"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " created"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hCf3wynIwRhN"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " after"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "U6JDLgzofjtVn3"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "08"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " date"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "RnVHQWdhJ3l8u6w"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0Bd"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "H"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nAgORdypTNLjXC"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "O1elf7gYnOHLbpd"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "vp"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " created"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "SzJmRrMfJCIq"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "At"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rB"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "A3E"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " {"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "f2"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " $"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Oo"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "gte"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "F"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "twB"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ISO"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Date"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "(\""
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "202"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "U"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "3"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4T7"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "JLT"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "01"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ms"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "UUV"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "01"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0Z"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\")"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "C"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " }"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Z8"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " })\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Q6k8mAcnbZZjOTk"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "aM3"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "VV"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Pro"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "jections"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "B5UqVYu7QxUY"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "d5"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "only"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " certain"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "sgOrioR2cyHi"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " fields"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "O2lwxay5e84K3"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "):"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1n"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "d"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "U7hRBDIMXp3Ic"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".find"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "h18gak6cTuUmq75"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({},"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " {"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "HU"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " title"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rd0QHUGdTigPEL"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "T9p"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Gbj"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "1"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "wj3"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3qx"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " year"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Z1tqHy7ZDriagiM"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Bwv"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nJt"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "202"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "A"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "0"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "jI6"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8q6"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " _"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "i0"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "id"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Qv"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "HuW"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "wGb"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "0"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3A2"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " })."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "limit"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "TOxL8QCWgKlqiFs"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Nxu"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "5"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3vp"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ")\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "fGuOVq8bO4TwfmX"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "X8f"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Improve"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "RYMsqxUim4UZ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " performance"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "PBWcN9Tp"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " with"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "pGM03xpXy25B6zD"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " indexes"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0uZX1DZ1hz4z"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "vH"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "cNq"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "M3"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Create"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "yG8a3YWe1R7xy"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " index"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "7wuLXj4o0p5Cvh"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " on"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "e"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "59"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " commonly"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "dxjHippkgo4"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " queried"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "2avcf2FUTIwM"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " field"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "TZ6TWNjfI48Tq9"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "80H"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "e"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ucbhaI8yje9LHS"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".create"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hUMTNXNpt0izv"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Index"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "uL8xavm1UIs9Imu"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "tv"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " email"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "FPlNJO63VLb3UI"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "RGw"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "vjm"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "1"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "JPR"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " })\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "E3SMq4Bo1nmCvM9"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Guz"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "4b"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Another"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hpbm4ghMxhE2"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " example"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "N39QNNig694x"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "nPc"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "w"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DA5FnR4TOAsFV"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".create"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "geBwcuUJCFrq1"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Index"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "M6v4Re2GtfeAfE4"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Jl"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " title"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "H4fH4Y3qJ3TnV8"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Sq7"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "kyf"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "1"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Gto"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " })\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "YdJma5D0EGJDY"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Oys"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Add"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " data"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Y33eOUMwkCej9dr"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "K"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " modify"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Vxpfum9fc0xRZ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " structure"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "utfM6gLW1A"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "10"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "C7w"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9c"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Insert"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "exe26iVjbshsj"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "fi"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " new"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " user"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1PuUXS5DXBlXISb"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ITP"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "x"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "mW2PF0BVOEV0YG"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".insert"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Xp5vMht4oVnsK"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "One"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "C"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "fb"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " name"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "KE23S3VCDFqfx9s"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Mh0"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " \""
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Alice"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hktPTUJDHXmTNx1"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "n"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " email"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "T1Q5RXygdKoQhZ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6ul"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " \""
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Z"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "alice"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "5ocDBdZJNloAThm"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "@example"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "MtoI1GdhTlFL"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".com"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "d"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " joined"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "mzhJsRKtQculG"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Gtm"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " new"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Date"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "zKqvT7Z3iuMcIjD"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "()"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "bc"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " })\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "pGHdCGfA3VywMie"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "aJK"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Qx"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Add"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "iz"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " new"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " movie"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "UIhi2OLRYN9pjo"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "FGU"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "N"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ywyNQS92Nb6tV"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".insert"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "wVEPL8IXDc0cv"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "One"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "I"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "({"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "p0"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " title"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "j6O2J8ObS6JV9S"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ThR"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " \""
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "q"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Example"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "31iZTS40MAina"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Movie"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rhgdH4LLD35pKK"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "B"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " year"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "EiMM0kY2a9K4eEx"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "YyQ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Nig"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "202"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "5"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "4"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "TNr"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "T0A"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " rating"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0OD3dKx2fezDP"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "PGq"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "NJ5"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "7"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "zf0"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -8801,12 +5849,1758 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "Sca"
+    "obfuscation": "TjQ"
   },
   {
-    "id": "chatcmpl-DmDmD03XTrIkeotlFmZZCmsu102cC",
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
     "object": "chat.completion.chunk",
-    "created": 1780385073,
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "5"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "HeW"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " })\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "af43TzNKBa2Yt"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "46r"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Aggreg"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "oVBCK6I6Ps8oa"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "ation"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "IfqT4b2VSLGyOhS"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " analysis"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "LCbFsR55WEA"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "g3"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " "
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "xug"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " -"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "1V"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " Count"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "plMaAVORNJSLUV"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " average"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "dEs6UqM79uce"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " rating"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "NJe2PVEXNovG9"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " per"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " year"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "9KZVvrPnm5yCmpC"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "AD0"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " group"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "95GrnBjKefyyyG"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " by"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "b"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " year"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6oqPJ05bvdKcqCZ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "fcW"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " etc"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".:"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ad"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "P"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "DG9RV59YqkP6o"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".aggregate"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "iChMNiTrLo"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "(["
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "np"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " {"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "J3"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " $"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "OF"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "group"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "TKbOvmrY9ASwqml"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "mUt"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " {"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "aS"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " _"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Ur"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "id"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "KV"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Qoh"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " \"$"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "year"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "u"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " avg"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Rating"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "WMZclk3HTE7JYQ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "buu"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " {"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "it"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " $"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "u5"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "avg"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "a"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "otq"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " \"$"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "rating"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "GQQJW5rG0qnuxW"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\""
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Xb"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " }"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "RX"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " }"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "SM"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " }"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "pE"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ])\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hNk4jTTNsAP09"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "If"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "eC"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " tell"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "SCyNeFXEN61j234"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " me"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "u"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " which"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "o7FdDodkr6Tgt6"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " collection"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "zep7z2hT9"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " want"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6fcZ0xV62r99VMi"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " to"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "r"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " start"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "B3TugVEp10HJSz"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " with"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "qgLVzHGXkZ3uAFp"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " what"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "QYWtO7GlFIcYHCd"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " want"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0SYKmQe8GiIzfGa"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " to"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "M"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " learn"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "x15X87QElUy5qY"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " ("
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "sX"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "structure"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "fskPjrmkIOs"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "pl6"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " counts"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "IjgDJG8uMz5vf"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "vam"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "3d"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " specific"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "zp7H5eznzj9"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " query"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "MFqyqJEcpb59LH"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "dzw"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " creating"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "oZDCvmOgILG"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " an"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "6"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " index"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8tfuE46tFIXBzO"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hTD"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " etc"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ".),"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "v"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " I"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "lo"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "’ll"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "w"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " tailor"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "mtKR6WjeWAdg8"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " the"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " steps"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "wQPaSE6xqqeSpl"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " and"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " provide"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ZEU7te6P6EQH"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " exact"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "tWigRgzvhKVcwM"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " commands"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "TcjRgI5GwU9"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "z"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " even"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ZvcEYYaaHgahQZX"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " mock"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "EeCsOVLgFgTUuqQ"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " results"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "aGlATEoiGvsv"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "."
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "rcA"
+  },
+  {
+    "id": "chatcmpl-DmPMBVKlt0TZDui2inxzBkLypnGBP",
+    "object": "chat.completion.chunk",
+    "created": 1780429587,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -8817,6 +7611,6 @@
         "finish_reason": "stop"
       }
     ],
-    "obfuscation": "vFPSgEiocrYaGV"
+    "obfuscation": "6bMq1uQlAGzEbt"
   }
 ]

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/followup-response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-DmDmCmwbIKyuqIeuk6eJXHqiOFUzI",
+  "object": "chat.completion",
+  "created": 1780385072,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Great. With the collections identified (movies and users), here are practical next steps to explore and work with your data. I’ve included example commands you can run in your MongoDB client (mongosh or a driver).\n\n1) Peek at sample documents\n- Movies: db.movies.find({}).limit(5).pretty()\n- Users: db.users.find({}).limit(5).pretty()\n\n2) Check data shape and counts\n- Rough counts: db.movies.estimatedDocumentCount(), db.users.estimatedDocumentCount()\n- Look at a sample document to see fields: db.movies.findOne(), db.users.findOne()\n\n3) Review existing indexes\n- Movies: db.movies.getIndexes()\n- Users: db.users.getIndexes()\n\n4) Add helpful indexes (if not present)\n- On common query fields, e.g.:\n  - db.movies.createIndex({ title: 1 })\n  - db.users.createIndex({ email: 1 }, { unique: true })\n\n5) Quick data profiling with aggregation\n- Group by a field (e.g., genre) to summarize:\n  - db.movies.aggregate([{ $group: { _id: \"$genre\", count: { $sum: 1 } } }])\n- Count active users, etc., based on a status field if you have one.\n\n6) Check for missing or inconsistent data\n- Find documents missing a field:\n  - db.movies.find({ title: { $exists: false } }).limit(10)\n  - db.users.find({ email: { $exists: false } }).limit(10)\n\n7) Basic data quality and validation\n- If you use schemas (via schemas in MongoDB or your app layer), review required fields, types, and constraints.\n- Consider setting up simple validators if you’re on a modern MongoDB version.\n\n8) Security and maintenance\n- Review user roles and authentication settings.\n- Plan backups and, if needed, replication/sharding strategy for scale.\n\nIf you tell me your goal (e.g., “find users who signed up last 30 days,” “list movies by genre,” “ensure emails are unique,” or “set up an index for fast lookups”), I can tailor exact commands and a small, ready-to-run plan for you. Would you like me to draft a specific query or index plan based on a particular use case?",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 203,
+    "completion_tokens": 1635,
+    "total_tokens": 1838,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 1152,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/followup-response.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/followup-response.json
@@ -1,14 +1,14 @@
 {
-  "id": "chatcmpl-DmDmCmwbIKyuqIeuk6eJXHqiOFUzI",
+  "id": "chatcmpl-DmPMB2veUsWTjPwIz3wOr2ecUODwf",
   "object": "chat.completion",
-  "created": 1780385072,
+  "created": 1780429587,
   "model": "gpt-5-nano-2025-08-07",
   "choices": [
     {
       "index": 0,
       "message": {
         "role": "assistant",
-        "content": "Great. With the collections identified (movies and users), here are practical next steps to explore and work with your data. I’ve included example commands you can run in your MongoDB client (mongosh or a driver).\n\n1) Peek at sample documents\n- Movies: db.movies.find({}).limit(5).pretty()\n- Users: db.users.find({}).limit(5).pretty()\n\n2) Check data shape and counts\n- Rough counts: db.movies.estimatedDocumentCount(), db.users.estimatedDocumentCount()\n- Look at a sample document to see fields: db.movies.findOne(), db.users.findOne()\n\n3) Review existing indexes\n- Movies: db.movies.getIndexes()\n- Users: db.users.getIndexes()\n\n4) Add helpful indexes (if not present)\n- On common query fields, e.g.:\n  - db.movies.createIndex({ title: 1 })\n  - db.users.createIndex({ email: 1 }, { unique: true })\n\n5) Quick data profiling with aggregation\n- Group by a field (e.g., genre) to summarize:\n  - db.movies.aggregate([{ $group: { _id: \"$genre\", count: { $sum: 1 } } }])\n- Count active users, etc., based on a status field if you have one.\n\n6) Check for missing or inconsistent data\n- Find documents missing a field:\n  - db.movies.find({ title: { $exists: false } }).limit(10)\n  - db.users.find({ email: { $exists: false } }).limit(10)\n\n7) Basic data quality and validation\n- If you use schemas (via schemas in MongoDB or your app layer), review required fields, types, and constraints.\n- Consider setting up simple validators if you’re on a modern MongoDB version.\n\n8) Security and maintenance\n- Review user roles and authentication settings.\n- Plan backups and, if needed, replication/sharding strategy for scale.\n\nIf you tell me your goal (e.g., “find users who signed up last 30 days,” “list movies by genre,” “ensure emails are unique,” or “set up an index for fast lookups”), I can tailor exact commands and a small, ready-to-run plan for you. Would you like me to draft a specific query or index plan based on a particular use case?",
+        "content": "Nice. Since you have two collections (movies and users), a good next move is to explore the data a bit more to understand its shape and contents. Here are practical options—pick what matches your goal, and I can walk you through it or run it if you want.\n\nRecommended quick start\n- Peek a few documents from each collection:\n  - Movies: db.movies.find({}).limit(5)\n  - Users: db.users.find({}).limit(5)\n\nOther useful next steps\n- Get document counts:\n  - Movies: db.movies.countDocuments({})\n  - Users: db.users.countDocuments({})\n\n- Inspect indexes (to see what’s optimized):\n  - Movies: db.movies.getIndexes()\n  - Users: db.users.getIndexes()\n\n- Create helpful indexes (example):\n  - Movies: db.movies.createIndex({ year: 1 })\n  - Users: db.users.createIndex({ email: 1 }, { unique: true })\n\n- Simple aggregations to summarize data:\n  - Movies by year: db.movies.aggregate([{ $group: { _id: \"$year\", count: { $sum: 1 } } }, { $sort: { _id: 1 } }])\n  - Users by country: db.users.aggregate([{ $group: { _id: \"$country\", count: { $sum: 1 } } }, { $sort: { _id: 1 } }])\n\n- Add or modify data:\n  - Insert a movie: db.movies.insertOne({ title: \"New Movie\", year: 2024, genre: \"Drama\" })\n  - Update a user: db.users.updateOne({ _id: ObjectId(\"...\") }, { $set: { lastLogin: new Date() } })\n\n- Data export/import (backup or migration):\n  - Export a collection: mongoexport --db mydb --collection movies --out movies.json\n\n- Validate or enforce schema basics (MongoDB schema validation is optional but helpful for consistency):\n  - Examples: require certain fields, set types, or enforce unique emails on users\n\nTell me which option sounds best, or describe your specific goal (e.g., “I want to find all movies from 2015 in genre X” or “I want to know how many users signed up per month”), and I’ll provide step-by-step commands or guide you through it. If you’d like, I can also suggest a concrete next action based on your objective.",
         "refusal": null,
         "annotations": []
       },
@@ -17,14 +17,14 @@
   ],
   "usage": {
     "prompt_tokens": 203,
-    "completion_tokens": 1635,
-    "total_tokens": 1838,
+    "completion_tokens": 2235,
+    "total_tokens": 2438,
     "prompt_tokens_details": {
       "cached_tokens": 0,
       "audio_tokens": 0
     },
     "completion_tokens_details": {
-      "reasoning_tokens": 1152,
+      "reasoning_tokens": 1728,
       "audio_tokens": 0,
       "accepted_prediction_tokens": 0,
       "rejected_prediction_tokens": 0

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/request.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/request.json
@@ -1,0 +1,50 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": "List the collections in the mydb database."
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "reasoning_signature": "dGhvdWdodF9zaWduYXR1cmVfMTIz",
+      "tool_calls": [
+        {
+          "id": "call_123",
+          "type": "function",
+          "function": {
+            "name": "list_collections",
+            "arguments": "{\"database\":\"mydb\"}"
+          }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_123",
+      "content": "[\"movies\",\"users\"]"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "list_collections",
+        "description": "List the collections in a MongoDB database.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "database": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "database"
+          ]
+        }
+      }
+    }
+  ],
+  "tool_choice": "auto"
+}

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/response-streaming.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/response-streaming.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -17,12 +17,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "YG"
+    "obfuscation": "HS"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -30,17 +30,35 @@
       {
         "index": 0,
         "delta": {
-          "content": "Collections"
+          "content": "The"
         },
         "finish_reason": null
       }
     ],
-    "obfuscation": "41RIeDtWt"
+    "obfuscation": "d"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " collections"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "0mOZeWFQ"
+  },
+  {
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
+    "object": "chat.completion.chunk",
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -53,12 +71,30 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "H"
+    "obfuscation": "b"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " the"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
+    "object": "chat.completion.chunk",
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -71,12 +107,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "h"
+    "obfuscation": "q"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -89,12 +125,48 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "8K"
+    "obfuscation": "GJ"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " database"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "dFl5SyiikNU"
+  },
+  {
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
+    "object": "chat.completion.chunk",
+    "created": 1780429585,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " are"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
+    "object": "chat.completion.chunk",
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -107,12 +179,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "d"
+    "obfuscation": "r"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -125,12 +197,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "Yui"
+    "obfuscation": "Q0n"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -143,12 +215,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "eOfOX9aRG53kb"
+    "obfuscation": "k0zDHwyySeL34"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -161,12 +233,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "iL"
+    "obfuscation": "Wk"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -179,12 +251,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "2ne"
+    "obfuscation": "cbC"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -197,318 +269,12 @@
         "finish_reason": null
       }
     ],
-    "obfuscation": "MfZGi8kHnUuCni"
+    "obfuscation": "s8hOouJRoj7ErI"
   },
   {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "id": "chatcmpl-DmPM9XXp4EmwUjbmcNrRF1uY3BIVc",
     "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "\n\n"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "Would"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "qk5MzukCJsJ8AT1"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " you"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": ""
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " like"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "ERgevwP12H4qXoS"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " document"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "pnyte57tr6O"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " counts"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "XfBiG2lgsPT8l"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ","
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "67T"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " sample"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "mGsWPPaocrttA"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " documents"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "hZGA0zhfGl"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": ","
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "75C"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " or"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "n"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " details"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "yW2fgU0A1d7F"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " from"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "jW2nu6yC4qKF1Dj"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " a"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Fg"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " specific"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "pFCJPQy4M5T"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": " collection"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "RqRZijej5"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
-    "model": "gpt-5-nano-2025-08-07",
-    "service_tier": "default",
-    "system_fingerprint": null,
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "content": "?"
-        },
-        "finish_reason": null
-      }
-    ],
-    "obfuscation": "Fnr"
-  },
-  {
-    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
-    "object": "chat.completion.chunk",
-    "created": 1780385070,
+    "created": 1780429585,
     "model": "gpt-5-nano-2025-08-07",
     "service_tier": "default",
     "system_fingerprint": null,
@@ -519,6 +285,6 @@
         "finish_reason": "stop"
       }
     ],
-    "obfuscation": "IbziF59xQQovBK"
+    "obfuscation": "tdLrVWDvnJMrSw"
   }
 ]

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/response-streaming.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/response-streaming.json
@@ -1,0 +1,524 @@
+[
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "role": "assistant",
+          "content": "",
+          "refusal": null
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "YG"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Collections"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "41RIeDtWt"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " in"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "H"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " my"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "h"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "db"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "8K"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ":\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "d"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Yui"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " movies"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "eOfOX9aRG53kb"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "iL"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "-"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "2ne"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " users"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "MfZGi8kHnUuCni"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "\n\n"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Would"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "qk5MzukCJsJ8AT1"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " you"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": ""
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " like"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "ERgevwP12H4qXoS"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " document"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "pnyte57tr6O"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " counts"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "XfBiG2lgsPT8l"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "67T"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " sample"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "mGsWPPaocrttA"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " documents"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "hZGA0zhfGl"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": ","
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "75C"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " or"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "n"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " details"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "yW2fgU0A1d7F"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " from"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "jW2nu6yC4qKF1Dj"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " a"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Fg"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " specific"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "pFCJPQy4M5T"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": " collection"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "RqRZijej5"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "?"
+        },
+        "finish_reason": null
+      }
+    ],
+    "obfuscation": "Fnr"
+  },
+  {
+    "id": "chatcmpl-DmDmAj4qMzAOEjXo4r5OwXwyr173p",
+    "object": "chat.completion.chunk",
+    "created": 1780385070,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {},
+        "finish_reason": "stop"
+      }
+    ],
+    "obfuscation": "IbziF59xQQovBK"
+  }
+]

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/response.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/response.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-DmDmA9sYLUEp3kPtZhFwTr3ouzjy7",
+  "object": "chat.completion",
+  "created": 1780385070,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The collections in the mydb database are:\n- movies\n- users",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 173,
+    "completion_tokens": 215,
+    "total_tokens": 388,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 192,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/response.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/chat-completions/response.json
@@ -1,7 +1,7 @@
 {
-  "id": "chatcmpl-DmDmA9sYLUEp3kPtZhFwTr3ouzjy7",
+  "id": "chatcmpl-DmPM9Fei1v4cr1qkaSLx00f5mDlBT",
   "object": "chat.completion",
-  "created": 1780385070,
+  "created": 1780429585,
   "model": "gpt-5-nano-2025-08-07",
   "choices": [
     {
@@ -17,14 +17,14 @@
   ],
   "usage": {
     "prompt_tokens": 173,
-    "completion_tokens": 215,
-    "total_tokens": 388,
+    "completion_tokens": 151,
+    "total_tokens": 324,
     "prompt_tokens_details": {
       "cached_tokens": 0,
       "audio_tokens": 0
     },
     "completion_tokens_details": {
-      "reasoning_tokens": 192,
+      "reasoning_tokens": 128,
       "audio_tokens": 0,
       "accepted_prediction_tokens": 0,
       "rejected_prediction_tokens": 0

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-request.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-request.json
@@ -1,0 +1,81 @@
+{
+  "contents": [
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "List the collections in the mydb database."
+        }
+      ]
+    },
+    {
+      "role": "model",
+      "parts": [
+        {
+          "functionCall": {
+            "id": "call_123",
+            "name": "list_collections",
+            "args": {
+              "database": "mydb"
+            }
+          },
+          "thoughtSignature": "dGhvdWdodF9zaWduYXR1cmVfMTIz"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "parts": [
+        {
+          "functionResponse": {
+            "id": "call_123",
+            "name": "list_collections",
+            "response": {
+              "output": [
+                "movies",
+                "users"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "role": "model",
+      "parts": [
+        {
+          "text": "The collections in the `mydb` database are `movies` and `users`."
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "What should I do next?"
+        }
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "functionDeclarations": [
+        {
+          "name": "list_collections",
+          "description": "List the collections in a MongoDB database.",
+          "parameters": {
+            "type": "OBJECT",
+            "properties": {
+              "database": {
+                "type": "STRING"
+              }
+            },
+            "required": [
+              "database"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-request.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-request.json
@@ -13,7 +13,6 @@
       "parts": [
         {
           "functionCall": {
-            "id": "call_123",
             "name": "list_collections",
             "args": {
               "database": "mydb"
@@ -28,7 +27,6 @@
       "parts": [
         {
           "functionResponse": {
-            "id": "call_123",
             "name": "list_collections",
             "response": {
               "output": [
@@ -44,7 +42,7 @@
       "role": "model",
       "parts": [
         {
-          "text": "The collections in the `mydb` database are `movies` and `users`."
+          "text": "The collections in the 'mydb' database are: movies, users."
         }
       ]
     },

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-response-streaming.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-response-streaming.json
@@ -5,8 +5,7 @@
         "content": {
           "parts": [
             {
-              "text": "I'",
-              "thoughtSignature": "Cl0BDDnWx7h2ZnTXKMbSAdIb3jby8Vv4YThyzs3ZaKZp5ny6y93qTXf9zQuda1ICQ4BjluueKF2ogY2WMIOg9OGuK/T7O1OW7FqWwMHDBVE3uEVff6wCcJ0Q1XSeFmAKjQIBDDnWx/SUcrNRQ+RTa7ZXs8MBxliFnhWoaahq4+YtmESa3WPIUyyAnJsw9zhvOqFmVV+S2aPatjMkCahl4+X8HdMMrUmcajUejHBd8jbTtUSY190z1zOPPwbKo71Ht3yMoQklxGtIYZYKv3WIYAacBfGBz4RD40KQjTmF7rLwcf4JSIi7xbMW8F3+6PYjVN/w8z0WBF1sohuxaF6w8Czpv19umTsNdz9H1wAC36tBadoj6mwSCvSPYg6YQwRSHFECPPI/ZLc5wA9FISQ7G3k/F/ZECDzeRVaEzhepkAc3TVOkmA0q+Cnzskz8YdglLChZRd2VrWjrPQnErdJX/xdz/QW6BPXeWO35QtjMjQ=="
+              "text": "I can help you"
             }
           ],
           "role": "model"
@@ -15,20 +14,19 @@
       }
     ],
     "usageMetadata": {
-      "promptTokenCount": 107,
-      "candidatesTokenCount": 2,
-      "totalTokenCount": 168,
+      "promptTokenCount": 105,
+      "candidatesTokenCount": 4,
+      "totalTokenCount": 109,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
-          "tokenCount": 107
+          "tokenCount": 105
         }
       ],
-      "thoughtsTokenCount": 59,
       "serviceTier": "standard"
     },
     "modelVersion": "gemini-2.5-flash",
-    "responseId": "LoUeareVPNDK_uMPqJKf6Aw"
+    "responseId": "EjMfasnPAdKJz7IPsNTVeA"
   },
   {
     "candidates": [
@@ -36,7 +34,7 @@
         "content": {
           "parts": [
             {
-              "text": "m not sure what you mean by \"next\". Could you please provide more context? For example, are you looking to:\n\n*   **Query one of the collections?** (e.g., \"Show me all movies released in 20"
+              "text": " with a few more things related to MongoDB. Do you want to:\n\n1"
             }
           ],
           "role": "model"
@@ -45,20 +43,19 @@
       }
     ],
     "usageMetadata": {
-      "promptTokenCount": 107,
-      "candidatesTokenCount": 53,
-      "totalTokenCount": 219,
+      "promptTokenCount": 105,
+      "candidatesTokenCount": 20,
+      "totalTokenCount": 125,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
-          "tokenCount": 107
+          "tokenCount": 105
         }
       ],
-      "thoughtsTokenCount": 59,
       "serviceTier": "standard"
     },
     "modelVersion": "gemini-2.5-flash",
-    "responseId": "LoUeareVPNDK_uMPqJKf6Aw"
+    "responseId": "EjMfasnPAdKJz7IPsNTVeA"
   },
   {
     "candidates": [
@@ -66,7 +63,7 @@
         "content": {
           "parts": [
             {
-              "text": "23.\")\n*   **Add data to a collection?** (e.g., \"Add a new user to the 'users' collection.\")\n*   **Perform a different database operation?**\n*   **Do something completely unrelated"
+              "text": ". **List documents in a collection?** (e.g., \"List all movies in the 'movies' collection.\")\n2. **Find a specific document in a collection?** (e.g., \"Find the user named"
             }
           ],
           "role": "model"
@@ -75,20 +72,19 @@
       }
     ],
     "usageMetadata": {
-      "promptTokenCount": 107,
-      "candidatesTokenCount": 103,
-      "totalTokenCount": 269,
+      "promptTokenCount": 105,
+      "candidatesTokenCount": 68,
+      "totalTokenCount": 173,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
-          "tokenCount": 107
+          "tokenCount": 105
         }
       ],
-      "thoughtsTokenCount": 59,
       "serviceTier": "standard"
     },
     "modelVersion": "gemini-2.5-flash",
-    "responseId": "LoUeareVPNDK_uMPqJKf6Aw"
+    "responseId": "EjMfasnPAdKJz7IPsNTVeA"
   },
   {
     "candidates": [
@@ -96,7 +92,65 @@
         "content": {
           "parts": [
             {
-              "text": " to databases?**"
+              "text": " 'John Doe' in the 'users' collection.\")\n3. **Insert a new document into a collection?** (e.g., \"Add a new movie titled 'The Matrix' to the 'movies' collection.\")\n4. **Update"
+            }
+          ],
+          "role": "model"
+        },
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 105,
+      "candidatesTokenCount": 119,
+      "totalTokenCount": 224,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 105
+        }
+      ],
+      "serviceTier": "standard"
+    },
+    "modelVersion": "gemini-2.5-flash",
+    "responseId": "EjMfasnPAdKJz7IPsNTVeA"
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": " an existing document in a collection?** (e.g., \"Change the genre of 'The Matrix' to 'Sci-Fi'.\")\n5. **Delete a document from a collection?** (e.g., \"Delete"
+            }
+          ],
+          "role": "model"
+        },
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 105,
+      "candidatesTokenCount": 167,
+      "totalTokenCount": 272,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 105
+        }
+      ],
+      "serviceTier": "standard"
+    },
+    "modelVersion": "gemini-2.5-flash",
+    "responseId": "EjMfasnPAdKJz7IPsNTVeA"
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": " the movie 'The Matrix'.\")\n\nLet me know what you'd like to do!"
             }
           ],
           "role": "model"
@@ -106,19 +160,18 @@
       }
     ],
     "usageMetadata": {
-      "promptTokenCount": 107,
-      "candidatesTokenCount": 107,
-      "totalTokenCount": 273,
+      "promptTokenCount": 105,
+      "candidatesTokenCount": 186,
+      "totalTokenCount": 291,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
-          "tokenCount": 107
+          "tokenCount": 105
         }
       ],
-      "thoughtsTokenCount": 59,
       "serviceTier": "standard"
     },
     "modelVersion": "gemini-2.5-flash",
-    "responseId": "LoUeareVPNDK_uMPqJKf6Aw"
+    "responseId": "EjMfasnPAdKJz7IPsNTVeA"
   }
 ]

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-response-streaming.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-response-streaming.json
@@ -1,0 +1,124 @@
+[
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": "I'",
+              "thoughtSignature": "Cl0BDDnWx7h2ZnTXKMbSAdIb3jby8Vv4YThyzs3ZaKZp5ny6y93qTXf9zQuda1ICQ4BjluueKF2ogY2WMIOg9OGuK/T7O1OW7FqWwMHDBVE3uEVff6wCcJ0Q1XSeFmAKjQIBDDnWx/SUcrNRQ+RTa7ZXs8MBxliFnhWoaahq4+YtmESa3WPIUyyAnJsw9zhvOqFmVV+S2aPatjMkCahl4+X8HdMMrUmcajUejHBd8jbTtUSY190z1zOPPwbKo71Ht3yMoQklxGtIYZYKv3WIYAacBfGBz4RD40KQjTmF7rLwcf4JSIi7xbMW8F3+6PYjVN/w8z0WBF1sohuxaF6w8Czpv19umTsNdz9H1wAC36tBadoj6mwSCvSPYg6YQwRSHFECPPI/ZLc5wA9FISQ7G3k/F/ZECDzeRVaEzhepkAc3TVOkmA0q+Cnzskz8YdglLChZRd2VrWjrPQnErdJX/xdz/QW6BPXeWO35QtjMjQ=="
+            }
+          ],
+          "role": "model"
+        },
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 107,
+      "candidatesTokenCount": 2,
+      "totalTokenCount": 168,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 107
+        }
+      ],
+      "thoughtsTokenCount": 59,
+      "serviceTier": "standard"
+    },
+    "modelVersion": "gemini-2.5-flash",
+    "responseId": "LoUeareVPNDK_uMPqJKf6Aw"
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": "m not sure what you mean by \"next\". Could you please provide more context? For example, are you looking to:\n\n*   **Query one of the collections?** (e.g., \"Show me all movies released in 20"
+            }
+          ],
+          "role": "model"
+        },
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 107,
+      "candidatesTokenCount": 53,
+      "totalTokenCount": 219,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 107
+        }
+      ],
+      "thoughtsTokenCount": 59,
+      "serviceTier": "standard"
+    },
+    "modelVersion": "gemini-2.5-flash",
+    "responseId": "LoUeareVPNDK_uMPqJKf6Aw"
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": "23.\")\n*   **Add data to a collection?** (e.g., \"Add a new user to the 'users' collection.\")\n*   **Perform a different database operation?**\n*   **Do something completely unrelated"
+            }
+          ],
+          "role": "model"
+        },
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 107,
+      "candidatesTokenCount": 103,
+      "totalTokenCount": 269,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 107
+        }
+      ],
+      "thoughtsTokenCount": 59,
+      "serviceTier": "standard"
+    },
+    "modelVersion": "gemini-2.5-flash",
+    "responseId": "LoUeareVPNDK_uMPqJKf6Aw"
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": " to databases?**"
+            }
+          ],
+          "role": "model"
+        },
+        "finishReason": "STOP",
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 107,
+      "candidatesTokenCount": 107,
+      "totalTokenCount": 273,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 107
+        }
+      ],
+      "thoughtsTokenCount": 59,
+      "serviceTier": "standard"
+    },
+    "modelVersion": "gemini-2.5-flash",
+    "responseId": "LoUeareVPNDK_uMPqJKf6Aw"
+  }
+]

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-response.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-response.json
@@ -4,8 +4,7 @@
       "content": {
         "parts": [
           {
-            "text": "You could try inserting, finding, updating, or deleting documents within one of the collections. What would you like to do?",
-            "thoughtSignature": "CssDAQw51sebZ2IO/6FLyjjQzcQGmwIuyqAGl7CYIcFN660Fb1q/wllLPvo7PiRISQpmsau1/EKI6jhkwLLKjZR8kUESk9U6nG4xw2QHj0QeLlT2bZjz14vK3dQI99kMdIZZFzP7Q3B1puCcPCpgFOT7eKxnq4gBNRUU2jL6RCio52gy8B90htz9zrvAl5+nip7JZNxjYt3mBjtXfQhz8AlQJFHTLrsa9FK2006IjFmLoogmFyUV3E1jpGqk6wgSC9vP42brgLRJF3a1aJAkvjJa3Pl1mRhFseupJJg24QyPbZ/B2DfM1BMJOZ/bnR1UQfMzru91MWm8pcT9U/1rTt50NFhaIoDo7AV3hSYXGdf9+i0KSiAI76tU1h4zkc8TKeSJUzx2RgeoPm/SKUHeoJ8Z02WLYZvwz+Py5ZyaN5YdnCsJ8VSaZqHJrE1OO9GsP7YjVQcYw6CQZX4flo9xUqySwZJ8GaSfbz8b9XwTNm6QSSwbkjfOXR3PJrcFOH9eN0QoJw+rXTTtbg7p8ZOIYbxj+hP0Gf2QYTjd0TPjFr+I/IiW+U9iS3RFXoap+OvmxvNX+R1oDVdsavbEmacuUhgGASjpOlTDg4x3X3MN"
+            "text": "That depends on what you're trying to achieve! Since you've just listed the collections, perhaps you'd like to:\n\n*   **View the documents within a collection:** You could specify a collection name and ask to see what's inside.\n*   **Query a collection:** If you're looking for specific data, you could ask to search a collection with certain criteria.\n*   **Add data to a collection:** If you're building up your database, you might want to insert new documents.\n*   **Update or delete data:** If you need to modify existing information.\n\nCould you tell me what you're interested in doing with the `movies` or `users` collections?"
           }
         ],
         "role": "model"
@@ -15,18 +14,17 @@
     }
   ],
   "usageMetadata": {
-    "promptTokenCount": 107,
-    "candidatesTokenCount": 25,
-    "totalTokenCount": 215,
+    "promptTokenCount": 105,
+    "candidatesTokenCount": 148,
+    "totalTokenCount": 253,
     "promptTokensDetails": [
       {
         "modality": "TEXT",
-        "tokenCount": 107
+        "tokenCount": 105
       }
     ],
-    "thoughtsTokenCount": 83,
     "serviceTier": "standard"
   },
   "modelVersion": "gemini-2.5-flash",
-  "responseId": "LoUeauzsOLfL_uMP_p-iyAw"
+  "responseId": "ETMfaqCnPMjqz7IPpqqj8AI"
 }

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-response.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/followup-response.json
@@ -1,0 +1,32 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "You could try inserting, finding, updating, or deleting documents within one of the collections. What would you like to do?",
+            "thoughtSignature": "CssDAQw51sebZ2IO/6FLyjjQzcQGmwIuyqAGl7CYIcFN660Fb1q/wllLPvo7PiRISQpmsau1/EKI6jhkwLLKjZR8kUESk9U6nG4xw2QHj0QeLlT2bZjz14vK3dQI99kMdIZZFzP7Q3B1puCcPCpgFOT7eKxnq4gBNRUU2jL6RCio52gy8B90htz9zrvAl5+nip7JZNxjYt3mBjtXfQhz8AlQJFHTLrsa9FK2006IjFmLoogmFyUV3E1jpGqk6wgSC9vP42brgLRJF3a1aJAkvjJa3Pl1mRhFseupJJg24QyPbZ/B2DfM1BMJOZ/bnR1UQfMzru91MWm8pcT9U/1rTt50NFhaIoDo7AV3hSYXGdf9+i0KSiAI76tU1h4zkc8TKeSJUzx2RgeoPm/SKUHeoJ8Z02WLYZvwz+Py5ZyaN5YdnCsJ8VSaZqHJrE1OO9GsP7YjVQcYw6CQZX4flo9xUqySwZJ8GaSfbz8b9XwTNm6QSSwbkjfOXR3PJrcFOH9eN0QoJw+rXTTtbg7p8ZOIYbxj+hP0Gf2QYTjd0TPjFr+I/IiW+U9iS3RFXoap+OvmxvNX+R1oDVdsavbEmacuUhgGASjpOlTDg4x3X3MN"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 107,
+    "candidatesTokenCount": 25,
+    "totalTokenCount": 215,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 107
+      }
+    ],
+    "thoughtsTokenCount": 83,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "LoUeauzsOLfL_uMP_p-iyAw"
+}

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/request.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/request.json
@@ -1,0 +1,65 @@
+{
+  "contents": [
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "List the collections in the mydb database."
+        }
+      ]
+    },
+    {
+      "role": "model",
+      "parts": [
+        {
+          "functionCall": {
+            "id": "call_123",
+            "name": "list_collections",
+            "args": {
+              "database": "mydb"
+            }
+          },
+          "thoughtSignature": "dGhvdWdodF9zaWduYXR1cmVfMTIz"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "parts": [
+        {
+          "functionResponse": {
+            "id": "call_123",
+            "name": "list_collections",
+            "response": {
+              "output": [
+                "movies",
+                "users"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "functionDeclarations": [
+        {
+          "name": "list_collections",
+          "description": "List the collections in a MongoDB database.",
+          "parameters": {
+            "type": "OBJECT",
+            "properties": {
+              "database": {
+                "type": "STRING"
+              }
+            },
+            "required": [
+              "database"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/request.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/request.json
@@ -13,7 +13,6 @@
       "parts": [
         {
           "functionCall": {
-            "id": "call_123",
             "name": "list_collections",
             "args": {
               "database": "mydb"
@@ -28,7 +27,6 @@
       "parts": [
         {
           "functionResponse": {
-            "id": "call_123",
             "name": "list_collections",
             "response": {
               "output": [

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/response-streaming.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/response-streaming.json
@@ -26,7 +26,7 @@
       "serviceTier": "standard"
     },
     "modelVersion": "gemini-2.5-flash",
-    "responseId": "LoUeasnOFrfL_uMP9Z-iyAw"
+    "responseId": "ETMfasOQCMHhz7IPzdfmmA8"
   },
   {
     "candidates": [
@@ -34,7 +34,7 @@
         "content": {
           "parts": [
             {
-              "text": " `mydb` database are `movies` and `users`."
+              "text": " `mydb` database are: `movies` and `users`."
             }
           ],
           "role": "model"
@@ -45,8 +45,8 @@
     ],
     "usageMetadata": {
       "promptTokenCount": 83,
-      "candidatesTokenCount": 16,
-      "totalTokenCount": 99,
+      "candidatesTokenCount": 17,
+      "totalTokenCount": 100,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
@@ -56,6 +56,6 @@
       "serviceTier": "standard"
     },
     "modelVersion": "gemini-2.5-flash",
-    "responseId": "LoUeasnOFrfL_uMP9Z-iyAw"
+    "responseId": "ETMfasOQCMHhz7IPzdfmmA8"
   }
 ]

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/response-streaming.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/response-streaming.json
@@ -1,0 +1,61 @@
+[
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": "The collections in the"
+            }
+          ],
+          "role": "model"
+        },
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 83,
+      "candidatesTokenCount": 4,
+      "totalTokenCount": 87,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 83
+        }
+      ],
+      "serviceTier": "standard"
+    },
+    "modelVersion": "gemini-2.5-flash",
+    "responseId": "LoUeasnOFrfL_uMP9Z-iyAw"
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": " `mydb` database are `movies` and `users`."
+            }
+          ],
+          "role": "model"
+        },
+        "finishReason": "STOP",
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 83,
+      "candidatesTokenCount": 16,
+      "totalTokenCount": 99,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 83
+        }
+      ],
+      "serviceTier": "standard"
+    },
+    "modelVersion": "gemini-2.5-flash",
+    "responseId": "LoUeasnOFrfL_uMP9Z-iyAw"
+  }
+]

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/response.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/response.json
@@ -4,7 +4,7 @@
       "content": {
         "parts": [
           {
-            "text": "The collections in the `mydb` database are `movies` and `users`."
+            "text": "The collections in the 'mydb' database are: movies, users."
           }
         ],
         "role": "model"
@@ -15,8 +15,8 @@
   ],
   "usageMetadata": {
     "promptTokenCount": 83,
-    "candidatesTokenCount": 16,
-    "totalTokenCount": 99,
+    "candidatesTokenCount": 14,
+    "totalTokenCount": 97,
     "promptTokensDetails": [
       {
         "modality": "TEXT",
@@ -26,5 +26,5 @@
     "serviceTier": "standard"
   },
   "modelVersion": "gemini-2.5-flash",
-  "responseId": "LoUeasfqF9DK_uMPqJKf6Aw"
+  "responseId": "ETMfauKeCKeGz7IP4sKaoAQ"
 }

--- a/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/response.json
+++ b/payloads/snapshots/googleToolCallThoughtSignatureReplayParam/google/response.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The collections in the `mydb` database are `movies` and `users`."
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 83,
+    "candidatesTokenCount": 16,
+    "totalTokenCount": 99,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 83
+      }
+    ],
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "LoUeasfqF9DK_uMPqJKf6Aw"
+}

--- a/payloads/transforms/chat-completions_to_anthropic/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/chat-completions_to_anthropic/googleToolCallThoughtSignatureReplayParam.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_015LQHcNzXwfqPkWxys7rTWo",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "The collections in the **mydb** database are:\n\n1. **movies**\n2. **users**"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 639,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 26,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/payloads/transforms/chat-completions_to_anthropic/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/chat-completions_to_anthropic/googleToolCallThoughtSignatureReplayParam.json
@@ -1,6 +1,6 @@
 {
   "model": "claude-sonnet-4-5-20250929",
-  "id": "msg_015LQHcNzXwfqPkWxys7rTWo",
+  "id": "msg_01S9JLYYZe4k5uctkuMhmrhv",
   "type": "message",
   "role": "assistant",
   "content": [

--- a/payloads/transforms/chat-completions_to_bedrock/googleToolCallThoughtSignatureReplayParam-streaming.json
+++ b/payloads/transforms/chat-completions_to_bedrock/googleToolCallThoughtSignatureReplayParam-streaming.json
@@ -7,7 +7,7 @@
   {
     "contentBlockDelta": {
       "delta": {
-        "text": "The **"
+        "text": "The"
       },
       "contentBlockIndex": 0
     }
@@ -15,7 +15,7 @@
   {
     "contentBlockDelta": {
       "delta": {
-        "text": "mydb** database contains the"
+        "text": " collections"
       },
       "contentBlockIndex": 0
     }
@@ -23,7 +23,7 @@
   {
     "contentBlockDelta": {
       "delta": {
-        "text": " following collections:\n\n1. **movies"
+        "text": " in the **"
       },
       "contentBlockIndex": 0
     }
@@ -31,7 +31,15 @@
   {
     "contentBlockDelta": {
       "delta": {
-        "text": "**"
+        "text": "mydb** database are:"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "\n\n1. **movies**"
       },
       "contentBlockIndex": 0
     }
@@ -62,7 +70,7 @@
         "totalTokens": 664
       },
       "metrics": {
-        "latencyMs": 1472
+        "latencyMs": 1347
       }
     }
   }

--- a/payloads/transforms/chat-completions_to_bedrock/googleToolCallThoughtSignatureReplayParam-streaming.json
+++ b/payloads/transforms/chat-completions_to_bedrock/googleToolCallThoughtSignatureReplayParam-streaming.json
@@ -1,0 +1,69 @@
+[
+  {
+    "messageStart": {
+      "role": "assistant"
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "The **"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "mydb** database contains the"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " following collections:\n\n1. **movies"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "**"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "\n2. **users**"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockStop": {
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "messageStop": {
+      "stopReason": "end_turn"
+    }
+  },
+  {
+    "metadata": {
+      "usage": {
+        "inputTokens": 639,
+        "outputTokens": 25,
+        "totalTokens": 664
+      },
+      "metrics": {
+        "latencyMs": 1472
+      }
+    }
+  }
+]

--- a/payloads/transforms/chat-completions_to_bedrock/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/chat-completions_to_bedrock/googleToolCallThoughtSignatureReplayParam.json
@@ -18,11 +18,11 @@
     "cacheWriteInputTokens": 0
   },
   "metrics": {
-    "latencyMs": 1195
+    "latencyMs": 1408
   },
   "$metadata": {
     "httpStatusCode": 200,
-    "requestId": "81244456-39d4-4ae7-8b19-3d35072f1e84",
+    "requestId": "890315d5-44b5-4c75-bfcc-5c87296e10bb",
     "attempts": 1,
     "totalRetryDelay": 0
   }

--- a/payloads/transforms/chat-completions_to_bedrock/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/chat-completions_to_bedrock/googleToolCallThoughtSignatureReplayParam.json
@@ -1,0 +1,29 @@
+{
+  "output": {
+    "message": {
+      "role": "assistant",
+      "content": [
+        {
+          "text": "The collections in the **mydb** database are:\n\n1. **movies**\n2. **users**"
+        }
+      ]
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "inputTokens": 639,
+    "outputTokens": 26,
+    "totalTokens": 665,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokens": 0
+  },
+  "metrics": {
+    "latencyMs": 1195
+  },
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "81244456-39d4-4ae7-8b19-3d35072f1e84",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  }
+}

--- a/payloads/transforms/chat-completions_to_google/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/chat-completions_to_google/googleToolCallThoughtSignatureReplayParam.json
@@ -4,7 +4,7 @@
       "content": {
         "parts": [
           {
-            "text": "The `mydb` database has two collections: `movies` and `users`."
+            "text": "The collections in the `mydb` database are `movies` and `users`."
           }
         ],
         "role": "model"
@@ -26,5 +26,5 @@
     "serviceTier": "standard"
   },
   "modelVersion": "gemini-2.5-flash",
-  "responseId": "PIUeaqSqIc3TjMcPy766gQM"
+  "responseId": "ITMfaq70ApWFz7IPp7XT0QQ"
 }

--- a/payloads/transforms/chat-completions_to_google/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/chat-completions_to_google/googleToolCallThoughtSignatureReplayParam.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The `mydb` database has two collections: `movies` and `users`."
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 83,
+    "candidatesTokenCount": 16,
+    "totalTokenCount": 99,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 83
+      }
+    ],
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "PIUeaqSqIc3TjMcPy766gQM"
+}

--- a/payloads/transforms/chat-completions_to_responses/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/chat-completions_to_responses/googleToolCallThoughtSignatureReplayParam.json
@@ -1,0 +1,98 @@
+{
+  "id": "resp_065e504389243eaa006a1e853c8b70819aaa433808cf406cba",
+  "object": "response",
+  "created_at": 1780385084,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1780385086,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "moderation": null,
+  "output": [
+    {
+      "id": "rs_065e504389243eaa006a1e853d4068819a9b2f5a3bb4fdef36",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_065e504389243eaa006a1e853e0398819aad6f1e938280b4fb",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "The collections in mydb are: movies and users. If you’d like, I can show document counts or sample documents from either collection."
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": "current_turn",
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "function",
+      "description": "List the collections in a MongoDB database.",
+      "name": "list_collections",
+      "parameters": {
+        "properties": {
+          "database": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "database"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 89,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 174,
+    "output_tokens_details": {
+      "reasoning_tokens": 128
+    },
+    "total_tokens": 263
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "The collections in mydb are: movies and users. If you’d like, I can show document counts or sample documents from either collection."
+}

--- a/payloads/transforms/chat-completions_to_responses/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/chat-completions_to_responses/googleToolCallThoughtSignatureReplayParam.json
@@ -1,13 +1,13 @@
 {
-  "id": "resp_065e504389243eaa006a1e853c8b70819aaa433808cf406cba",
+  "id": "resp_0b84110d340c2d3c006a1f332124ac8199b234ca6f6df198ba",
   "object": "response",
-  "created_at": 1780385084,
+  "created_at": 1780429601,
   "status": "completed",
   "background": false,
   "billing": {
     "payer": "developer"
   },
-  "completed_at": 1780385086,
+  "completed_at": 1780429602,
   "error": null,
   "frequency_penalty": 0,
   "incomplete_details": null,
@@ -18,12 +18,13 @@
   "moderation": null,
   "output": [
     {
-      "id": "rs_065e504389243eaa006a1e853d4068819a9b2f5a3bb4fdef36",
+      "id": "rs_0b84110d340c2d3c006a1f33217628819999ed2532d4f88152",
       "type": "reasoning",
+      "content": [],
       "summary": []
     },
     {
-      "id": "msg_065e504389243eaa006a1e853e0398819aad6f1e938280b4fb",
+      "id": "msg_0b84110d340c2d3c006a1f33229414819999567a18c6e8b83a",
       "type": "message",
       "status": "completed",
       "content": [
@@ -31,7 +32,7 @@
           "type": "output_text",
           "annotations": [],
           "logprobs": [],
-          "text": "The collections in mydb are: movies and users. If you’d like, I can show document counts or sample documents from either collection."
+          "text": "The collections in the mydb database are:\n- movies\n- users\n\nWould you like to see document counts or sample documents from any of these?"
         }
       ],
       "role": "assistant"
@@ -86,13 +87,13 @@
     "input_tokens_details": {
       "cached_tokens": 0
     },
-    "output_tokens": 174,
+    "output_tokens": 222,
     "output_tokens_details": {
       "reasoning_tokens": 128
     },
-    "total_tokens": 263
+    "total_tokens": 311
   },
   "user": null,
   "metadata": {},
-  "output_text": "The collections in mydb are: movies and users. If you’d like, I can show document counts or sample documents from either collection."
+  "output_text": "The collections in the mydb database are:\n- movies\n- users\n\nWould you like to see document counts or sample documents from any of these?"
 }

--- a/payloads/transforms/google_to_anthropic/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/google_to_anthropic/googleToolCallThoughtSignatureReplayParam.json
@@ -1,6 +1,6 @@
 {
   "model": "claude-sonnet-4-5-20250929",
-  "id": "msg_018C1ZQ692QPys9jWecx9MAP",
+  "id": "msg_01FUE4j76tyLCKE2K8M2AmNS",
   "type": "message",
   "role": "assistant",
   "content": [

--- a/payloads/transforms/google_to_anthropic/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/google_to_anthropic/googleToolCallThoughtSignatureReplayParam.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_018C1ZQ692QPys9jWecx9MAP",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "The collections in the **mydb** database are:\n\n1. **movies**\n2. **users**"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 642,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 26,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/payloads/transforms/google_to_chat-completions/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/google_to_chat-completions/googleToolCallThoughtSignatureReplayParam.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-DmDmPO0ISzTQa1sxxu6wJuSvGiHqx",
+  "object": "chat.completion",
+  "created": 1780385085,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The mydb database contains 2 collections:\n- movies\n- users",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 176,
+    "completion_tokens": 151,
+    "total_tokens": 327,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 128,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/transforms/google_to_chat-completions/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/google_to_chat-completions/googleToolCallThoughtSignatureReplayParam.json
@@ -1,14 +1,14 @@
 {
-  "id": "chatcmpl-DmDmPO0ISzTQa1sxxu6wJuSvGiHqx",
+  "id": "chatcmpl-DmPMPnBE2vnHb6Uh23ZixdvEmrA9F",
   "object": "chat.completion",
-  "created": 1780385085,
+  "created": 1780429601,
   "model": "gpt-5-nano-2025-08-07",
   "choices": [
     {
       "index": 0,
       "message": {
         "role": "assistant",
-        "content": "The mydb database contains 2 collections:\n- movies\n- users",
+        "content": "The collections in the mydb database are:\n- movies\n- users",
         "refusal": null,
         "annotations": []
       },

--- a/payloads/transforms/google_to_responses/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/google_to_responses/googleToolCallThoughtSignatureReplayParam.json
@@ -1,0 +1,98 @@
+{
+  "id": "resp_0ba185e790d38d2b006a1e853dd19c819b85950374125c53a7",
+  "object": "response",
+  "created_at": 1780385085,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1780385087,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "moderation": null,
+  "output": [
+    {
+      "id": "rs_0ba185e790d38d2b006a1e853e7d48819b8610bbc023579e46",
+      "type": "reasoning",
+      "summary": []
+    },
+    {
+      "id": "msg_0ba185e790d38d2b006a1e853f7a54819babddec1cdc3d1f85",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "The collections in mydb are: movies and users."
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": "current_turn",
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "function",
+      "description": "List the collections in a MongoDB database.",
+      "name": "list_collections",
+      "parameters": {
+        "properties": {
+          "database": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "database"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 92,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 187,
+    "output_tokens_details": {
+      "reasoning_tokens": 128
+    },
+    "total_tokens": 279
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "The collections in mydb are: movies and users."
+}

--- a/payloads/transforms/google_to_responses/googleToolCallThoughtSignatureReplayParam.json
+++ b/payloads/transforms/google_to_responses/googleToolCallThoughtSignatureReplayParam.json
@@ -1,13 +1,13 @@
 {
-  "id": "resp_0ba185e790d38d2b006a1e853dd19c819b85950374125c53a7",
+  "id": "resp_029792e03dc7334d006a1f3322b8c0819bbb49a1f14bba521b",
   "object": "response",
-  "created_at": 1780385085,
+  "created_at": 1780429602,
   "status": "completed",
   "background": false,
   "billing": {
     "payer": "developer"
   },
-  "completed_at": 1780385087,
+  "completed_at": 1780429604,
   "error": null,
   "frequency_penalty": 0,
   "incomplete_details": null,
@@ -18,12 +18,13 @@
   "moderation": null,
   "output": [
     {
-      "id": "rs_0ba185e790d38d2b006a1e853e7d48819b8610bbc023579e46",
+      "id": "rs_029792e03dc7334d006a1f3322ff20819b971c0d7951e9b941",
       "type": "reasoning",
+      "content": [],
       "summary": []
     },
     {
-      "id": "msg_0ba185e790d38d2b006a1e853f7a54819babddec1cdc3d1f85",
+      "id": "msg_029792e03dc7334d006a1f33242b60819bae00a15015be25c7",
       "type": "message",
       "status": "completed",
       "content": [
@@ -31,7 +32,7 @@
           "type": "output_text",
           "annotations": [],
           "logprobs": [],
-          "text": "The collections in mydb are: movies and users."
+          "text": "The collections in mydb are:\n- movies\n- users\n\nWould you like any details from these collections (e.g., document counts or sample documents)?"
         }
       ],
       "role": "assistant"
@@ -86,13 +87,13 @@
     "input_tokens_details": {
       "cached_tokens": 0
     },
-    "output_tokens": 187,
+    "output_tokens": 233,
     "output_tokens_details": {
-      "reasoning_tokens": 128
+      "reasoning_tokens": 192
     },
-    "total_tokens": 279
+    "total_tokens": 325
   },
   "user": null,
   "metadata": {},
-  "output_text": "The collections in mydb are: movies and users."
+  "output_text": "The collections in mydb are:\n- movies\n- users\n\nWould you like any details from these collections (e.g., document counts or sample documents)?"
 }


### PR DESCRIPTION
Fixed Gemini tool-call signature round-tripping through the OpenAI chat-completions gateway path: Google functionCall parts with thoughtSignature were imported into lingua’s universal tool-call encrypted_content, but the OpenAI chat response converter dropped that signature unless there was also a reasoning block. The converter now emits the tool-call signature as reasoning_signature, so clients can replay assistant tool_calls with that field and lingua can translate it back into Google thoughtSignature on the next request, avoiding Vertex’s “missing thought_signature” 400 on multi-turn tool loops. Added a focused converter test plus a payload case/snapshots for the second-turn replay shape.