### PR TITLE
Fix Gemini 3.5 Responses tool-result transforms without replaying unsigned function calls

### DIFF
--- a/crates/lingua/build.rs
+++ b/crates/lingua/build.rs
@@ -36,6 +36,9 @@ fn main() {
     generate_google_test_cases(&workspace);
 }
 
+const RESPONSES_ROUNDTRIP_SKIP_CASES: &[&str] =
+    &["responsesFunctionCallOutputWithoutThoughtSignatureParam"];
+
 fn generate_test_cases(workspace: &Path) {
     let snapshots_dir = workspace.join("payloads/snapshots");
 
@@ -69,6 +72,10 @@ fn generate_test_cases(workspace: &Path) {
 
             // Skip hidden directories and cache files
             if test_case_name.starts_with('.') {
+                continue;
+            }
+
+            if RESPONSES_ROUNDTRIP_SKIP_CASES.contains(&test_case_name) {
                 continue;
             }
 

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -783,63 +783,63 @@ fn fill_tool_names_from_context(messages: &mut [Message]) {
 }
 
 fn sanitize_function_call_history_for_google_capabilities(messages: &mut Vec<Message>) {
-    let mut later_tool_result_ids = std::collections::HashSet::new();
-    let mut sanitized_reversed = Vec::with_capacity(messages.len());
+    let Some(current_turn_start) = messages
+        .iter()
+        .rposition(|message| matches!(message, Message::User { .. }))
+    else {
+        return;
+    };
 
-    for mut msg in messages.drain(..).rev() {
-        match &mut msg {
+    let mut later_tool_result_ids = std::collections::HashSet::new();
+    let mut index = messages.len();
+    while index > current_turn_start + 1 {
+        index -= 1;
+
+        match &mut messages[index] {
             Message::Tool { content } => {
                 for part in content {
                     let ToolContentPart::ToolResult(result) = part;
                     later_tool_result_ids.insert(result.tool_call_id.clone());
                 }
-                sanitized_reversed.push(msg);
             }
-            Message::Assistant { content, .. } => match content {
-                AssistantContent::String(_) => sanitized_reversed.push(msg),
-                AssistantContent::Array(parts) => {
-                    let has_signed_tool_call = parts.iter().any(|part| {
-                        matches!(
-                            part,
-                            AssistantContentPart::ToolCall {
-                                encrypted_content: Some(_),
-                                ..
-                            }
-                        )
-                    });
-                    let mut kept_parts = Vec::with_capacity(parts.len());
-                    for part in parts.drain(..) {
-                        if let AssistantContentPart::ToolCall {
-                            tool_call_id,
-                            encrypted_content: None,
+            Message::Assistant {
+                content: AssistantContent::Array(parts),
+                ..
+            } => {
+                let has_signed_tool_call = parts.iter().any(|part| {
+                    matches!(
+                        part,
+                        AssistantContentPart::ToolCall {
+                            encrypted_content: Some(_),
                             ..
-                        } = &part
-                        {
-                            // Gemini parallel function-call turns carry the thoughtSignature
-                            // only on the first functionCall. Keep unsigned siblings when the
-                            // same model turn has any signed call; drop only all-unsigned paired
-                            // calls used by Responses as call_id -> functionResponse metadata.
-                            if !has_signed_tool_call && later_tool_result_ids.contains(tool_call_id)
-                            {
-                                continue;
-                            }
                         }
+                    )
+                });
 
-                        kept_parts.push(part);
+                parts.retain(|part| {
+                    if let AssistantContentPart::ToolCall {
+                        tool_call_id,
+                        encrypted_content: None,
+                        ..
+                    } = part
+                    {
+                        // Gemini parallel calls put the signature only on the first sibling.
+                        // Only all-unsigned paired calls are synthetic Responses bridge history.
+                        if !has_signed_tool_call && later_tool_result_ids.contains(tool_call_id) {
+                            return false;
+                        }
                     }
 
-                    *parts = kept_parts;
-                    if !parts.is_empty() {
-                        sanitized_reversed.push(msg);
-                    }
+                    true
+                });
+
+                if parts.is_empty() {
+                    messages.remove(index);
                 }
-            },
-            _ => sanitized_reversed.push(msg),
+            }
+            _ => {}
         }
     }
-
-    sanitized_reversed.reverse();
-    *messages = sanitized_reversed;
 }
 
 #[cfg(test)]
@@ -1018,10 +1018,10 @@ mod tests {
     }
 
     #[test]
-    fn test_google_sanitizes_vertex_gemini_unsigned_function_call_history() {
+    fn test_google_keeps_unsigned_function_call_history_before_current_turn() {
         let adapter = GoogleAdapter;
         let req = UniversalRequest {
-            model: Some("publishers/google/models/gemini-3.5-flash".to_string()),
+            model: Some("gemini-3.5-flash".to_string()),
             messages: vec![
                 Message::User {
                     content: UserContent::String("List databases.".to_string()),
@@ -1049,61 +1049,8 @@ mod tests {
                         },
                     )],
                 },
-            ],
-            params: UniversalParams::default(),
-        };
-
-        let payload = adapter.request_from_universal(&req).unwrap();
-        let typed_payload: GenerateContentRequest =
-            serde_json::from_value(payload).expect("request should deserialize");
-        let contents = typed_payload.contents.expect("contents should be present");
-
-        let mut has_function_call = false;
-        let mut function_response_name = None;
-        for content in contents {
-            for part in content.parts.unwrap_or_default() {
-                has_function_call |= part.function_call.is_some();
-                if let Some(function_response) = part.function_response {
-                    function_response_name = function_response.name;
-                }
-            }
-        }
-
-        assert!(!has_function_call);
-        assert_eq!(function_response_name.as_deref(), Some("list_databases"));
-    }
-
-    #[test]
-    fn test_google_sanitizes_resource_gemini_unsigned_function_call_history() {
-        let adapter = GoogleAdapter;
-        let req = UniversalRequest {
-            model: Some("models/gemini-3.5-flash".to_string()),
-            messages: vec![
                 Message::User {
-                    content: UserContent::String("List databases.".to_string()),
-                },
-                Message::Assistant {
-                    id: None,
-                    content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
-                        tool_call_id: "call_1".to_string(),
-                        tool_name: "list_databases".to_string(),
-                        arguments: crate::universal::message::ToolCallArguments::from(
-                            "{}".to_string(),
-                        ),
-                        encrypted_content: None,
-                        provider_options: None,
-                        provider_executed: None,
-                    }]),
-                },
-                Message::Tool {
-                    content: vec![ToolContentPart::ToolResult(
-                        crate::universal::message::ToolResultContentPart {
-                            tool_call_id: "call_1".to_string(),
-                            tool_name: "list_databases".to_string(),
-                            output: json!({"databases": ["admin", "config", "local"]}),
-                            provider_options: None,
-                        },
-                    )],
+                    content: UserContent::String("Summarize that.".to_string()),
                 },
             ],
             params: UniversalParams::default(),
@@ -1114,19 +1061,15 @@ mod tests {
             serde_json::from_value(payload).expect("request should deserialize");
         let contents = typed_payload.contents.expect("contents should be present");
 
-        let mut has_function_call = false;
-        let mut function_response_name = None;
-        for content in contents {
-            for part in content.parts.unwrap_or_default() {
-                has_function_call |= part.function_call.is_some();
-                if let Some(function_response) = part.function_response {
-                    function_response_name = function_response.name;
-                }
-            }
-        }
+        let has_function_call = contents.into_iter().any(|content| {
+            content
+                .parts
+                .unwrap_or_default()
+                .into_iter()
+                .any(|part| part.function_call.is_some())
+        });
 
-        assert!(!has_function_call);
-        assert_eq!(function_response_name.as_deref(), Some("list_databases"));
+        assert!(has_function_call);
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -204,15 +204,7 @@ impl ProviderAdapter for GoogleAdapter {
 
         let capabilities = GoogleCapabilities::detect(req.model.as_deref());
         if capabilities.requires_thought_signature_for_function_call_history {
-            // Gemini 3 rejects replayed model functionCall parts without thoughtSignature.
-            // Responses follow-up requests can include an unsigned function_call solely to
-            // pair call_id -> name for a following function_call_output. After filling tool
-            // result names from that context, drop only unsigned function calls that have a
-            // matching later tool result, because the result is preserved as functionResponse.
-            // Leave unpaired unsigned function calls intact so Google can return the native
-            // provider validation error instead of Lingua silently changing semantics.
-            sanitize_function_call_history_for_google_capabilities(&mut messages);
-            flatten_consecutive_messages(&mut messages);
+            add_dummy_thought_signatures_for_transferred_function_call_history(&mut messages);
         }
 
         // Convert messages to Google contents
@@ -782,7 +774,9 @@ fn fill_tool_names_from_context(messages: &mut [Message]) {
     }
 }
 
-fn sanitize_function_call_history_for_google_capabilities(messages: &mut Vec<Message>) {
+const GOOGLE_DUMMY_THOUGHT_SIGNATURE: &str = "skip_thought_signature_validator";
+
+fn add_dummy_thought_signatures_for_transferred_function_call_history(messages: &mut [Message]) {
     let Some(current_turn_start) = messages
         .iter()
         .rposition(|message| matches!(message, Message::User { .. }))
@@ -806,7 +800,7 @@ fn sanitize_function_call_history_for_google_capabilities(messages: &mut Vec<Mes
                 content: AssistantContent::Array(parts),
                 ..
             } => {
-                let has_signed_tool_call = parts.iter().any(|part| {
+                if parts.iter().any(|part| {
                     matches!(
                         part,
                         AssistantContentPart::ToolCall {
@@ -814,27 +808,35 @@ fn sanitize_function_call_history_for_google_capabilities(messages: &mut Vec<Mes
                             ..
                         }
                     )
-                });
+                }) {
+                    continue;
+                }
 
-                parts.retain(|part| {
+                let mut first_paired_unsigned_call = None;
+                for (part_index, part) in parts.iter().enumerate() {
                     if let AssistantContentPart::ToolCall {
                         tool_call_id,
                         encrypted_content: None,
                         ..
                     } = part
                     {
-                        // Gemini parallel calls put the signature only on the first sibling.
-                        // Only all-unsigned paired calls are synthetic Responses bridge history.
-                        if !has_signed_tool_call && later_tool_result_ids.contains(tool_call_id) {
-                            return false;
+                        if later_tool_result_ids.contains(tool_call_id) {
+                            first_paired_unsigned_call = Some(part_index);
+                            break;
                         }
                     }
+                }
 
-                    true
-                });
-
-                if parts.is_empty() {
-                    messages.remove(index);
+                if let Some(part_index) = first_paired_unsigned_call {
+                    // Google documents these dummy signatures for function-call history that
+                    // did not come from Gemini. Preserve the call/response pairing and mark the
+                    // first current-turn call so Gemini 3 skips signature validation.
+                    if let AssistantContentPart::ToolCall {
+                        encrypted_content, ..
+                    } = &mut parts[part_index]
+                    {
+                        *encrypted_content = Some(GOOGLE_DUMMY_THOUGHT_SIGNATURE.to_string());
+                    }
                 }
             }
             _ => {}
@@ -962,7 +964,7 @@ mod tests {
     }
 
     #[test]
-    fn test_google_drops_paired_unsigned_function_call_history_for_signature_models() {
+    fn test_google_marks_transferred_function_call_history_for_signature_models() {
         let adapter = GoogleAdapter;
         let req = UniversalRequest {
             model: Some("gemini-3.5-flash".to_string()),
@@ -1002,105 +1004,28 @@ mod tests {
             serde_json::from_value(payload).expect("request should deserialize");
         let contents = typed_payload.contents.expect("contents should be present");
 
-        let mut has_function_call = false;
+        let mut function_call_signature = None;
         let mut function_response_name = None;
         for content in contents {
             for part in content.parts.unwrap_or_default() {
-                has_function_call |= part.function_call.is_some();
+                if part.function_call.is_some() {
+                    function_call_signature = part.thought_signature;
+                }
                 if let Some(function_response) = part.function_response {
                     function_response_name = function_response.name;
                 }
             }
         }
 
-        assert!(!has_function_call);
+        assert_eq!(
+            function_call_signature.as_deref(),
+            Some(GOOGLE_DUMMY_THOUGHT_SIGNATURE)
+        );
         assert_eq!(function_response_name.as_deref(), Some("list_databases"));
     }
 
     #[test]
-    fn test_google_keeps_unsigned_function_call_history_before_current_turn() {
-        let adapter = GoogleAdapter;
-        let req = UniversalRequest {
-            model: Some("gemini-3.5-flash".to_string()),
-            messages: vec![
-                Message::User {
-                    content: UserContent::String("List databases.".to_string()),
-                },
-                Message::Assistant {
-                    id: None,
-                    content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
-                        tool_call_id: "call_1".to_string(),
-                        tool_name: "list_databases".to_string(),
-                        arguments: crate::universal::message::ToolCallArguments::from(
-                            "{}".to_string(),
-                        ),
-                        encrypted_content: None,
-                        provider_options: None,
-                        provider_executed: None,
-                    }]),
-                },
-                Message::Tool {
-                    content: vec![ToolContentPart::ToolResult(
-                        crate::universal::message::ToolResultContentPart {
-                            tool_call_id: "call_1".to_string(),
-                            tool_name: "list_databases".to_string(),
-                            output: json!({"databases": ["admin", "config", "local"]}),
-                            provider_options: None,
-                        },
-                    )],
-                },
-                Message::User {
-                    content: UserContent::String("Summarize that.".to_string()),
-                },
-            ],
-            params: UniversalParams::default(),
-        };
-
-        let payload = adapter.request_from_universal(&req).unwrap();
-        let typed_payload: GenerateContentRequest =
-            serde_json::from_value(payload).expect("request should deserialize");
-        let contents = typed_payload.contents.expect("contents should be present");
-
-        let has_function_call = contents.into_iter().any(|content| {
-            content
-                .parts
-                .unwrap_or_default()
-                .into_iter()
-                .any(|part| part.function_call.is_some())
-        });
-
-        assert!(has_function_call);
-    }
-
-    #[test]
-    fn test_google_keeps_signed_function_call_history_for_signature_models() {
-        let adapter = GoogleAdapter;
-        let req = UniversalRequest {
-            model: Some("gemini-3.5-flash".to_string()),
-            messages: vec![Message::Assistant {
-                id: None,
-                content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
-                    tool_call_id: "call_1".to_string(),
-                    tool_name: "list_databases".to_string(),
-                    arguments: crate::universal::message::ToolCallArguments::from("{}".to_string()),
-                    encrypted_content: Some("thought_signature_123".to_string()),
-                    provider_options: None,
-                    provider_executed: None,
-                }]),
-            }],
-            params: UniversalParams::default(),
-        };
-
-        let payload = adapter.request_from_universal(&req).unwrap();
-        let payload_text = serde_json::to_string(&payload).unwrap();
-
-        assert!(payload_text.contains("functionCall"));
-        assert!(payload_text.contains("thoughtSignature"));
-        assert!(payload_text.contains("thought_signature_123"));
-    }
-
-    #[test]
-    fn test_google_keeps_unsigned_parallel_function_call_sibling_for_signature_models() {
+    fn test_google_preserves_parallel_transferred_function_call_history_for_signature_models() {
         let adapter = GoogleAdapter;
         let req = UniversalRequest {
             model: Some("gemini-3.5-flash".to_string()),
@@ -1119,7 +1044,7 @@ mod tests {
                             arguments: crate::universal::message::ToolCallArguments::from(
                                 r#"{"location":"Paris"}"#.to_string(),
                             ),
-                            encrypted_content: Some("thought_signature_123".to_string()),
+                            encrypted_content: None,
                             provider_options: None,
                             provider_executed: None,
                         },
@@ -1164,70 +1089,23 @@ mod tests {
             serde_json::from_value(payload).expect("request should deserialize");
         let contents = typed_payload.contents.expect("contents should be present");
 
-        let model_parts = contents
+        let function_call_signatures: Vec<_> = contents
             .iter()
-            .find(|content| content.role.as_deref() == Some("model"))
-            .and_then(|content| content.parts.as_ref())
-            .expect("model content should have parts");
-        let function_calls: Vec<_> = model_parts
-            .iter()
-            .filter_map(|part| {
-                part.function_call
-                    .as_ref()
-                    .map(|call| (call, part.thought_signature.as_deref()))
-            })
+            .flat_map(|content| content.parts.as_deref().unwrap_or(&[]))
+            .filter(|part| part.function_call.is_some())
+            .map(|part| part.thought_signature.as_deref())
             .collect();
+        let function_response_count = contents
+            .iter()
+            .flat_map(|content| content.parts.as_deref().unwrap_or(&[]))
+            .filter(|part| part.function_response.is_some())
+            .count();
 
-        assert_eq!(function_calls.len(), 2);
         assert_eq!(
-            function_calls[0].0.name.as_deref(),
-            Some("get_current_temperature")
+            function_call_signatures,
+            vec![Some(GOOGLE_DUMMY_THOUGHT_SIGNATURE), None]
         );
-        assert_eq!(function_calls[0].1, Some("thought_signature_123"));
-        assert_eq!(
-            function_calls[1].0.name.as_deref(),
-            Some("get_current_temperature")
-        );
-        assert_eq!(function_calls[1].1, None);
-    }
-
-    #[test]
-    fn test_google_keeps_unpaired_unsigned_function_call_history_for_provider_validation() {
-        let adapter = GoogleAdapter;
-        let req = UniversalRequest {
-            model: Some("gemini-3.5-flash".to_string()),
-            messages: vec![Message::Assistant {
-                id: None,
-                content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
-                    tool_call_id: "call_1".to_string(),
-                    tool_name: "list_databases".to_string(),
-                    arguments: crate::universal::message::ToolCallArguments::from("{}".to_string()),
-                    encrypted_content: None,
-                    provider_options: None,
-                    provider_executed: None,
-                }]),
-            }],
-            params: UniversalParams::default(),
-        };
-
-        let payload = adapter.request_from_universal(&req).unwrap();
-        let typed_payload: GenerateContentRequest =
-            serde_json::from_value(payload).expect("request should deserialize");
-        let contents = typed_payload.contents.expect("contents should be present");
-
-        let mut function_call_name = None;
-        let mut function_call_thought_signature = None;
-        for content in contents {
-            for part in content.parts.unwrap_or_default() {
-                if let Some(function_call) = part.function_call {
-                    function_call_name = function_call.name;
-                    function_call_thought_signature = part.thought_signature;
-                }
-            }
-        }
-
-        assert_eq!(function_call_name.as_deref(), Some("list_databases"));
-        assert!(function_call_thought_signature.is_none());
+        assert_eq!(function_response_count, 2);
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -798,6 +798,15 @@ fn sanitize_function_call_history_for_google_capabilities(messages: &mut Vec<Mes
             Message::Assistant { content, .. } => match content {
                 AssistantContent::String(_) => sanitized_reversed.push(msg),
                 AssistantContent::Array(parts) => {
+                    let has_signed_tool_call = parts.iter().any(|part| {
+                        matches!(
+                            part,
+                            AssistantContentPart::ToolCall {
+                                encrypted_content: Some(_),
+                                ..
+                            }
+                        )
+                    });
                     let mut kept_parts = Vec::with_capacity(parts.len());
                     for part in parts.drain(..) {
                         if let AssistantContentPart::ToolCall {
@@ -806,7 +815,12 @@ fn sanitize_function_call_history_for_google_capabilities(messages: &mut Vec<Mes
                             ..
                         } = &part
                         {
-                            if later_tool_result_ids.contains(tool_call_id) {
+                            // Gemini parallel function-call turns carry the thoughtSignature
+                            // only on the first functionCall. Keep unsigned siblings when the
+                            // same model turn has any signed call; drop only all-unsigned paired
+                            // calls used by Responses as call_id -> functionResponse metadata.
+                            if !has_signed_tool_call && later_tool_result_ids.contains(tool_call_id)
+                            {
                                 continue;
                             }
                         }
@@ -1060,6 +1074,62 @@ mod tests {
     }
 
     #[test]
+    fn test_google_sanitizes_resource_gemini_unsigned_function_call_history() {
+        let adapter = GoogleAdapter;
+        let req = UniversalRequest {
+            model: Some("models/gemini-3.5-flash".to_string()),
+            messages: vec![
+                Message::User {
+                    content: UserContent::String("List databases.".to_string()),
+                },
+                Message::Assistant {
+                    id: None,
+                    content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
+                        tool_call_id: "call_1".to_string(),
+                        tool_name: "list_databases".to_string(),
+                        arguments: crate::universal::message::ToolCallArguments::from(
+                            "{}".to_string(),
+                        ),
+                        encrypted_content: None,
+                        provider_options: None,
+                        provider_executed: None,
+                    }]),
+                },
+                Message::Tool {
+                    content: vec![ToolContentPart::ToolResult(
+                        crate::universal::message::ToolResultContentPart {
+                            tool_call_id: "call_1".to_string(),
+                            tool_name: "list_databases".to_string(),
+                            output: json!({"databases": ["admin", "config", "local"]}),
+                            provider_options: None,
+                        },
+                    )],
+                },
+            ],
+            params: UniversalParams::default(),
+        };
+
+        let payload = adapter.request_from_universal(&req).unwrap();
+        let typed_payload: GenerateContentRequest =
+            serde_json::from_value(payload).expect("request should deserialize");
+        let contents = typed_payload.contents.expect("contents should be present");
+
+        let mut has_function_call = false;
+        let mut function_response_name = None;
+        for content in contents {
+            for part in content.parts.unwrap_or_default() {
+                has_function_call |= part.function_call.is_some();
+                if let Some(function_response) = part.function_response {
+                    function_response_name = function_response.name;
+                }
+            }
+        }
+
+        assert!(!has_function_call);
+        assert_eq!(function_response_name.as_deref(), Some("list_databases"));
+    }
+
+    #[test]
     fn test_google_keeps_signed_function_call_history_for_signature_models() {
         let adapter = GoogleAdapter;
         let req = UniversalRequest {
@@ -1084,6 +1154,98 @@ mod tests {
         assert!(payload_text.contains("functionCall"));
         assert!(payload_text.contains("thoughtSignature"));
         assert!(payload_text.contains("thought_signature_123"));
+    }
+
+    #[test]
+    fn test_google_keeps_unsigned_parallel_function_call_sibling_for_signature_models() {
+        let adapter = GoogleAdapter;
+        let req = UniversalRequest {
+            model: Some("gemini-3.5-flash".to_string()),
+            messages: vec![
+                Message::User {
+                    content: UserContent::String(
+                        "Check the weather in Paris and London.".to_string(),
+                    ),
+                },
+                Message::Assistant {
+                    id: None,
+                    content: AssistantContent::Array(vec![
+                        AssistantContentPart::ToolCall {
+                            tool_call_id: "call_paris".to_string(),
+                            tool_name: "get_current_temperature".to_string(),
+                            arguments: crate::universal::message::ToolCallArguments::from(
+                                r#"{"location":"Paris"}"#.to_string(),
+                            ),
+                            encrypted_content: Some("thought_signature_123".to_string()),
+                            provider_options: None,
+                            provider_executed: None,
+                        },
+                        AssistantContentPart::ToolCall {
+                            tool_call_id: "call_london".to_string(),
+                            tool_name: "get_current_temperature".to_string(),
+                            arguments: crate::universal::message::ToolCallArguments::from(
+                                r#"{"location":"London"}"#.to_string(),
+                            ),
+                            encrypted_content: None,
+                            provider_options: None,
+                            provider_executed: None,
+                        },
+                    ]),
+                },
+                Message::Tool {
+                    content: vec![
+                        ToolContentPart::ToolResult(
+                            crate::universal::message::ToolResultContentPart {
+                                tool_call_id: "call_paris".to_string(),
+                                tool_name: "get_current_temperature".to_string(),
+                                output: json!({"temp": "15C"}),
+                                provider_options: None,
+                            },
+                        ),
+                        ToolContentPart::ToolResult(
+                            crate::universal::message::ToolResultContentPart {
+                                tool_call_id: "call_london".to_string(),
+                                tool_name: "get_current_temperature".to_string(),
+                                output: json!({"temp": "12C"}),
+                                provider_options: None,
+                            },
+                        ),
+                    ],
+                },
+            ],
+            params: UniversalParams::default(),
+        };
+
+        let payload = adapter.request_from_universal(&req).unwrap();
+        let typed_payload: GenerateContentRequest =
+            serde_json::from_value(payload).expect("request should deserialize");
+        let contents = typed_payload.contents.expect("contents should be present");
+
+        let model_parts = contents
+            .iter()
+            .find(|content| content.role.as_deref() == Some("model"))
+            .and_then(|content| content.parts.as_ref())
+            .expect("model content should have parts");
+        let function_calls: Vec<_> = model_parts
+            .iter()
+            .filter_map(|part| {
+                part.function_call
+                    .as_ref()
+                    .map(|call| (call, part.thought_signature.as_deref()))
+            })
+            .collect();
+
+        assert_eq!(function_calls.len(), 2);
+        assert_eq!(
+            function_calls[0].0.name.as_deref(),
+            Some("get_current_temperature")
+        );
+        assert_eq!(function_calls[0].1, Some("thought_signature_123"));
+        assert_eq!(
+            function_calls[1].0.name.as_deref(),
+            Some("get_current_temperature")
+        );
+        assert_eq!(function_calls[1].1, None);
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -216,10 +216,9 @@ impl ProviderAdapter for GoogleAdapter {
         }
 
         // Convert messages to Google contents
-        let mut google_contents: Vec<GoogleContent> =
+        let google_contents: Vec<GoogleContent> =
             <Vec<GoogleContent> as TryFromLLM<Vec<Message>>>::try_from(messages)
                 .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
-        merge_consecutive_google_contents_by_role(&mut google_contents);
 
         let mut obj = Map::new();
 
@@ -829,25 +828,6 @@ fn sanitize_function_call_history_for_google_capabilities(messages: &mut Vec<Mes
     *messages = sanitized_reversed;
 }
 
-fn merge_consecutive_google_contents_by_role(contents: &mut Vec<GoogleContent>) {
-    let mut merged: Vec<GoogleContent> = Vec::with_capacity(contents.len());
-
-    for mut content in contents.drain(..) {
-        if let Some(last) = merged.last_mut() {
-            if last.role == content.role {
-                let mut last_parts = last.parts.take().unwrap_or_default();
-                last_parts.extend(content.parts.take().unwrap_or_default());
-                last.parts = Some(last_parts);
-                continue;
-            }
-        }
-
-        merged.push(content);
-    }
-
-    *contents = merged;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1021,59 +1001,6 @@ mod tests {
 
         assert!(!has_function_call);
         assert_eq!(function_response_name.as_deref(), Some("list_databases"));
-    }
-
-    #[test]
-    fn test_google_merges_user_and_tool_result_after_dropping_unsigned_function_call() {
-        let adapter = GoogleAdapter;
-        let req = UniversalRequest {
-            model: Some("gemini-3.5-flash".to_string()),
-            messages: vec![
-                Message::User {
-                    content: UserContent::String("List databases.".to_string()),
-                },
-                Message::Assistant {
-                    id: None,
-                    content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
-                        tool_call_id: "call_1".to_string(),
-                        tool_name: "list_databases".to_string(),
-                        arguments: crate::universal::message::ToolCallArguments::from(
-                            "{}".to_string(),
-                        ),
-                        encrypted_content: None,
-                        provider_options: None,
-                        provider_executed: None,
-                    }]),
-                },
-                Message::Tool {
-                    content: vec![ToolContentPart::ToolResult(
-                        crate::universal::message::ToolResultContentPart {
-                            tool_call_id: "call_1".to_string(),
-                            tool_name: "list_databases".to_string(),
-                            output: json!({"databases": ["admin", "config", "local"]}),
-                            provider_options: None,
-                        },
-                    )],
-                },
-            ],
-            params: UniversalParams::default(),
-        };
-
-        let payload = adapter.request_from_universal(&req).unwrap();
-        let typed_payload: GenerateContentRequest =
-            serde_json::from_value(payload).expect("request should deserialize");
-        let contents = typed_payload.contents.expect("contents should be present");
-
-        assert_eq!(contents.len(), 1);
-        assert_eq!(contents[0].role.as_deref(), Some("user"));
-
-        let parts = contents[0]
-            .parts
-            .as_ref()
-            .expect("merged user content should have parts");
-        assert!(parts.iter().any(|part| part.text.is_some()));
-        assert!(parts.iter().any(|part| part.function_response.is_some()));
-        assert!(!parts.iter().any(|part| part.function_call.is_some()));
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -1004,6 +1004,62 @@ mod tests {
     }
 
     #[test]
+    fn test_google_sanitizes_vertex_gemini_unsigned_function_call_history() {
+        let adapter = GoogleAdapter;
+        let req = UniversalRequest {
+            model: Some("publishers/google/models/gemini-3.5-flash".to_string()),
+            messages: vec![
+                Message::User {
+                    content: UserContent::String("List databases.".to_string()),
+                },
+                Message::Assistant {
+                    id: None,
+                    content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
+                        tool_call_id: "call_1".to_string(),
+                        tool_name: "list_databases".to_string(),
+                        arguments: crate::universal::message::ToolCallArguments::from(
+                            "{}".to_string(),
+                        ),
+                        encrypted_content: None,
+                        provider_options: None,
+                        provider_executed: None,
+                    }]),
+                },
+                Message::Tool {
+                    content: vec![ToolContentPart::ToolResult(
+                        crate::universal::message::ToolResultContentPart {
+                            tool_call_id: "call_1".to_string(),
+                            tool_name: "list_databases".to_string(),
+                            output: json!({"databases": ["admin", "config", "local"]}),
+                            provider_options: None,
+                        },
+                    )],
+                },
+            ],
+            params: UniversalParams::default(),
+        };
+
+        let payload = adapter.request_from_universal(&req).unwrap();
+        let typed_payload: GenerateContentRequest =
+            serde_json::from_value(payload).expect("request should deserialize");
+        let contents = typed_payload.contents.expect("contents should be present");
+
+        let mut has_function_call = false;
+        let mut function_response_name = None;
+        for content in contents {
+            for part in content.parts.unwrap_or_default() {
+                has_function_call |= part.function_call.is_some();
+                if let Some(function_response) = part.function_response {
+                    function_response_name = function_response.name;
+                }
+            }
+        }
+
+        assert!(!has_function_call);
+        assert_eq!(function_response_name.as_deref(), Some("list_databases"));
+    }
+
+    #[test]
     fn test_google_keeps_signed_function_call_history_for_signature_models() {
         let adapter = GoogleAdapter;
         let req = UniversalRequest {

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -18,6 +18,7 @@ use crate::providers::google::generated::{
     ThinkingLevel, Tool as GoogleTool, ToolConfig, UsageMetadata,
 };
 use crate::providers::google::params::GoogleParams;
+use crate::providers::google::GoogleCapabilities;
 use crate::serde_json::{self, Map, Value};
 use crate::universal::convert::TryFromLLM;
 use crate::universal::message::{AssistantContent, AssistantContentPart, Message};
@@ -200,6 +201,19 @@ impl ProviderAdapter for GoogleAdapter {
         // Fill in tool names from preceding tool_calls — Google requires functionResponse.name
         // but some formats (e.g. OpenAI chat-completions role:tool) don't carry the function name
         fill_tool_names_from_context(&mut messages);
+
+        let capabilities = GoogleCapabilities::detect(req.model.as_deref());
+        if capabilities.requires_thought_signature_for_function_call_history {
+            // Gemini 3 rejects replayed model functionCall parts without thoughtSignature.
+            // Responses follow-up requests can include an unsigned function_call solely to
+            // pair call_id -> name for a following function_call_output. After filling tool
+            // result names from that context, drop only unsigned function calls that have a
+            // matching later tool result, because the result is preserved as functionResponse.
+            // Leave unpaired unsigned function calls intact so Google can return the native
+            // provider validation error instead of Lingua silently changing semantics.
+            sanitize_function_call_history_for_google_capabilities(&mut messages);
+            flatten_consecutive_messages(&mut messages);
+        }
 
         // Convert messages to Google contents
         let google_contents: Vec<GoogleContent> =
@@ -768,6 +782,52 @@ fn fill_tool_names_from_context(messages: &mut [Message]) {
     }
 }
 
+fn sanitize_function_call_history_for_google_capabilities(messages: &mut Vec<Message>) {
+    let mut later_tool_result_ids = std::collections::HashSet::new();
+    let mut sanitized_reversed = Vec::with_capacity(messages.len());
+
+    for mut msg in messages.drain(..).rev() {
+        match &mut msg {
+            Message::Tool { content } => {
+                for part in content {
+                    let ToolContentPart::ToolResult(result) = part;
+                    later_tool_result_ids.insert(result.tool_call_id.clone());
+                }
+                sanitized_reversed.push(msg);
+            }
+            Message::Assistant { content, .. } => match content {
+                AssistantContent::String(_) => sanitized_reversed.push(msg),
+                AssistantContent::Array(parts) => {
+                    let mut kept_parts = Vec::with_capacity(parts.len());
+                    for part in parts.drain(..) {
+                        if let AssistantContentPart::ToolCall {
+                            tool_call_id,
+                            encrypted_content: None,
+                            ..
+                        } = &part
+                        {
+                            if later_tool_result_ids.contains(tool_call_id) {
+                                continue;
+                            }
+                        }
+
+                        kept_parts.push(part);
+                    }
+
+                    *parts = kept_parts;
+                    if !parts.is_empty() {
+                        sanitized_reversed.push(msg);
+                    }
+                }
+            },
+            _ => sanitized_reversed.push(msg),
+        }
+    }
+
+    sanitized_reversed.reverse();
+    *messages = sanitized_reversed;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -881,6 +941,108 @@ mod tests {
             mode,
             Some(crate::providers::google::generated::FunctionCallingConfigMode::Any)
         );
+    }
+
+    #[test]
+    fn test_google_drops_paired_unsigned_function_call_history_for_signature_models() {
+        let adapter = GoogleAdapter;
+        let req = UniversalRequest {
+            model: Some("gemini-3.5-flash".to_string()),
+            messages: vec![
+                Message::User {
+                    content: UserContent::String("List databases.".to_string()),
+                },
+                Message::Assistant {
+                    id: None,
+                    content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
+                        tool_call_id: "call_1".to_string(),
+                        tool_name: "list_databases".to_string(),
+                        arguments: crate::universal::message::ToolCallArguments::from(
+                            "{}".to_string(),
+                        ),
+                        encrypted_content: None,
+                        provider_options: None,
+                        provider_executed: None,
+                    }]),
+                },
+                Message::Tool {
+                    content: vec![ToolContentPart::ToolResult(
+                        crate::universal::message::ToolResultContentPart {
+                            tool_call_id: "call_1".to_string(),
+                            tool_name: "list_databases".to_string(),
+                            output: json!({"databases": ["admin", "config", "local"]}),
+                            provider_options: None,
+                        },
+                    )],
+                },
+            ],
+            params: UniversalParams::default(),
+        };
+
+        let payload = adapter.request_from_universal(&req).unwrap();
+        let contents = payload
+            .get("contents")
+            .and_then(Value::as_array)
+            .expect("contents should be an array");
+        let payload_text = serde_json::to_string(&contents).unwrap();
+
+        assert!(!payload_text.contains("functionCall"));
+        assert!(payload_text.contains("functionResponse"));
+        assert!(payload_text.contains("list_databases"));
+    }
+
+    #[test]
+    fn test_google_keeps_signed_function_call_history_for_signature_models() {
+        let adapter = GoogleAdapter;
+        let req = UniversalRequest {
+            model: Some("gemini-3.5-flash".to_string()),
+            messages: vec![Message::Assistant {
+                id: None,
+                content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
+                    tool_call_id: "call_1".to_string(),
+                    tool_name: "list_databases".to_string(),
+                    arguments: crate::universal::message::ToolCallArguments::from("{}".to_string()),
+                    encrypted_content: Some("thought_signature_123".to_string()),
+                    provider_options: None,
+                    provider_executed: None,
+                }]),
+            }],
+            params: UniversalParams::default(),
+        };
+
+        let payload = adapter.request_from_universal(&req).unwrap();
+        let payload_text = serde_json::to_string(&payload).unwrap();
+
+        assert!(payload_text.contains("functionCall"));
+        assert!(payload_text.contains("thoughtSignature"));
+        assert!(payload_text.contains("thought_signature_123"));
+    }
+
+    #[test]
+    fn test_google_keeps_unpaired_unsigned_function_call_history_for_provider_validation() {
+        let adapter = GoogleAdapter;
+        let req = UniversalRequest {
+            model: Some("gemini-3.5-flash".to_string()),
+            messages: vec![Message::Assistant {
+                id: None,
+                content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
+                    tool_call_id: "call_1".to_string(),
+                    tool_name: "list_databases".to_string(),
+                    arguments: crate::universal::message::ToolCallArguments::from("{}".to_string()),
+                    encrypted_content: None,
+                    provider_options: None,
+                    provider_executed: None,
+                }]),
+            }],
+            params: UniversalParams::default(),
+        };
+
+        let payload = adapter.request_from_universal(&req).unwrap();
+        let payload_text = serde_json::to_string(&payload).unwrap();
+
+        assert!(payload_text.contains("functionCall"));
+        assert!(payload_text.contains("call_1"));
+        assert!(!payload_text.contains("thoughtSignature"));
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -870,8 +870,10 @@ mod tests {
         );
 
         let reconstructed = adapter.request_from_universal(&universal).unwrap();
-        assert!(reconstructed.get("contents").is_some());
-        assert!(reconstructed.get("generationConfig").is_some());
+        let reconstructed: GenerateContentRequest =
+            serde_json::from_value(reconstructed).expect("request should deserialize");
+        assert!(reconstructed.contents.is_some());
+        assert!(reconstructed.generation_config.is_some());
     }
 
     #[test]
@@ -890,7 +892,9 @@ mod tests {
         // but it should be preserved through serialization
 
         let reconstructed = adapter.request_from_universal(&universal).unwrap();
-        assert!(reconstructed.get("contents").is_some());
+        let reconstructed: GenerateContentRequest =
+            serde_json::from_value(reconstructed).expect("request should deserialize");
+        assert!(reconstructed.contents.is_some());
     }
 
     #[test]
@@ -980,15 +984,23 @@ mod tests {
         };
 
         let payload = adapter.request_from_universal(&req).unwrap();
-        let contents = payload
-            .get("contents")
-            .and_then(Value::as_array)
-            .expect("contents should be an array");
-        let payload_text = serde_json::to_string(&contents).unwrap();
+        let typed_payload: GenerateContentRequest =
+            serde_json::from_value(payload).expect("request should deserialize");
+        let contents = typed_payload.contents.expect("contents should be present");
 
-        assert!(!payload_text.contains("functionCall"));
-        assert!(payload_text.contains("functionResponse"));
-        assert!(payload_text.contains("list_databases"));
+        let mut has_function_call = false;
+        let mut function_response_name = None;
+        for content in contents {
+            for part in content.parts.unwrap_or_default() {
+                has_function_call |= part.function_call.is_some();
+                if let Some(function_response) = part.function_response {
+                    function_response_name = function_response.name;
+                }
+            }
+        }
+
+        assert!(!has_function_call);
+        assert_eq!(function_response_name.as_deref(), Some("list_databases"));
     }
 
     #[test]
@@ -1038,11 +1050,23 @@ mod tests {
         };
 
         let payload = adapter.request_from_universal(&req).unwrap();
-        let payload_text = serde_json::to_string(&payload).unwrap();
+        let typed_payload: GenerateContentRequest =
+            serde_json::from_value(payload).expect("request should deserialize");
+        let contents = typed_payload.contents.expect("contents should be present");
 
-        assert!(payload_text.contains("functionCall"));
-        assert!(payload_text.contains("call_1"));
-        assert!(!payload_text.contains("thoughtSignature"));
+        let mut function_call_name = None;
+        let mut function_call_thought_signature = None;
+        for content in contents {
+            for part in content.parts.unwrap_or_default() {
+                if let Some(function_call) = part.function_call {
+                    function_call_name = function_call.name;
+                    function_call_thought_signature = part.thought_signature;
+                }
+            }
+        }
+
+        assert_eq!(function_call_name.as_deref(), Some("list_databases"));
+        assert!(function_call_thought_signature.is_none());
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -216,9 +216,10 @@ impl ProviderAdapter for GoogleAdapter {
         }
 
         // Convert messages to Google contents
-        let google_contents: Vec<GoogleContent> =
+        let mut google_contents: Vec<GoogleContent> =
             <Vec<GoogleContent> as TryFromLLM<Vec<Message>>>::try_from(messages)
                 .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+        merge_consecutive_google_contents_by_role(&mut google_contents);
 
         let mut obj = Map::new();
 
@@ -828,6 +829,25 @@ fn sanitize_function_call_history_for_google_capabilities(messages: &mut Vec<Mes
     *messages = sanitized_reversed;
 }
 
+fn merge_consecutive_google_contents_by_role(contents: &mut Vec<GoogleContent>) {
+    let mut merged: Vec<GoogleContent> = Vec::with_capacity(contents.len());
+
+    for mut content in contents.drain(..) {
+        if let Some(last) = merged.last_mut() {
+            if last.role == content.role {
+                let mut last_parts = last.parts.take().unwrap_or_default();
+                last_parts.extend(content.parts.take().unwrap_or_default());
+                last.parts = Some(last_parts);
+                continue;
+            }
+        }
+
+        merged.push(content);
+    }
+
+    *contents = merged;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1001,6 +1021,59 @@ mod tests {
 
         assert!(!has_function_call);
         assert_eq!(function_response_name.as_deref(), Some("list_databases"));
+    }
+
+    #[test]
+    fn test_google_merges_user_and_tool_result_after_dropping_unsigned_function_call() {
+        let adapter = GoogleAdapter;
+        let req = UniversalRequest {
+            model: Some("gemini-3.5-flash".to_string()),
+            messages: vec![
+                Message::User {
+                    content: UserContent::String("List databases.".to_string()),
+                },
+                Message::Assistant {
+                    id: None,
+                    content: AssistantContent::Array(vec![AssistantContentPart::ToolCall {
+                        tool_call_id: "call_1".to_string(),
+                        tool_name: "list_databases".to_string(),
+                        arguments: crate::universal::message::ToolCallArguments::from(
+                            "{}".to_string(),
+                        ),
+                        encrypted_content: None,
+                        provider_options: None,
+                        provider_executed: None,
+                    }]),
+                },
+                Message::Tool {
+                    content: vec![ToolContentPart::ToolResult(
+                        crate::universal::message::ToolResultContentPart {
+                            tool_call_id: "call_1".to_string(),
+                            tool_name: "list_databases".to_string(),
+                            output: json!({"databases": ["admin", "config", "local"]}),
+                            provider_options: None,
+                        },
+                    )],
+                },
+            ],
+            params: UniversalParams::default(),
+        };
+
+        let payload = adapter.request_from_universal(&req).unwrap();
+        let typed_payload: GenerateContentRequest =
+            serde_json::from_value(payload).expect("request should deserialize");
+        let contents = typed_payload.contents.expect("contents should be present");
+
+        assert_eq!(contents.len(), 1);
+        assert_eq!(contents[0].role.as_deref(), Some("user"));
+
+        let parts = contents[0]
+            .parts
+            .as_ref()
+            .expect("merged user content should have parts");
+        assert!(parts.iter().any(|part| part.text.is_some()));
+        assert!(parts.iter().any(|part| part.function_response.is_some()));
+        assert!(!parts.iter().any(|part| part.function_call.is_some()));
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/capabilities.rs
+++ b/crates/lingua/src/providers/google/capabilities.rs
@@ -34,6 +34,7 @@ const THINKING_BUDGET_PREFIXES: &[&str] = &["gemini-2.5", "gemini-2.0"];
 /// Google model capabilities
 pub struct GoogleCapabilities {
     pub thinking_style: GoogleThinkingStyle,
+    pub requires_thought_signature_for_function_call_history: bool,
 }
 
 impl GoogleCapabilities {
@@ -59,7 +60,13 @@ impl GoogleCapabilities {
             })
             .unwrap_or(GoogleThinkingStyle::ThinkingBudget);
 
-        Self { thinking_style }
+        let requires_thought_signature_for_function_call_history =
+            thinking_style == GoogleThinkingStyle::ThinkingLevelBased;
+
+        Self {
+            thinking_style,
+            requires_thought_signature_for_function_call_history,
+        }
     }
 }
 

--- a/crates/lingua/src/providers/google/capabilities.rs
+++ b/crates/lingua/src/providers/google/capabilities.rs
@@ -42,7 +42,7 @@ impl GoogleCapabilities {
     pub fn detect(model: Option<&str>) -> Self {
         let thinking_style = model
             .map(|m| {
-                let m_lower = m.to_ascii_lowercase();
+                let m_lower = normalize_google_model_id(m).to_ascii_lowercase();
                 if THINKING_LEVEL_PREFIXES
                     .iter()
                     .any(|p| m_lower.starts_with(p))
@@ -68,6 +68,13 @@ impl GoogleCapabilities {
             requires_thought_signature_for_function_call_history,
         }
     }
+}
+
+fn normalize_google_model_id(model: &str) -> &str {
+    model
+        .strip_prefix("publishers/google/models/")
+        .or_else(|| model.strip_prefix("models/"))
+        .unwrap_or(model)
 }
 
 pub fn thinking_level_to_effort(level: &ThinkingLevel) -> ReasoningEffort {
@@ -110,6 +117,21 @@ mod tests {
             GoogleCapabilities::detect(Some("Gemini-3-Flash")).thinking_style,
             GoogleThinkingStyle::ThinkingLevelBased
         );
+
+        let vertex_capabilities =
+            GoogleCapabilities::detect(Some("publishers/google/models/gemini-3.5-flash"));
+        assert_eq!(
+            vertex_capabilities.thinking_style,
+            GoogleThinkingStyle::ThinkingLevelBased
+        );
+        assert!(vertex_capabilities.requires_thought_signature_for_function_call_history);
+
+        let gemini_api_capabilities = GoogleCapabilities::detect(Some("models/gemini-3.5-flash"));
+        assert_eq!(
+            gemini_api_capabilities.thinking_style,
+            GoogleThinkingStyle::ThinkingLevelBased
+        );
+        assert!(gemini_api_capabilities.requires_thought_signature_for_function_call_history);
     }
 
     #[test]

--- a/payloads/cases/models.ts
+++ b/payloads/cases/models.ts
@@ -11,7 +11,7 @@ export const ANTHROPIC_MODEL = "claude-sonnet-4-5-20250929";
 export const ANTHROPIC_OPUS_MODEL = "claude-opus-4-6";
 // For Anthropic mid-conversation system messages (requires Opus 4.8+)
 export const ANTHROPIC_OPUS_4_8_MODEL = "claude-opus-4-8";
-export const GOOGLE_MODEL = "gemini-2.5-flash";
+export const GOOGLE_MODEL = "gemini-3.5-flash";
 export const GOOGLE_GEMINI_3_MODEL = "gemini-3-flash-preview";
 export const GOOGLE_IMAGE_MODEL = "gemini-2.5-flash-image";
 export const GOOGLE_TTS_MODEL = "gemini-2.5-flash-preview-tts";

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -267,6 +267,53 @@ export const paramsCases: TestCaseCollection = {
     bedrock: null,
   },
 
+  responsesFunctionCallOutputWithoutThoughtSignatureParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: "What databases exist in the connected MongoDB instance? Use the list_databases tool.",
+            },
+          ],
+        },
+        {
+          type: "function_call",
+          call_id: "6k7x6c84",
+          name: "list_databases",
+          arguments: "{}",
+        },
+        {
+          type: "function_call_output",
+          call_id: "6k7x6c84",
+          output:
+            '[{"type":"text","text":"{\\"databases\\":[\\"admin\\",\\"config\\",\\"local\\"]}"}]',
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          name: "list_databases",
+          description: "List databases in the connected MongoDB instance.",
+          parameters: {
+            type: "object",
+            properties: {},
+            additionalProperties: false,
+          },
+          strict: false,
+        },
+      ],
+      tool_choice: "auto",
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
   imageUrlMimeTypeFallbackParam: {
     "chat-completions": {
       model: OPENAI_CHAT_COMPLETIONS_MODEL,

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -6608,11 +6608,11 @@ data: [DONE]
 `;
 
 exports[`streaming: chat-completions → google > parallelToolCallsRequest > streaming 1`] = `
-"data: {"choices":[{"delta":{"content":"The weather in San","role":"assistant"},"finish_reason":null,"index":0}],"id":"8jr6aarKHc2f1MkPlq-rgQM","model":"gemini-2.5-flash","object":"chat.completion.chunk","usage":{"completion_tokens":4,"prompt_tokens":140,"total_tokens":144}}
+"data: {"choices":[{"delta":{"content":"The weather in San Francisco is 65°F and sunny. In New York, it","role":"assistant"},"finish_reason":null,"index":0}],"id":"tjwjap2YAqCb9MoPjsLu8AE","model":"gemini-3.5-flash","object":"chat.completion.chunk","usage":{"completion_tokens":19,"prompt_tokens":151,"total_tokens":170}}
 
-data: {"choices":[{"delta":{"content":" Francisco, CA is 65°F and sunny. In New York, NY","role":"assistant"},"finish_reason":null,"index":0}],"id":"8jr6aarKHc2f1MkPlq-rgQM","model":"gemini-2.5-flash","object":"chat.completion.chunk","usage":{"completion_tokens":21,"prompt_tokens":140,"total_tokens":161}}
+data: {"choices":[{"delta":{"content":" is 45°F and cloudy.","role":"assistant"},"finish_reason":null,"index":0}],"id":"tjwjap2YAqCb9MoPjsLu8AE","model":"gemini-3.5-flash","object":"chat.completion.chunk","usage":{"completion_tokens":28,"prompt_tokens":151,"total_tokens":179}}
 
-data: {"choices":[{"delta":{"content":", it is 45°F and cloudy.","role":"assistant"},"finish_reason":"stop","index":0}],"id":"8jr6aarKHc2f1MkPlq-rgQM","model":"gemini-2.5-flash","object":"chat.completion.chunk","usage":{"completion_tokens":32,"prompt_tokens":140,"total_tokens":172}}
+data: {"choices":[{"delta":{"content":"","reasoning_signature":"EjQKMgEMOdbHOJySIIza8a3N6ADqxqUsPx0vnACleDwU5HBUkO172QSmDZZSOAzZ0nKYVoY7","role":"assistant"},"finish_reason":"stop","index":0}],"id":"tjwjap2YAqCb9MoPjsLu8AE","model":"gemini-3.5-flash","object":"chat.completion.chunk","usage":{"completion_tokens":28,"prompt_tokens":151,"total_tokens":179}}
 
 data: [DONE]
 
@@ -10015,13 +10015,13 @@ data: {"response":{"id":"iW_VaZ3aDdSa_uMPpsqI4Qw","model":"gemini-2.5-flash","ob
 
 exports[`streaming: responses → google > parallelToolCallsRequest > streaming 1`] = `
 "event: response.output_text.delta
-data: {"content_index":0,"delta":"The weather in San","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"In San Francisco, CA, it is currently 65°","output_index":0,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" Francisco, CA is 65°F and sunny. In New York, NY","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"F and sunny. In New York, NY, it is 45°F and cloudy.","output_index":0,"type":"response.output_text.delta"}
 
 event: response.completed
-data: {"response":{"id":"im_VaZyKKI3m_uMPnpjMmQY","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":140,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":173}},"type":"response.completed"}
+data: {"response":{"id":"ujwjap_VJNTQjMcP2rTuuA0","model":"gemini-3.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":151,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":184}},"type":"response.completed"}
 
 "
 `;

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -3059,6 +3059,30 @@ exports[`anthropic → google > parallelToolCallsRequest > request 1`] = `
     {
       "parts": [
         {
+          "functionCall": {
+            "args": {
+              "location": "San Francisco, CA",
+            },
+            "id": "toolu_sf",
+            "name": "get_weather",
+          },
+          "thoughtSignature": "skip_thought_signature_validator",
+        },
+        {
+          "functionCall": {
+            "args": {
+              "location": "New York, NY",
+            },
+            "id": "toolu_nyc",
+            "name": "get_weather",
+          },
+        },
+      ],
+      "role": "model",
+    },
+    {
+      "parts": [
+        {
           "functionResponse": {
             "id": "toolu_sf",
             "name": "get_weather",
@@ -3121,18 +3145,18 @@ exports[`anthropic → google > parallelToolCallsRequest > response 1`] = `
 {
   "content": [
     {
-      "text": "The weather in San Francisco, CA is 65°F and sunny. In New York, NY, it is 45°F and cloudy.",
+      "text": "The current weather in San Francisco is 65°F and sunny, while in New York it is 45°F and cloudy.",
       "type": "text",
     },
   ],
   "id": "msg_transformed",
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "role": "assistant",
   "stop_reason": "end_turn",
   "type": "message",
   "usage": {
-    "input_tokens": 140,
-    "output_tokens": 32,
+    "input_tokens": 151,
+    "output_tokens": 29,
   },
 }
 `;
@@ -14031,6 +14055,28 @@ exports[`chat-completions → google > parallelToolCallsRequest > request 1`] = 
     {
       "parts": [
         {
+          "functionCall": {
+            "args": {
+              "location": "San Francisco, CA",
+            },
+            "name": "get_weather",
+          },
+          "thoughtSignature": "skip_thought_signature_validator",
+        },
+        {
+          "functionCall": {
+            "args": {
+              "location": "New York, NY",
+            },
+            "name": "get_weather",
+          },
+        },
+      ],
+      "role": "model",
+    },
+    {
+      "parts": [
+        {
           "functionResponse": {
             "name": "get_weather",
             "response": {
@@ -14086,19 +14132,22 @@ exports[`chat-completions → google > parallelToolCallsRequest > response 1`] =
       "index": 0,
       "message": {
         "annotations": [],
-        "content": "The weather in San Francisco, CA is 65°F and sunny. In New York, NY, it is 45°F and cloudy.",
+        "content": "In San Francisco, the weather is currently 65°F and sunny. In New York, it is 45°F and cloudy.",
         "role": "assistant",
       },
     },
   ],
   "created": 0,
   "id": "chatcmpl-transformed",
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "object": "chat.completion",
   "usage": {
-    "completion_tokens": 32,
-    "prompt_tokens": 140,
-    "total_tokens": 172,
+    "completion_tokens": 123,
+    "completion_tokens_details": {
+      "reasoning_tokens": 93,
+    },
+    "prompt_tokens": 151,
+    "total_tokens": 274,
   },
 }
 `;
@@ -31895,6 +31944,28 @@ exports[`responses → google > parallelToolCallsRequest > request 1`] = `
     {
       "parts": [
         {
+          "functionCall": {
+            "args": {
+              "location": "San Francisco, CA",
+            },
+            "name": "get_weather",
+          },
+          "thoughtSignature": "skip_thought_signature_validator",
+        },
+        {
+          "functionCall": {
+            "args": {
+              "location": "New York, NY",
+            },
+            "name": "get_weather",
+          },
+        },
+      ],
+      "role": "model",
+    },
+    {
+      "parts": [
+        {
           "functionResponse": {
             "name": "get_weather",
             "response": {
@@ -31947,14 +32018,14 @@ exports[`responses → google > parallelToolCallsRequest > response 1`] = `
   "created_at": 0,
   "id": "resp_transformed",
   "incomplete_details": null,
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "object": "response",
   "output": [
     {
       "content": [
         {
           "annotations": [],
-          "text": "The weather in San Francisco, CA is 65°F and sunny. In New York, NY, it is 45°F and cloudy.",
+          "text": "In San Francisco, it is currently 65°F and sunny. In New York, it is 45°F and cloudy.",
           "type": "output_text",
         },
       ],
@@ -31964,21 +32035,21 @@ exports[`responses → google > parallelToolCallsRequest > response 1`] = `
       "type": "message",
     },
   ],
-  "output_text": "The weather in San Francisco, CA is 65°F and sunny. In New York, NY, it is 45°F and cloudy.",
+  "output_text": "In San Francisco, it is currently 65°F and sunny. In New York, it is 45°F and cloudy.",
   "parallel_tool_calls": false,
   "status": "completed",
   "tool_choice": "none",
   "tools": [],
   "usage": {
-    "input_tokens": 140,
+    "input_tokens": 151,
     "input_tokens_details": {
       "cached_tokens": 0,
     },
-    "output_tokens": 32,
+    "output_tokens": 113,
     "output_tokens_details": {
-      "reasoning_tokens": 0,
+      "reasoning_tokens": 85,
     },
-    "total_tokens": 172,
+    "total_tokens": 264,
   },
 }
 `;
@@ -32754,6 +32825,19 @@ exports[`responses → google > responsesFunctionCallOutputWithoutThoughtSignatu
     {
       "parts": [
         {
+          "functionCall": {
+            "args": {},
+            "id": "6k7x6c84",
+            "name": "list_databases",
+          },
+          "thoughtSignature": "skip_thought_signature_validator",
+        },
+      ],
+      "role": "model",
+    },
+    {
+      "parts": [
+        {
           "functionResponse": {
             "id": "6k7x6c84",
             "name": "list_databases",
@@ -32809,11 +32893,11 @@ exports[`responses → google > responsesFunctionCallOutputWithoutThoughtSignatu
       "content": [
         {
           "annotations": [],
-          "text": "The following databases exist in the connected MongoDB instance:
+          "text": "The databases that exist in the connected MongoDB instance are:
 
-* admin
-* config
-* local",
+*   **admin**
+*   **config**
+*   **local**",
           "type": "output_text",
         },
       ],
@@ -32823,25 +32907,25 @@ exports[`responses → google > responsesFunctionCallOutputWithoutThoughtSignatu
       "type": "message",
     },
   ],
-  "output_text": "The following databases exist in the connected MongoDB instance:
+  "output_text": "The databases that exist in the connected MongoDB instance are:
 
-* admin
-* config
-* local",
+*   **admin**
+*   **config**
+*   **local**",
   "parallel_tool_calls": false,
   "status": "completed",
   "tool_choice": "none",
   "tools": [],
   "usage": {
-    "input_tokens": 78,
+    "input_tokens": 87,
     "input_tokens_details": {
       "cached_tokens": 0,
     },
-    "output_tokens": 47,
+    "output_tokens": 65,
     "output_tokens_details": {
-      "reasoning_tokens": 28,
+      "reasoning_tokens": 36,
     },
-    "total_tokens": 125,
+    "total_tokens": 152,
   },
 }
 `;

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -2007,10 +2007,10 @@ exports[`anthropic → google > anthropicMessageWithSystemMessage > request 1`] 
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "HIGH",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -2092,7 +2092,7 @@ exports[`anthropic → google > anthropicMidConversationSystemMessage > request 
     "maxOutputTokens": 16,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -2135,7 +2135,7 @@ exports[`anthropic → google > cacheControl1hParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -2182,7 +2182,7 @@ exports[`anthropic → google > cacheControl5mParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -2229,7 +2229,7 @@ exports[`anthropic → google > codeInterpreterToolParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2284,7 +2284,7 @@ exports[`anthropic → google > complexReasoningRequest > request 1`] = `
     "maxOutputTokens": 20000,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2410,7 +2410,7 @@ exports[`anthropic → google > documentContentParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2458,7 +2458,7 @@ exports[`anthropic → google > imageContentParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2500,7 +2500,7 @@ exports[`anthropic → google > instructionsParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -2562,7 +2562,7 @@ exports[`anthropic → google > jsonSchemaFormatParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2602,7 +2602,7 @@ exports[`anthropic → google > maxCompletionTokensParam > request 1`] = `
     "maxOutputTokens": 500,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2642,7 +2642,7 @@ exports[`anthropic → google > metadataParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2688,7 +2688,7 @@ exports[`anthropic → google > multimodalRequest > request 1`] = `
     "maxOutputTokens": 300,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2729,10 +2729,10 @@ exports[`anthropic → google > opus47AdaptiveThinkingReasoningEffortParam > req
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "MEDIUM",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2800,10 +2800,10 @@ exports[`anthropic → google > outputConfigEffortWithJsonSchemaParam > request 
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "MEDIUM",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2883,7 +2883,7 @@ exports[`anthropic → google > outputConfigJsonSchemaParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2941,7 +2941,7 @@ exports[`anthropic → google > outputFormatJsonSchemaParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -2981,7 +2981,7 @@ exports[`anthropic → google > parallelToolCallsDisabledParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "toolConfig": {
     "functionCallingConfig": {
       "mode": "AUTO",
@@ -3059,29 +3059,6 @@ exports[`anthropic → google > parallelToolCallsRequest > request 1`] = `
     {
       "parts": [
         {
-          "functionCall": {
-            "args": {
-              "location": "San Francisco, CA",
-            },
-            "id": "toolu_sf",
-            "name": "get_weather",
-          },
-        },
-        {
-          "functionCall": {
-            "args": {
-              "location": "New York, NY",
-            },
-            "id": "toolu_nyc",
-            "name": "get_weather",
-          },
-        },
-      ],
-      "role": "model",
-    },
-    {
-      "parts": [
-        {
           "functionResponse": {
             "id": "toolu_sf",
             "name": "get_weather",
@@ -3107,7 +3084,7 @@ exports[`anthropic → google > parallelToolCallsRequest > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "toolConfig": {
     "functionCallingConfig": {
       "mode": "AUTO",
@@ -3176,7 +3153,7 @@ exports[`anthropic → google > promptCacheKeyParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -3224,10 +3201,10 @@ exports[`anthropic → google > reasoningEffortLowParam > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "LOW",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3277,10 +3254,10 @@ exports[`anthropic → google > reasoningEffortMaxClampsToGpt5NanoParam > reques
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "HIGH",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3329,7 +3306,7 @@ exports[`anthropic → google > reasoningRequest > request 1`] = `
     "maxOutputTokens": 20000,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3400,7 +3377,7 @@ exports[`anthropic → google > reasoningRequestTruncated > request 1`] = `
     "maxOutputTokens": 100,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3441,10 +3418,10 @@ exports[`anthropic → google > reasoningSummaryParam > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "MEDIUM",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3493,7 +3470,7 @@ exports[`anthropic → google > reasoningWithOutput > request 1`] = `
     "maxOutputTokens": 20000,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3542,7 +3519,7 @@ exports[`anthropic → google > safetyIdentifierParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3582,7 +3559,7 @@ exports[`anthropic → google > serviceTierParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3622,7 +3599,7 @@ exports[`anthropic → google > simpleRequest > request 1`] = `
     "maxOutputTokens": 20000,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3662,7 +3639,7 @@ exports[`anthropic → google > simpleRequestTruncated > request 1`] = `
     "maxOutputTokens": 1,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3701,7 +3678,7 @@ exports[`anthropic → google > stopSequencesParam > request 1`] = `
       "ten",
     ],
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3741,7 +3718,7 @@ exports[`anthropic → google > streamParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3781,7 +3758,7 @@ exports[`anthropic → google > systemMessageArrayContent > request 1`] = `
     "maxOutputTokens": 300,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -3837,7 +3814,7 @@ exports[`anthropic → google > temperatureParam > request 1`] = `
     "responseSchema": null,
     "temperature": 0.7,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3877,7 +3854,7 @@ exports[`anthropic → google > textEditorToolParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3931,7 +3908,7 @@ exports[`anthropic → google > textEditorToolV2Param > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -3986,7 +3963,7 @@ exports[`anthropic → google > textEditorToolV3Param > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -4057,7 +4034,7 @@ exports[`anthropic → google > textFormatJsonSchemaParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -4115,7 +4092,7 @@ exports[`anthropic → google > textFormatJsonSchemaWithDescriptionParam > reque
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -4158,7 +4135,7 @@ exports[`anthropic → google > thinkingDisabledParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -4271,7 +4248,7 @@ exports[`anthropic → google > toolChoiceAnyParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "toolConfig": {
     "functionCallingConfig": {
       "mode": "ANY",
@@ -4343,7 +4320,7 @@ exports[`anthropic → google > toolChoiceAutoParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "toolConfig": {
     "functionCallingConfig": {
       "mode": "AUTO",
@@ -4411,7 +4388,7 @@ exports[`anthropic → google > toolChoiceNoneParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "toolConfig": {
     "functionCallingConfig": {
       "mode": "NONE",
@@ -4479,7 +4456,7 @@ exports[`anthropic → google > toolChoiceRequiredParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "toolConfig": {
     "functionCallingConfig": {
       "allowedFunctionNames": [
@@ -4555,7 +4532,7 @@ exports[`anthropic → google > topKParam > request 1`] = `
     "responseSchema": null,
     "topK": 40,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -4596,7 +4573,7 @@ exports[`anthropic → google > topPParam > request 1`] = `
     "responseSchema": null,
     "topP": 0.9,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -4636,7 +4613,7 @@ exports[`anthropic → google > webSearchToolAdvancedParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -4678,7 +4655,7 @@ exports[`anthropic → google > webSearchToolParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -4722,7 +4699,7 @@ exports[`anthropic → google > webSearchUserLocationParam > request 1`] = `
     "maxOutputTokens": 1024,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -12784,7 +12761,7 @@ exports[`chat-completions → google > complexReasoningRequest > request 1`] = `
     "maxOutputTokens": 20000,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -12899,7 +12876,7 @@ exports[`chat-completions → google > exclusiveMinimumToolParam > request 1`] =
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "tools": [
     {
       "functionDeclarations": [
@@ -12968,7 +12945,7 @@ exports[`chat-completions → google > frequencyPenaltyParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13016,10 +12993,10 @@ exports[`chat-completions → google > functionToolsWithReasoningEffortParam > r
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 2048,
+      "thinkingLevel": "MEDIUM",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "tools": [
     {
       "functionDeclarations": [
@@ -13133,7 +13110,7 @@ exports[`chat-completions → google > googleToolCallThoughtSignatureReplayParam
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "toolConfig": {
     "functionCallingConfig": {
       "mode": "AUTO",
@@ -13208,7 +13185,7 @@ exports[`chat-completions → google > imageUrlMimeTypeFallbackParam > request 1
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13266,7 +13243,7 @@ exports[`chat-completions → google > instructionsParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -13332,7 +13309,7 @@ exports[`chat-completions → google > jsonSchemaFormatParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13398,7 +13375,7 @@ exports[`chat-completions → google > jsonSchemaMinMaxItemsParam > request 1`] 
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13461,7 +13438,7 @@ exports[`chat-completions → google > jsonSchemaMinimumMaximumParam > request 1
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13542,7 +13519,7 @@ exports[`chat-completions → google > jsonSchemaPrefixItemsParam > request 1`] 
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13586,7 +13563,7 @@ exports[`chat-completions → google > logitBiasParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13630,7 +13607,7 @@ exports[`chat-completions → google > logprobsParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13678,7 +13655,7 @@ exports[`chat-completions → google > maxCompletionTokensParam > request 1`] = 
     "maxOutputTokens": 500,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13722,7 +13699,7 @@ exports[`chat-completions → google > metadataParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13776,7 +13753,7 @@ exports[`chat-completions → google > multimodalRequest > request 1`] = `
     "maxOutputTokens": 300,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13820,7 +13797,7 @@ exports[`chat-completions → google > nMultipleCompletionsParam > request 1`] =
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13864,7 +13841,7 @@ exports[`chat-completions → google > openaiPromptCacheKeyParam > request 1`] =
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13913,10 +13890,10 @@ exports[`chat-completions → google > opus47AdaptiveThinkingReasoningEffortPara
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 2048,
+      "thinkingLevel": "MEDIUM",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -13966,7 +13943,7 @@ exports[`chat-completions → google > parallelToolCallsDisabledParam > request 
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "tools": [
     {
       "functionDeclarations": [
@@ -14054,27 +14031,6 @@ exports[`chat-completions → google > parallelToolCallsRequest > request 1`] = 
     {
       "parts": [
         {
-          "functionCall": {
-            "args": {
-              "location": "San Francisco, CA",
-            },
-            "name": "get_weather",
-          },
-        },
-        {
-          "functionCall": {
-            "args": {
-              "location": "New York, NY",
-            },
-            "name": "get_weather",
-          },
-        },
-      ],
-      "role": "model",
-    },
-    {
-      "parts": [
-        {
           "functionResponse": {
             "name": "get_weather",
             "response": {
@@ -14094,7 +14050,7 @@ exports[`chat-completions → google > parallelToolCallsRequest > request 1`] = 
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "tools": [
     {
       "functionDeclarations": [
@@ -14163,7 +14119,7 @@ function divide(a, b) {
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14368,7 +14324,7 @@ exports[`chat-completions → google > presencePenaltyParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14412,7 +14368,7 @@ exports[`chat-completions → google > promptCacheKeyParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14460,10 +14416,10 @@ exports[`chat-completions → google > reasoningEffortLowParam > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "LOW",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14519,10 +14475,10 @@ exports[`chat-completions → google > reasoningEffortMinimalParam > request 1`]
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "MINIMAL",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14574,10 +14530,10 @@ exports[`chat-completions → google > reasoningEffortNoneParam > request 1`] = 
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 0,
+      "thinkingLevel": "THINKING_LEVEL_UNSPECIFIED",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14618,7 +14574,7 @@ exports[`chat-completions → google > reasoningRequest > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14697,7 +14653,7 @@ exports[`chat-completions → google > reasoningRequestTruncated > request 1`] =
     "maxOutputTokens": 100,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14745,10 +14701,10 @@ exports[`chat-completions → google > reasoningSummaryParam > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 2048,
+      "thinkingLevel": "MEDIUM",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14798,7 +14754,7 @@ exports[`chat-completions → google > reasoningWithOutput > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14858,7 +14814,7 @@ exports[`chat-completions → google > safetyIdentifierParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14902,7 +14858,7 @@ exports[`chat-completions → google > seedParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14946,7 +14902,7 @@ exports[`chat-completions → google > serviceTierParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -14994,10 +14950,10 @@ exports[`chat-completions → google > simpleRequest > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "LOW",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15049,7 +15005,7 @@ exports[`chat-completions → google > simpleRequestTruncated > request 1`] = `
     "maxOutputTokens": 1,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15096,7 +15052,7 @@ exports[`chat-completions → google > stopSequencesParam > request 1`] = `
       "ten",
     ],
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15140,7 +15096,7 @@ exports[`chat-completions → google > storeDisabledParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15188,7 +15144,7 @@ exports[`chat-completions → google > systemMessageArrayContent > request 1`] =
     "maxOutputTokens": 300,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -15261,7 +15217,7 @@ exports[`chat-completions → google > temperatureParam > request 1`] = `
     "responseSchema": null,
     "temperature": 0.7,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15309,7 +15265,7 @@ exports[`chat-completions → google > textFormatJsonObjectParam > request 1`] =
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15381,7 +15337,7 @@ exports[`chat-completions → google > textFormatJsonSchemaNullableUnionTypeGpt5
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15450,7 +15406,7 @@ exports[`chat-completions → google > textFormatJsonSchemaParam > request 1`] =
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15519,7 +15475,7 @@ exports[`chat-completions → google > textFormatJsonSchemaWithDescriptionParam 
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15570,7 +15526,7 @@ exports[`chat-completions → google > textFormatTextParam > request 1`] = `
     "responseMimeType": "text/plain",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15697,7 +15653,7 @@ exports[`chat-completions → google > toolChoiceRequiredParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "toolConfig": {
     "functionCallingConfig": {
       "allowedFunctionNames": [
@@ -15884,7 +15840,7 @@ exports[`chat-completions → google > topPParam > request 1`] = `
     "responseSchema": null,
     "topP": 0.9,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -15932,7 +15888,7 @@ exports[`chat-completions → google > topPReasoningModelParam > request 1`] = `
     "responseSchema": null,
     "topP": 0.9,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -29244,6 +29200,113 @@ However, the sky can appear different colors depending on conditions:
 }
 `;
 
+exports[`responses → anthropic > responsesFunctionCallOutputWithoutThoughtSignatureParam > request 1`] = `
+{
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "What databases exist in the connected MongoDB instance? Use the list_databases tool.",
+          "type": "text",
+        },
+      ],
+      "role": "user",
+    },
+    {
+      "content": [
+        {
+          "id": "6k7x6c84",
+          "input": {},
+          "name": "list_databases",
+          "type": "tool_use",
+        },
+      ],
+      "role": "assistant",
+    },
+    {
+      "content": [
+        {
+          "content": "[{"text":"{\\"databases\\":[\\"admin\\",\\"config\\",\\"local\\"]}","type":"text"}]",
+          "tool_use_id": "6k7x6c84",
+          "type": "tool_result",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "model": "claude-sonnet-4-5-20250929",
+  "tool_choice": {
+    "type": "auto",
+  },
+  "tools": [
+    {
+      "description": "List databases in the connected MongoDB instance.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "list_databases",
+      "strict": false,
+    },
+  ],
+}
+`;
+
+exports[`responses → anthropic > responsesFunctionCallOutputWithoutThoughtSignatureParam > response 1`] = `
+{
+  "created_at": 0,
+  "id": "resp_01JimcjPekKD1ZgMUksBLG27",
+  "incomplete_details": null,
+  "model": "claude-sonnet-4-5-20250929",
+  "object": "response",
+  "output": [
+    {
+      "content": [
+        {
+          "annotations": [],
+          "text": "The connected MongoDB instance contains the following databases:
+
+1. **admin** - The administrative database for MongoDB
+2. **config** - Used for sharded cluster configuration data
+3. **local** - Contains local-only data (e.g., replication configuration)
+
+These are the standard system databases that come with a MongoDB installation. There don't appear to be any user-created databases in this instance yet.",
+          "type": "output_text",
+        },
+      ],
+      "id": "msg_transformed_item_0",
+      "role": "assistant",
+      "status": "completed",
+      "type": "message",
+    },
+  ],
+  "output_text": "The connected MongoDB instance contains the following databases:
+
+1. **admin** - The administrative database for MongoDB
+2. **config** - Used for sharded cluster configuration data
+3. **local** - Contains local-only data (e.g., replication configuration)
+
+These are the standard system databases that come with a MongoDB installation. There don't appear to be any user-created databases in this instance yet.",
+  "parallel_tool_calls": false,
+  "status": "completed",
+  "tool_choice": "none",
+  "tools": [],
+  "usage": {
+    "input_tokens": 642,
+    "input_tokens_details": {
+      "cached_tokens": 0,
+    },
+    "output_tokens": 89,
+    "output_tokens_details": {
+      "reasoning_tokens": 0,
+    },
+    "total_tokens": 731,
+  },
+}
+`;
+
 exports[`responses → anthropic > responsesInputFileUrlParam > request 1`] = `
 {
   "max_tokens": 4096,
@@ -30387,7 +30450,7 @@ exports[`responses → google > codeInterpreterToolParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -30603,10 +30666,10 @@ exports[`responses → google > complexReasoningRequest > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 15000,
+      "thinkingLevel": "HIGH",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -30997,7 +31060,7 @@ exports[`responses → google > exclusiveMinimumToolParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "tools": [
     {
       "functionDeclarations": [
@@ -31083,10 +31146,10 @@ exports[`responses → google > functionToolsWithReasoningEffortParam > request 
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 2048,
+      "thinkingLevel": "MEDIUM",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "tools": [
     {
       "functionDeclarations": [
@@ -31177,7 +31240,7 @@ exports[`responses → google > instructionsParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -31259,7 +31322,7 @@ exports[`responses → google > jsonSchemaFormatParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -31338,7 +31401,7 @@ exports[`responses → google > jsonSchemaMinMaxItemsParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -31414,7 +31477,7 @@ exports[`responses → google > jsonSchemaMinimumMaximumParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -31508,7 +31571,7 @@ exports[`responses → google > jsonSchemaPrefixItemsParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -31565,7 +31628,7 @@ exports[`responses → google > metadataParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -31632,7 +31695,7 @@ exports[`responses → google > multimodalRequest > request 1`] = `
     "maxOutputTokens": 300,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -31689,7 +31752,7 @@ exports[`responses → google > openaiPromptCacheKeyParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -31746,7 +31809,7 @@ exports[`responses → google > parallelToolCallsDisabledParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "tools": [
     {
       "functionDeclarations": [
@@ -31832,27 +31895,6 @@ exports[`responses → google > parallelToolCallsRequest > request 1`] = `
     {
       "parts": [
         {
-          "functionCall": {
-            "args": {
-              "location": "San Francisco, CA",
-            },
-            "name": "get_weather",
-          },
-        },
-        {
-          "functionCall": {
-            "args": {
-              "location": "New York, NY",
-            },
-            "name": "get_weather",
-          },
-        },
-      ],
-      "role": "model",
-    },
-    {
-      "parts": [
-        {
           "functionResponse": {
             "name": "get_weather",
             "response": {
@@ -31872,7 +31914,7 @@ exports[`responses → google > parallelToolCallsRequest > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "tools": [
     {
       "functionDeclarations": [
@@ -31953,7 +31995,7 @@ exports[`responses → google > promptCacheKeyParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32014,10 +32056,10 @@ exports[`responses → google > reasoningEffortLowParam > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "LOW",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32093,10 +32135,10 @@ exports[`responses → google > reasoningEffortMinimalParam > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "MINIMAL",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32176,10 +32218,10 @@ exports[`responses → google > reasoningEffortNoneParam > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 0,
+      "thinkingLevel": "THINKING_LEVEL_UNSPECIFIED",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32240,10 +32282,10 @@ exports[`responses → google > reasoningRequest > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 3072,
+      "thinkingLevel": "HIGH",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32426,10 +32468,10 @@ exports[`responses → google > reasoningRequestTruncated > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "HIGH",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32507,10 +32549,10 @@ exports[`responses → google > reasoningSummaryParam > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 2048,
+      "thinkingLevel": "MEDIUM",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32586,10 +32628,10 @@ exports[`responses → google > reasoningWithOutput > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "LOW",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32698,6 +32740,112 @@ So, while we most commonly think of the sky as **blue**, it can be a beautiful s
 }
 `;
 
+exports[`responses → google > responsesFunctionCallOutputWithoutThoughtSignatureParam > request 1`] = `
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "What databases exist in the connected MongoDB instance? Use the list_databases tool.",
+        },
+      ],
+      "role": "user",
+    },
+    {
+      "parts": [
+        {
+          "functionResponse": {
+            "id": "6k7x6c84",
+            "name": "list_databases",
+            "response": {
+              "output": [
+                {
+                  "text": "{"databases":["admin","config","local"]}",
+                  "type": "text",
+                },
+              ],
+            },
+          },
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "model": "gemini-3.5-flash",
+  "toolConfig": {
+    "functionCallingConfig": {
+      "mode": "AUTO",
+    },
+  },
+  "tools": [
+    {
+      "functionDeclarations": [
+        {
+          "description": "List databases in the connected MongoDB instance.",
+          "name": "list_databases",
+          "parameters": null,
+          "parametersJsonSchema": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object",
+          },
+          "response": null,
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`responses → google > responsesFunctionCallOutputWithoutThoughtSignatureParam > response 1`] = `
+{
+  "created_at": 0,
+  "id": "resp_transformed",
+  "incomplete_details": null,
+  "model": "gemini-3.5-flash",
+  "object": "response",
+  "output": [
+    {
+      "content": [
+        {
+          "annotations": [],
+          "text": "The following databases exist in the connected MongoDB instance:
+
+* admin
+* config
+* local",
+          "type": "output_text",
+        },
+      ],
+      "id": "msg_transformed_item_0",
+      "role": "assistant",
+      "status": "completed",
+      "type": "message",
+    },
+  ],
+  "output_text": "The following databases exist in the connected MongoDB instance:
+
+* admin
+* config
+* local",
+  "parallel_tool_calls": false,
+  "status": "completed",
+  "tool_choice": "none",
+  "tools": [],
+  "usage": {
+    "input_tokens": 78,
+    "input_tokens_details": {
+      "cached_tokens": 0,
+    },
+    "output_tokens": 47,
+    "output_tokens_details": {
+      "reasoning_tokens": 28,
+    },
+    "total_tokens": 125,
+  },
+}
+`;
+
 exports[`responses → google > responsesInputFileUrlParam > request 1`] = `
 {
   "contents": [
@@ -32716,7 +32864,7 @@ exports[`responses → google > responsesInputFileUrlParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32851,7 +32999,7 @@ exports[`responses → google > safetyIdentifierParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32908,7 +33056,7 @@ exports[`responses → google > serviceTierParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -32969,10 +33117,10 @@ exports[`responses → google > simpleRequest > request 1`] = `
     "responseSchema": null,
     "thinkingConfig": {
       "includeThoughts": true,
-      "thinkingBudget": 1024,
+      "thinkingLevel": "MINIMAL",
     },
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -33046,7 +33194,7 @@ exports[`responses → google > simpleRequestTruncated > request 1`] = `
     "maxOutputTokens": 1,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -33089,7 +33237,7 @@ exports[`responses → google > storeDisabledParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -33150,7 +33298,7 @@ exports[`responses → google > systemMessageArrayContent > request 1`] = `
     "maxOutputTokens": 300,
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "systemInstruction": {
     "parts": [
       {
@@ -33252,7 +33400,7 @@ exports[`responses → google > textFormatJsonObjectParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -33334,7 +33482,7 @@ exports[`responses → google > textFormatJsonSchemaParam > request 1`] = `
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -33413,7 +33561,7 @@ exports[`responses → google > textFormatJsonSchemaWithDescriptionParam > reque
     "responseMimeType": "application/json",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -33474,7 +33622,7 @@ exports[`responses → google > textFormatTextParam > request 1`] = `
     "responseMimeType": "text/plain",
     "responseSchema": null,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -33612,7 +33760,7 @@ exports[`responses → google > toolChoiceRequiredParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
   "toolConfig": {
     "functionCallingConfig": {
       "allowedFunctionNames": [
@@ -33700,7 +33848,7 @@ exports[`responses → google > topPReasoningModelParam > request 1`] = `
     "responseSchema": null,
     "topP": 0.9,
   },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -33757,7 +33905,7 @@ exports[`responses → google > truncationAutoParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 
@@ -33814,7 +33962,7 @@ exports[`responses → google > webSearchToolParam > request 1`] = `
       "role": "user",
     },
   ],
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.5-flash",
 }
 `;
 

--- a/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/followup-request.json
+++ b/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/followup-request.json
@@ -1,0 +1,63 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "What databases exist in the connected MongoDB instance? Use the list_databases tool."
+        }
+      ]
+    },
+    {
+      "type": "function_call",
+      "call_id": "6k7x6c84",
+      "name": "list_databases",
+      "arguments": "{}"
+    },
+    {
+      "type": "function_call_output",
+      "call_id": "6k7x6c84",
+      "output": "[{\"type\":\"text\",\"text\":\"{\\\"databases\\\":[\\\"admin\\\",\\\"config\\\",\\\"local\\\"]}\"}]"
+    },
+    {
+      "id": "rs_0c6dbce448cc8b0b006a2327e47c88819c81c61315bc2d1899",
+      "type": "reasoning",
+      "content": [],
+      "summary": []
+    },
+    {
+      "id": "msg_0c6dbce448cc8b0b006a2327e8fc20819c9edd24c2ca621d1b",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "The connected MongoDB instance has these databases:\n- admin\n- config\n- local"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "name": "list_databases",
+      "description": "List databases in the connected MongoDB instance.",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "strict": false
+    }
+  ],
+  "tool_choice": "auto"
+}

--- a/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/followup-response-streaming.json
+++ b/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/followup-response-streaming.json
@@ -1,0 +1,4134 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_0c6dbce448cc8b0b006a2327ec0ec8819c97c1bfafd8b8a560",
+      "object": "response",
+      "created_at": 1780688876,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "moderation": null,
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": "in_memory",
+      "reasoning": {
+        "context": "current_turn",
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "function",
+          "description": "List databases in the connected MongoDB instance.",
+          "name": "list_databases",
+          "parameters": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+          },
+          "strict": false
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_0c6dbce448cc8b0b006a2327ec0ec8819c97c1bfafd8b8a560",
+      "object": "response",
+      "created_at": 1780688876,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "moderation": null,
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": "in_memory",
+      "reasoning": {
+        "context": "current_turn",
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "function",
+          "description": "List databases in the connected MongoDB instance.",
+          "name": "list_databases",
+          "parameters": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+          },
+          "strict": false
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_0c6dbce448cc8b0b006a2327ec5c94819c876f5101a9cf1405",
+      "type": "reasoning",
+      "content": [],
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_0c6dbce448cc8b0b006a2327ec5c94819c876f5101a9cf1405",
+      "type": "reasoning",
+      "content": [],
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Since",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "uEEOdakCpSx",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " the",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "byMPgGo4hJ14",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " only",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Zqe2q6bRb5w",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " databases",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "skgCWm",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " shown",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "QigIsIhz4I",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " are",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "QMYEqY1MninL",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " admin",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "6IZJVk1QFZ",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "piJOxRuX5I058rW",
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " config",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "w1qYl2Cqs",
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "78K5Wlh6SOIBY91",
+    "output_index": 1,
+    "sequence_number": 15
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "T2Z6jPsYhMW6",
+    "output_index": 1,
+    "sequence_number": 16
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " local",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "nAWhN1XzpH",
+    "output_index": 1,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "PMjRvOqdQT09fzH",
+    "output_index": 1,
+    "sequence_number": 18
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "r9Q5SNOnrXh3",
+    "output_index": 1,
+    "sequence_number": 19
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’re",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "vCuvv4s6Pp82o",
+    "output_index": 1,
+    "sequence_number": 20
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " looking",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "0QRxM6T7",
+    "output_index": 1,
+    "sequence_number": 21
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " at",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "reNZLru8bdjOZ",
+    "output_index": 1,
+    "sequence_number": 22
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Mongo",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "urMnjiXmbN",
+    "output_index": 1,
+    "sequence_number": 23
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "DB",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "8xhWeH4COjVM0Y",
+    "output_index": 1,
+    "sequence_number": 24
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’s",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "xEarcJflTDx0LC",
+    "output_index": 1,
+    "sequence_number": 25
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " system",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "siLIms6sF",
+    "output_index": 1,
+    "sequence_number": 26
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " databases",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "S9sPiV",
+    "output_index": 1,
+    "sequence_number": 27
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "cx18Sn0gxE3Pkqr",
+    "output_index": 1,
+    "sequence_number": 28
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " What",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "AgFm1Q1SiOF",
+    "output_index": 1,
+    "sequence_number": 29
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "CCoUMVJJxhsX",
+    "output_index": 1,
+    "sequence_number": 30
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " do",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "6biLeGEfOjbU5",
+    "output_index": 1,
+    "sequence_number": 31
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " next",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "jLNME6QPndP",
+    "output_index": 1,
+    "sequence_number": 32
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " depends",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "peuYNHGq",
+    "output_index": 1,
+    "sequence_number": 33
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " on",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "lVzShavV5Diey",
+    "output_index": 1,
+    "sequence_number": 34
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " your",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "6Xkj2udRFZI",
+    "output_index": 1,
+    "sequence_number": 35
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " goal",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "fw0Rx8GMoC2",
+    "output_index": 1,
+    "sequence_number": 36
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "0ZTmdE4356TE93L",
+    "output_index": 1,
+    "sequence_number": 37
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Here",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Bxhv3jH4PCk",
+    "output_index": 1,
+    "sequence_number": 38
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " are",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "3Lf2X1KKsu3L",
+    "output_index": 1,
+    "sequence_number": 39
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " practical",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "8uQ6wG",
+    "output_index": 1,
+    "sequence_number": 40
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " options",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "1ma0OZZ3",
+    "output_index": 1,
+    "sequence_number": 41
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":\n\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "h0jj0jTjtsB5c",
+    "output_index": 1,
+    "sequence_number": 42
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "EBpT2VPe15wx6yR",
+    "output_index": 1,
+    "sequence_number": 43
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Explore",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "kZhmuwec",
+    "output_index": 1,
+    "sequence_number": 44
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " data",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "ZXiZdCxdMeG",
+    "output_index": 1,
+    "sequence_number": 45
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "tEI5r7wLzvCyOd",
+    "output_index": 1,
+    "sequence_number": 46
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "if",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "K8HqeTsZnEdyVB",
+    "output_index": 1,
+    "sequence_number": 47
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "7ARWCFL72dSz",
+    "output_index": 1,
+    "sequence_number": 48
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " plan",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "X2XmbpTpUJN",
+    "output_index": 1,
+    "sequence_number": 49
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " to",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "dBLJQLQNiWZZk",
+    "output_index": 1,
+    "sequence_number": 50
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " add",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "ETiVKozgMnUJ",
+    "output_index": 1,
+    "sequence_number": 51
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " your",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "3XFLs6iyihx",
+    "output_index": 1,
+    "sequence_number": 52
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " own",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "LC0HdqPJsn3b",
+    "output_index": 1,
+    "sequence_number": 53
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " data",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Lpcn2tyMGSW",
+    "output_index": 1,
+    "sequence_number": 54
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ")\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "DcxlwJmd34LN2Q",
+    "output_index": 1,
+    "sequence_number": 55
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "s1wQ7iA4NgTNUo2",
+    "output_index": 1,
+    "sequence_number": 56
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "fw19auSTyAlvNH",
+    "output_index": 1,
+    "sequence_number": 57
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " In",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Cb3tOppiGQqo3",
+    "output_index": 1,
+    "sequence_number": 58
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " the",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "eIfViptXmOBH",
+    "output_index": 1,
+    "sequence_number": 59
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " shell",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "sAHqpDEdOD",
+    "output_index": 1,
+    "sequence_number": 60
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "TIfwPxr1oGSziu",
+    "output_index": 1,
+    "sequence_number": 61
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "HrRngkTVRSLEX",
+    "output_index": 1,
+    "sequence_number": 62
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "YKRrZDk7eXEqJF",
+    "output_index": 1,
+    "sequence_number": 63
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " use",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "rephe8DtADEa",
+    "output_index": 1,
+    "sequence_number": 64
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " my",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Kcpr9UBJyHwt4",
+    "output_index": 1,
+    "sequence_number": 65
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "bPfDKQKvo1iqJG",
+    "output_index": 1,
+    "sequence_number": 66
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "JoXxwUDbVAym2xC",
+    "output_index": 1,
+    "sequence_number": 67
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "tcG9bYBD4XVMd",
+    "output_index": 1,
+    "sequence_number": 68
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "VloF69QdBq5GqF",
+    "output_index": 1,
+    "sequence_number": 69
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "DvCORH2yhPZ6i",
+    "output_index": 1,
+    "sequence_number": 70
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".create",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "1WXZtHwJJ",
+    "output_index": 1,
+    "sequence_number": 71
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Collection",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "w09EqP",
+    "output_index": 1,
+    "sequence_number": 72
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "(\"",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "aHyY6fjTyKbxIa",
+    "output_index": 1,
+    "sequence_number": 73
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "my",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "NdsGkbAgOrSAqW",
+    "output_index": 1,
+    "sequence_number": 74
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "collection",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "X1ug8S",
+    "output_index": 1,
+    "sequence_number": 75
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\")\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "BBcSRxQ8Ns0yg",
+    "output_index": 1,
+    "sequence_number": 76
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "O8cF1ibPPMDcv",
+    "output_index": 1,
+    "sequence_number": 77
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "VQ9dswC8XTujoG",
+    "output_index": 1,
+    "sequence_number": 78
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "7FvmwXiz2AQfg",
+    "output_index": 1,
+    "sequence_number": 79
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".my",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "tIuaqyN9pC2gJ",
+    "output_index": 1,
+    "sequence_number": 80
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "collection",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "vxvCf5",
+    "output_index": 1,
+    "sequence_number": 81
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".insert",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "B8ZiSV6X5",
+    "output_index": 1,
+    "sequence_number": 82
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "One",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "xcT41iNXsw9WE",
+    "output_index": 1,
+    "sequence_number": 83
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "({",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "eK9KDiFlvvsNdM",
+    "output_index": 1,
+    "sequence_number": 84
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " name",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "3yoQOvXEGWt",
+    "output_index": 1,
+    "sequence_number": 85
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "WbcArstMREHnPRS",
+    "output_index": 1,
+    "sequence_number": 86
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " \"",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "OVvlSDLfa345Zx",
+    "output_index": 1,
+    "sequence_number": 87
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Alice",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "R9V8ETaJxL8",
+    "output_index": 1,
+    "sequence_number": 88
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "wBbOIFZuH7LKHv",
+    "output_index": 1,
+    "sequence_number": 89
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " age",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "FPsQMcHMSADq",
+    "output_index": 1,
+    "sequence_number": 90
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "ExRvOdTRrMUfoFO",
+    "output_index": 1,
+    "sequence_number": 91
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Jdkcv6Y4rZK53wk",
+    "output_index": 1,
+    "sequence_number": 92
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "30",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "oXEwUmoX1aGyaI",
+    "output_index": 1,
+    "sequence_number": 93
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " })\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "o9VtBPfy9Kus",
+    "output_index": 1,
+    "sequence_number": 94
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "I5A9Okp9sN98n",
+    "output_index": 1,
+    "sequence_number": 95
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "FpdnqSb1EY4IxU",
+    "output_index": 1,
+    "sequence_number": 96
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "XRLJUkUwGdnaK",
+    "output_index": 1,
+    "sequence_number": 97
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".my",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "dbUp07C2Jx07l",
+    "output_index": 1,
+    "sequence_number": 98
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "collection",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "x5zhq0",
+    "output_index": 1,
+    "sequence_number": 99
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".find",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "745X5ZN3tyX",
+    "output_index": 1,
+    "sequence_number": 100
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "({",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "50nFlF8BnuNC3L",
+    "output_index": 1,
+    "sequence_number": 101
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "})\n\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "43RBYcwVVlDV",
+    "output_index": 1,
+    "sequence_number": 102
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "z6FPmCZNDqxG0q3",
+    "output_index": 1,
+    "sequence_number": 103
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Inspect",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "rcnZHKZq",
+    "output_index": 1,
+    "sequence_number": 104
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " what's",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "7LadU3YYM",
+    "output_index": 1,
+    "sequence_number": 105
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " in",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "wBXq3YGOWdd7u",
+    "output_index": 1,
+    "sequence_number": 106
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " the",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Z1vzEigEkFao",
+    "output_index": 1,
+    "sequence_number": 107
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " system",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "iBlSUIszh",
+    "output_index": 1,
+    "sequence_number": 108
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " databases",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "shzZRb",
+    "output_index": 1,
+    "sequence_number": 109
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "d7sJELh1kxXwtpM",
+    "output_index": 1,
+    "sequence_number": 110
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "ohkmL1TbLRHinGJ",
+    "output_index": 1,
+    "sequence_number": 111
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "RxVHNWk6Gv3F64",
+    "output_index": 1,
+    "sequence_number": 112
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Admin",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "r7llctbEKc",
+    "output_index": 1,
+    "sequence_number": 113
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " users",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "fsbJy5AKV9",
+    "output_index": 1,
+    "sequence_number": 114
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "9q1REyjGA0XliD",
+    "output_index": 1,
+    "sequence_number": 115
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "in",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "gTxEGipQlqZskI",
+    "output_index": 1,
+    "sequence_number": 116
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " admin",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "7vXiHozbco",
+    "output_index": 1,
+    "sequence_number": 117
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "):\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "kDEeQ2AFxRWtx",
+    "output_index": 1,
+    "sequence_number": 118
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Km66IfQWBG0Qg",
+    "output_index": 1,
+    "sequence_number": 119
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "EmuvVTTpdrDK3L",
+    "output_index": 1,
+    "sequence_number": 120
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " use",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "ccBLOjz2gbhW",
+    "output_index": 1,
+    "sequence_number": 121
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " admin",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "pTGGZ3SgtD",
+    "output_index": 1,
+    "sequence_number": 122
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Xylrmmwewm1VxGC",
+    "output_index": 1,
+    "sequence_number": 123
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "4C0wpZWJQ58sH",
+    "output_index": 1,
+    "sequence_number": 124
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "pa5q1bCfG3hyhC",
+    "output_index": 1,
+    "sequence_number": 125
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " show",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "7HDvW52ruiw",
+    "output_index": 1,
+    "sequence_number": 126
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " collections",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "vT6v",
+    "output_index": 1,
+    "sequence_number": 127
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "apogur5TUaJ2qMo",
+    "output_index": 1,
+    "sequence_number": 128
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Acpb9ZVNxKf0t",
+    "output_index": 1,
+    "sequence_number": 129
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "0EfJ0fdLSEnPux",
+    "output_index": 1,
+    "sequence_number": 130
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "2Vzxv2gy9Vj0v",
+    "output_index": 1,
+    "sequence_number": 131
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".get",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "OjTQsEygUxdN",
+    "output_index": 1,
+    "sequence_number": 132
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Users",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "4Ci2CTjNyJt",
+    "output_index": 1,
+    "sequence_number": 133
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "()\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "hPqWGtasoLrTy",
+    "output_index": 1,
+    "sequence_number": 134
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "hUuvQzEK6Xl80AO",
+    "output_index": 1,
+    "sequence_number": 135
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "q5HDV4b1LulQMH",
+    "output_index": 1,
+    "sequence_number": 136
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Config",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "bVFEgJ2bt",
+    "output_index": 1,
+    "sequence_number": 137
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "MgkqIjJl5qfhSO",
+    "output_index": 1,
+    "sequence_number": 138
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "in",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "VUCkkcXr7cedM3",
+    "output_index": 1,
+    "sequence_number": 139
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " config",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "1Frz2AEKf",
+    "output_index": 1,
+    "sequence_number": 140
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "):\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "LwkmluOlbvD60",
+    "output_index": 1,
+    "sequence_number": 141
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "loVKm6G5f4Aqi",
+    "output_index": 1,
+    "sequence_number": 142
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "8Ea7CJkGRmMr42",
+    "output_index": 1,
+    "sequence_number": 143
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " use",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "r8PPXzHTOqjX",
+    "output_index": 1,
+    "sequence_number": 144
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " config",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "vI2brcUgZ",
+    "output_index": 1,
+    "sequence_number": 145
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "yCOjOD2JE9VFAFZ",
+    "output_index": 1,
+    "sequence_number": 146
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "pJzZkx146Od4u",
+    "output_index": 1,
+    "sequence_number": 147
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "TU98MXrDZH30wk",
+    "output_index": 1,
+    "sequence_number": 148
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "81QJdSQLWFuhB",
+    "output_index": 1,
+    "sequence_number": 149
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".sh",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "kkzw80UIwUQae",
+    "output_index": 1,
+    "sequence_number": 150
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "ards",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "T8fe2oSLOfnK",
+    "output_index": 1,
+    "sequence_number": 151
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".find",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "5QVV7B2u0wj",
+    "output_index": 1,
+    "sequence_number": 152
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "()\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "NgZZk29dwFqyl",
+    "output_index": 1,
+    "sequence_number": 153
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "wdS1yHRCK9k6d",
+    "output_index": 1,
+    "sequence_number": 154
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "OSHZ2EfK8zyRl6",
+    "output_index": 1,
+    "sequence_number": 155
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "0jCBfRMzYJcrE",
+    "output_index": 1,
+    "sequence_number": 156
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".ch",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "0Uy7IvMsRMZID",
+    "output_index": 1,
+    "sequence_number": 157
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "unks",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "8pmdrsxYO9Y9",
+    "output_index": 1,
+    "sequence_number": 158
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".find",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "NThCCEHwcwj",
+    "output_index": 1,
+    "sequence_number": 159
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "({",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "wsr3mMlrMzvlB8",
+    "output_index": 1,
+    "sequence_number": 160
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "})",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "VBiiJV7IXwt60W",
+    "output_index": 1,
+    "sequence_number": 161
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "LVDfVe6W4aBGnHE",
+    "output_index": 1,
+    "sequence_number": 162
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " //",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "ajPFTET8TfDTI",
+    "output_index": 1,
+    "sequence_number": 163
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " if",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "EjCHc24fdcxYm",
+    "output_index": 1,
+    "sequence_number": 164
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " sh",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "bSMUlRECdacDj",
+    "output_index": 1,
+    "sequence_number": 165
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "arding",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "oCcbMiBH6u",
+    "output_index": 1,
+    "sequence_number": 166
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " is",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "wsNxsbykK0wv9",
+    "output_index": 1,
+    "sequence_number": 167
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " configured",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "BzPzq",
+    "output_index": 1,
+    "sequence_number": 168
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "b2HR1EHJR6mGdNH",
+    "output_index": 1,
+    "sequence_number": 169
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "GHWLzwt8M0s4gx4",
+    "output_index": 1,
+    "sequence_number": 170
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "0c9Cf6VWcTVi8T",
+    "output_index": 1,
+    "sequence_number": 171
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Local",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "y3DQXX7aJ1",
+    "output_index": 1,
+    "sequence_number": 172
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "PhD6JU78OkDhCv",
+    "output_index": 1,
+    "sequence_number": 173
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "in",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "b9asJQzuDnjnA7",
+    "output_index": 1,
+    "sequence_number": 174
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " local",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "o989G4dY2J",
+    "output_index": 1,
+    "sequence_number": 175
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "):\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "MOyjVPEo80EaY",
+    "output_index": 1,
+    "sequence_number": 176
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "oPdzz0QopVZAx",
+    "output_index": 1,
+    "sequence_number": 177
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "lce68vdmfl2vAk",
+    "output_index": 1,
+    "sequence_number": 178
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " use",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "9cxArxo3KjV0",
+    "output_index": 1,
+    "sequence_number": 179
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " local",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "XQzis6YHw5",
+    "output_index": 1,
+    "sequence_number": 180
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "QXKnoqWRn3HH2EV",
+    "output_index": 1,
+    "sequence_number": 181
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "vzZkHPbea1yHM",
+    "output_index": 1,
+    "sequence_number": 182
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "BFc6fdHKnz86gI",
+    "output_index": 1,
+    "sequence_number": 183
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "D8Dr3DP9JNpvl",
+    "output_index": 1,
+    "sequence_number": 184
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".op",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Op8dzD7kTin1V",
+    "output_index": 1,
+    "sequence_number": 185
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "log",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "TlBEvtHO8PfWb",
+    "output_index": 1,
+    "sequence_number": 186
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".rs",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "WC45ebpRweoHm",
+    "output_index": 1,
+    "sequence_number": 187
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".find",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "rBmfPs70g8h",
+    "output_index": 1,
+    "sequence_number": 188
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "().",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "vlNbXlGTPGIFV",
+    "output_index": 1,
+    "sequence_number": 189
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "limit",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "hkqLTNJI2Jt",
+    "output_index": 1,
+    "sequence_number": 190
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "(",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "5WKAg5g5fGHk1ye",
+    "output_index": 1,
+    "sequence_number": 191
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "5",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "j7oEUxRPEvV854u",
+    "output_index": 1,
+    "sequence_number": 192
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ")",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "MzaYBUCl1dmnct4",
+    "output_index": 1,
+    "sequence_number": 193
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "ebiLXpBPlK5uWsh",
+    "output_index": 1,
+    "sequence_number": 194
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " //",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "cnV6eoMkz6fc0",
+    "output_index": 1,
+    "sequence_number": 195
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " only",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "mtvATvCWH0E",
+    "output_index": 1,
+    "sequence_number": 196
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " if",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "R02UY9UKLYvjg",
+    "output_index": 1,
+    "sequence_number": 197
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "QkBM2J6KILkr",
+    "output_index": 1,
+    "sequence_number": 198
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’re",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "1yyEIAdcwxD4n",
+    "output_index": 1,
+    "sequence_number": 199
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " running",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "GSuWt2EG",
+    "output_index": 1,
+    "sequence_number": 200
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "t7cLHhUXlA2EVn",
+    "output_index": 1,
+    "sequence_number": 201
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " replica",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "BsqYTsHw",
+    "output_index": 1,
+    "sequence_number": 202
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " set",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "pr5WZ04bvm6v",
+    "output_index": 1,
+    "sequence_number": 203
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "fl5AX6JPW1Hubp",
+    "output_index": 1,
+    "sequence_number": 204
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "smOxJT4fSnaWltp",
+    "output_index": 1,
+    "sequence_number": 205
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Check",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "XBwwjgYxJj",
+    "output_index": 1,
+    "sequence_number": 206
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " server",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "OSQbhTNiN",
+    "output_index": 1,
+    "sequence_number": 207
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " health",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "3Jl51wS4N",
+    "output_index": 1,
+    "sequence_number": 208
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Pb7aAeU8w1Xo",
+    "output_index": 1,
+    "sequence_number": 209
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " status",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "PoTvZ0Ef5",
+    "output_index": 1,
+    "sequence_number": 210
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "xvJlqFKHfJUybN4",
+    "output_index": 1,
+    "sequence_number": 211
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "B5UxEh4n5OVtYdM",
+    "output_index": 1,
+    "sequence_number": 212
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "lK7rGg4Erm14Rk",
+    "output_index": 1,
+    "sequence_number": 213
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "6yxXeNEjptHER",
+    "output_index": 1,
+    "sequence_number": 214
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".server",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "ufByvoPZg",
+    "output_index": 1,
+    "sequence_number": 215
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Status",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "OhAK7THkv0",
+    "output_index": 1,
+    "sequence_number": 216
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "()\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "dYCf5zv9SS4sc",
+    "output_index": 1,
+    "sequence_number": 217
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "BkTo27OxnSvEnPX",
+    "output_index": 1,
+    "sequence_number": 218
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "j41zRnuwjZwG9M",
+    "output_index": 1,
+    "sequence_number": 219
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "piQQe0OflaCCH",
+    "output_index": 1,
+    "sequence_number": 220
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".stats",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "xi3j7VslfY",
+    "output_index": 1,
+    "sequence_number": 221
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "()\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "8VOnYbQzKeBLz",
+    "output_index": 1,
+    "sequence_number": 222
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "89KPHYmo0Myd9pL",
+    "output_index": 1,
+    "sequence_number": 223
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "PPZM8zbW9no46n",
+    "output_index": 1,
+    "sequence_number": 224
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " If",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "OOgj0FslHRbR1",
+    "output_index": 1,
+    "sequence_number": 225
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "wepVTEIj3vRQ",
+    "output_index": 1,
+    "sequence_number": 226
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’re",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "qtuA11IwhhcVO",
+    "output_index": 1,
+    "sequence_number": 227
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " on",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "DVZlEEVNmHTzB",
+    "output_index": 1,
+    "sequence_number": 228
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " a",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "PTEeQhuWOJzNL3",
+    "output_index": 1,
+    "sequence_number": 229
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " replica",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "T8SsnDfx",
+    "output_index": 1,
+    "sequence_number": 230
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " set",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "9bjwy7ZUV8Cl",
+    "output_index": 1,
+    "sequence_number": 231
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "yz2ysScdtcif4bh",
+    "output_index": 1,
+    "sequence_number": 232
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " rs",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "CrLe8flIcnJRQ",
+    "output_index": 1,
+    "sequence_number": 233
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".status",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "xQSRIgFYY",
+    "output_index": 1,
+    "sequence_number": 234
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "()",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "553t6RgfKzxbm9",
+    "output_index": 1,
+    "sequence_number": 235
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "PsVxPosdrls6",
+    "output_index": 1,
+    "sequence_number": 236
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " rs",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "R3Ug4UnNDqqtR",
+    "output_index": 1,
+    "sequence_number": 237
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".config",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "qEP38adOL",
+    "output_index": 1,
+    "sequence_number": 238
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "()\n\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "yIGgwKrZjxKo",
+    "output_index": 1,
+    "sequence_number": 239
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "07NTD4nd1MRzaiv",
+    "output_index": 1,
+    "sequence_number": 240
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Set",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "9GHDykhfi1mF",
+    "output_index": 1,
+    "sequence_number": 241
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " up",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "JfZbDLEAHaYQC",
+    "output_index": 1,
+    "sequence_number": 242
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " authentication",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "0",
+    "output_index": 1,
+    "sequence_number": 243
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "S5883ss6t8G9ZV",
+    "output_index": 1,
+    "sequence_number": 244
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "recommended",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "OBZZY",
+    "output_index": 1,
+    "sequence_number": 245
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " for",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "qxijxRNkF34h",
+    "output_index": 1,
+    "sequence_number": 246
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " production",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "2R5Rw",
+    "output_index": 1,
+    "sequence_number": 247
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ")\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "54gu8qCLzf2mwp",
+    "output_index": 1,
+    "sequence_number": 248
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "3Vd1M6h2OJLng7V",
+    "output_index": 1,
+    "sequence_number": 249
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "FCyRLZOtR7yOD2",
+    "output_index": 1,
+    "sequence_number": 250
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " If",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "1A4dUwlJIAGuG",
+    "output_index": 1,
+    "sequence_number": 251
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " auth",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "dycBjPdeYud",
+    "output_index": 1,
+    "sequence_number": 252
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " isn",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "wr14x9WCKmcq",
+    "output_index": 1,
+    "sequence_number": 253
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’t",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "4N9mHfToAjLPq3",
+    "output_index": 1,
+    "sequence_number": 254
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " enabled",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "XSuSlPWQ",
+    "output_index": 1,
+    "sequence_number": 255
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " yet",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Ffy1i7ZKQkhO",
+    "output_index": 1,
+    "sequence_number": 256
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "HksAaRLyZIslsxW",
+    "output_index": 1,
+    "sequence_number": 257
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "V0VAdckOAzGs",
+    "output_index": 1,
+    "sequence_number": 258
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "’ll",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "DqrJY7hktn7LH",
+    "output_index": 1,
+    "sequence_number": 259
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " typically",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "VZFGOr",
+    "output_index": 1,
+    "sequence_number": 260
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "KSuC2cf92JcqOP",
+    "output_index": 1,
+    "sequence_number": 261
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "N375MNhZPSfUs",
+    "output_index": 1,
+    "sequence_number": 262
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "SEpH93Fd9PCfhu",
+    "output_index": 1,
+    "sequence_number": 263
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " create",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Z1FJCdaub",
+    "output_index": 1,
+    "sequence_number": 264
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " an",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "CAWTIgIZJbP8U",
+    "output_index": 1,
+    "sequence_number": 265
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " admin",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "NrhSg5WVZT",
+    "output_index": 1,
+    "sequence_number": 266
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " user",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "H4LnsUzVtwQ",
+    "output_index": 1,
+    "sequence_number": 267
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " in",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "D5S0CJjSM678F",
+    "output_index": 1,
+    "sequence_number": 268
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " admin",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "004fDM6Qzf",
+    "output_index": 1,
+    "sequence_number": 269
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "XpQZEF6qrBw86W7",
+    "output_index": 1,
+    "sequence_number": 270
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "BAeWAfgnFPjlf",
+    "output_index": 1,
+    "sequence_number": 271
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "UP1Fc0Rso0iROm",
+    "output_index": 1,
+    "sequence_number": 272
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " restart",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "DHYfLZrj",
+    "output_index": 1,
+    "sequence_number": 273
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " mong",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "0tNnyeYFZEE",
+    "output_index": 1,
+    "sequence_number": 274
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "od",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "PEGh5mi7srYMIf",
+    "output_index": 1,
+    "sequence_number": 275
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " with",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "EqpdC0LdyzH",
+    "output_index": 1,
+    "sequence_number": 276
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " --",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "I9ldTbb2lrkHz",
+    "output_index": 1,
+    "sequence_number": 277
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "auth",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "HaMH9I0umy0K",
+    "output_index": 1,
+    "sequence_number": 278
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "TdYf2ZLNOfjBSes",
+    "output_index": 1,
+    "sequence_number": 279
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "RmMlxl8U8g5Kzne",
+    "output_index": 1,
+    "sequence_number": 280
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Pb3udZQtUg78Ap",
+    "output_index": 1,
+    "sequence_number": 281
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Example",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "4wXvwy4j",
+    "output_index": 1,
+    "sequence_number": 282
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "t5u38XNUjYfmJp",
+    "output_index": 1,
+    "sequence_number": 283
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "in",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Lf9Z53n4DTLQKg",
+    "output_index": 1,
+    "sequence_number": 284
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " admin",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "EDKCNaBSzk",
+    "output_index": 1,
+    "sequence_number": 285
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "):\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "fR7rA02W1viu6",
+    "output_index": 1,
+    "sequence_number": 286
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "D1mgjuUL0AlgE",
+    "output_index": 1,
+    "sequence_number": 287
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "EJcZWpjbuYoVp0",
+    "output_index": 1,
+    "sequence_number": 288
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " use",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "ZZdIpVtbLZT3",
+    "output_index": 1,
+    "sequence_number": 289
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " admin",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "TjQL8V6ORS",
+    "output_index": 1,
+    "sequence_number": 290
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "JGWyMdvmEcWTvzM",
+    "output_index": 1,
+    "sequence_number": 291
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "   ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "i1EzZz6uKj2mT",
+    "output_index": 1,
+    "sequence_number": 292
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "RIcFtUrt9tcp66",
+    "output_index": 1,
+    "sequence_number": 293
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "jt0iTVVFxru95",
+    "output_index": 1,
+    "sequence_number": 294
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".create",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "SU8jLclT5",
+    "output_index": 1,
+    "sequence_number": 295
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "User",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "xmtVQOrIKJqc",
+    "output_index": 1,
+    "sequence_number": 296
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "({",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "kR8dDE4PQdvsMp",
+    "output_index": 1,
+    "sequence_number": 297
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " user",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "9BdnLkV2rx3",
+    "output_index": 1,
+    "sequence_number": 298
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "dJzWoKHAPapj0sG",
+    "output_index": 1,
+    "sequence_number": 299
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " \"",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "l21IKvJ5lAVrbd",
+    "output_index": 1,
+    "sequence_number": 300
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "admin",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Cu2wM83tyqW",
+    "output_index": 1,
+    "sequence_number": 301
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "vPi1xcXBAWVjl0",
+    "output_index": 1,
+    "sequence_number": 302
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " pwd",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "bLQdvuY447Wn",
+    "output_index": 1,
+    "sequence_number": 303
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "fr9JKi45ylLhEb0",
+    "output_index": 1,
+    "sequence_number": 304
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " \"",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "f964fkibiSYM4h",
+    "output_index": 1,
+    "sequence_number": 305
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "strong",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "1helxjuF0r",
+    "output_index": 1,
+    "sequence_number": 306
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "password",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "naBbZBeN",
+    "output_index": 1,
+    "sequence_number": 307
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "vJk6nCyc7nxOl9",
+    "output_index": 1,
+    "sequence_number": 308
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " roles",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "UAFYkTNaBt",
+    "output_index": 1,
+    "sequence_number": 309
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "afbH5phAxF7hRTb",
+    "output_index": 1,
+    "sequence_number": 310
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " [{",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "kbDVI76Rpr5Eo",
+    "output_index": 1,
+    "sequence_number": 311
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " role",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "hpBB3bfTUK0",
+    "output_index": 1,
+    "sequence_number": 312
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "vW8FKrWCy9jSLYj",
+    "output_index": 1,
+    "sequence_number": 313
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " \"",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "dPykvKZTDee9Kl",
+    "output_index": 1,
+    "sequence_number": 314
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "root",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "CbYi5p0sbQMA",
+    "output_index": 1,
+    "sequence_number": 315
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "sUtBSF2M5AVLCt",
+    "output_index": 1,
+    "sequence_number": 316
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " db",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "YKXnGXWAt07RK",
+    "output_index": 1,
+    "sequence_number": 317
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "zij4UvUOvIlIgXz",
+    "output_index": 1,
+    "sequence_number": 318
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " \"",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "191VY0ZJsa68Bc",
+    "output_index": 1,
+    "sequence_number": 319
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "admin",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "gb7wmv3lJeT",
+    "output_index": 1,
+    "sequence_number": 320
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\"",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "KukrolMYdFXRj2W",
+    "output_index": 1,
+    "sequence_number": 321
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " }]",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "kqMIdfnoW5Drw",
+    "output_index": 1,
+    "sequence_number": 322
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " })\n\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "zSTMEM1LlBJ",
+    "output_index": 1,
+    "sequence_number": 323
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "cUFHiZzuvF0OYgS",
+    "output_index": 1,
+    "sequence_number": 324
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Back",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "CwW9PvB1GiN",
+    "output_index": 1,
+    "sequence_number": 325
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " up",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "91G4cOf6RjuBx",
+    "output_index": 1,
+    "sequence_number": 326
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " or",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "pckpwz9VAIllR",
+    "output_index": 1,
+    "sequence_number": 327
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " migrate",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "UT006X6F",
+    "output_index": 1,
+    "sequence_number": 328
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "zOVCyKBwEHhpjDM",
+    "output_index": 1,
+    "sequence_number": 329
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "haO9h35GkY32wgn",
+    "output_index": 1,
+    "sequence_number": 330
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "FmDzZieZp5XW8H",
+    "output_index": 1,
+    "sequence_number": 331
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " mong",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Bq75FtncUVK",
+    "output_index": 1,
+    "sequence_number": 332
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "od",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "5Ccmk53GlC7zSr",
+    "output_index": 1,
+    "sequence_number": 333
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "ump",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "qNeb7tRmmDIAM",
+    "output_index": 1,
+    "sequence_number": 334
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " to",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "5DDh5wTrh86Vs",
+    "output_index": 1,
+    "sequence_number": 335
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " back",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "4r6aXmfXhFM",
+    "output_index": 1,
+    "sequence_number": 336
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " up",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "hwly72wsMLFkp",
+    "output_index": 1,
+    "sequence_number": 337
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "A68Crayd4vxPvFJ",
+    "output_index": 1,
+    "sequence_number": 338
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "tN9XZhAAela9RGA",
+    "output_index": 1,
+    "sequence_number": 339
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " -",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "M20qeXHgUeUlB7",
+    "output_index": 1,
+    "sequence_number": 340
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " mong",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Uksc3om7XPu",
+    "output_index": 1,
+    "sequence_number": 341
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "ore",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "d6om4EjznD2SG",
+    "output_index": 1,
+    "sequence_number": 342
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "store",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "NTk7qZGSaVh",
+    "output_index": 1,
+    "sequence_number": 343
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " to",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "LpjItFJbRNygO",
+    "output_index": 1,
+    "sequence_number": 344
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " restore",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "bQM0U2nI",
+    "output_index": 1,
+    "sequence_number": 345
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n\n",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "8NVuKRpEvUXeaF",
+    "output_index": 1,
+    "sequence_number": 346
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Tell",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "gYFKMOUeWn6U",
+    "output_index": 1,
+    "sequence_number": 347
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " me",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "5yZB1Hg6gnOvY",
+    "output_index": 1,
+    "sequence_number": 348
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " your",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Kz84jdWzvbj",
+    "output_index": 1,
+    "sequence_number": 349
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " goal",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "lmqAZURxvRh",
+    "output_index": 1,
+    "sequence_number": 350
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "iuRwoAefd3wcpO",
+    "output_index": 1,
+    "sequence_number": 351
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "expl",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "DqYMe5BsuOBD",
+    "output_index": 1,
+    "sequence_number": 352
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "ore",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "uFCZDoTFgEGqi",
+    "output_index": 1,
+    "sequence_number": 353
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " data",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "YGyekkT37Fa",
+    "output_index": 1,
+    "sequence_number": 354
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "TuxRsPSR7qRihXd",
+    "output_index": 1,
+    "sequence_number": 355
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " configure",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "g7YKRu",
+    "output_index": 1,
+    "sequence_number": 356
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " security",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "iwMRS8M",
+    "output_index": 1,
+    "sequence_number": 357
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "OV6NINnk5GdnGtB",
+    "output_index": 1,
+    "sequence_number": 358
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " monitor",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "LDHEnJs0",
+    "output_index": 1,
+    "sequence_number": 359
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "aYLqeI6MF9iwWcE",
+    "output_index": 1,
+    "sequence_number": 360
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " backup",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "2JLJyCsfr",
+    "output_index": 1,
+    "sequence_number": 361
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "5YAck6f8txlgKnh",
+    "output_index": 1,
+    "sequence_number": 362
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " etc",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "jsw7bqu2TYiO",
+    "output_index": 1,
+    "sequence_number": 363
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".)",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "G9lxlQzhoQOeN3",
+    "output_index": 1,
+    "sequence_number": 364
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " and",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "5z9GZilJIcNx",
+    "output_index": 1,
+    "sequence_number": 365
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " your",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "B8cOebxCVaw",
+    "output_index": 1,
+    "sequence_number": 366
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " environment",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "pGjN",
+    "output_index": 1,
+    "sequence_number": 367
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " (",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "875hOUoyd5QeuU",
+    "output_index": 1,
+    "sequence_number": 368
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "shell",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "QMnKNikIGQs",
+    "output_index": 1,
+    "sequence_number": 369
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "JsRqUtPXi2iOULm",
+    "output_index": 1,
+    "sequence_number": 370
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " driver",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "walGgLFu9",
+    "output_index": 1,
+    "sequence_number": 371
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " language",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "6BQn7J8",
+    "output_index": 1,
+    "sequence_number": 372
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ",",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "1Pj1PDUuxZRmfFI",
+    "output_index": 1,
+    "sequence_number": 373
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " whether",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "GKrng5w6",
+    "output_index": 1,
+    "sequence_number": 374
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " auth",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "w8vfdn4WBGr",
+    "output_index": 1,
+    "sequence_number": 375
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " is",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "7OepTNOV2pNSM",
+    "output_index": 1,
+    "sequence_number": 376
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " enabled",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "kNylvn53",
+    "output_index": 1,
+    "sequence_number": 377
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ").",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "HwU88QSE0L34Ad",
+    "output_index": 1,
+    "sequence_number": 378
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " I",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "6NfHRdT9Qnx49B",
+    "output_index": 1,
+    "sequence_number": 379
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " can",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "JpxZJQRq2kXu",
+    "output_index": 1,
+    "sequence_number": 380
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " give",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Vod19vbdTSy",
+    "output_index": 1,
+    "sequence_number": 381
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "HelasbEilQgm",
+    "output_index": 1,
+    "sequence_number": 382
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " exact",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "l9OpF7LT6P",
+    "output_index": 1,
+    "sequence_number": 383
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " commands",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "Ip5vPFS",
+    "output_index": 1,
+    "sequence_number": 384
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " tailored",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "QIH9xpu",
+    "output_index": 1,
+    "sequence_number": 385
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " to",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "axp3TLOFacj1x",
+    "output_index": 1,
+    "sequence_number": 386
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "b1y17dbcAEMy",
+    "output_index": 1,
+    "sequence_number": 387
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ".",
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "obfuscation": "9m43uShrBPis0hU",
+    "output_index": 1,
+    "sequence_number": 388
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 389,
+    "text": "Since the only databases shown are admin, config, and local, you’re looking at MongoDB’s system databases. What you do next depends on your goal. Here are practical options:\n\n- Explore data (if you plan to add your own data)\n  - In the shell:\n    - use mydb\n    - db.createCollection(\"mycollection\")\n    - db.mycollection.insertOne({ name: \"Alice\", age: 30 })\n    - db.mycollection.find({})\n\n- Inspect what's in the system databases\n  - Admin users (in admin):\n    - use admin\n    - show collections\n    - db.getUsers()\n  - Config (in config):\n    - use config\n    - db.shards.find()\n    - db.chunks.find({})  // if sharding is configured\n  - Local (in local):\n    - use local\n    - db.oplog.rs.find().limit(5)  // only if you’re running a replica set\n\n- Check server health and status\n  - db.serverStatus()\n  - db.stats()\n  - If you’re on a replica set: rs.status() and rs.config()\n\n- Set up authentication (recommended for production)\n  - If auth isn’t enabled yet, you’ll typically:\n    - create an admin user in admin\n    - restart mongod with --auth\n  - Example (in admin):\n    - use admin\n    - db.createUser({ user: \"admin\", pwd: \"strongpassword\", roles: [{ role: \"root\", db: \"admin\" }] })\n\n- Back up or migrate\n  - mongodump to back up\n  - mongorestore to restore\n\nTell me your goal (explore data, configure security, monitor, backup, etc.) and your environment (shell, driver language, whether auth is enabled). I can give you exact commands tailored to you."
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "Since the only databases shown are admin, config, and local, you’re looking at MongoDB’s system databases. What you do next depends on your goal. Here are practical options:\n\n- Explore data (if you plan to add your own data)\n  - In the shell:\n    - use mydb\n    - db.createCollection(\"mycollection\")\n    - db.mycollection.insertOne({ name: \"Alice\", age: 30 })\n    - db.mycollection.find({})\n\n- Inspect what's in the system databases\n  - Admin users (in admin):\n    - use admin\n    - show collections\n    - db.getUsers()\n  - Config (in config):\n    - use config\n    - db.shards.find()\n    - db.chunks.find({})  // if sharding is configured\n  - Local (in local):\n    - use local\n    - db.oplog.rs.find().limit(5)  // only if you’re running a replica set\n\n- Check server health and status\n  - db.serverStatus()\n  - db.stats()\n  - If you’re on a replica set: rs.status() and rs.config()\n\n- Set up authentication (recommended for production)\n  - If auth isn’t enabled yet, you’ll typically:\n    - create an admin user in admin\n    - restart mongod with --auth\n  - Example (in admin):\n    - use admin\n    - db.createUser({ user: \"admin\", pwd: \"strongpassword\", roles: [{ role: \"root\", db: \"admin\" }] })\n\n- Back up or migrate\n  - mongodump to back up\n  - mongorestore to restore\n\nTell me your goal (explore data, configure security, monitor, backup, etc.) and your environment (shell, driver language, whether auth is enabled). I can give you exact commands tailored to you."
+    },
+    "sequence_number": 390
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Since the only databases shown are admin, config, and local, you’re looking at MongoDB’s system databases. What you do next depends on your goal. Here are practical options:\n\n- Explore data (if you plan to add your own data)\n  - In the shell:\n    - use mydb\n    - db.createCollection(\"mycollection\")\n    - db.mycollection.insertOne({ name: \"Alice\", age: 30 })\n    - db.mycollection.find({})\n\n- Inspect what's in the system databases\n  - Admin users (in admin):\n    - use admin\n    - show collections\n    - db.getUsers()\n  - Config (in config):\n    - use config\n    - db.shards.find()\n    - db.chunks.find({})  // if sharding is configured\n  - Local (in local):\n    - use local\n    - db.oplog.rs.find().limit(5)  // only if you’re running a replica set\n\n- Check server health and status\n  - db.serverStatus()\n  - db.stats()\n  - If you’re on a replica set: rs.status() and rs.config()\n\n- Set up authentication (recommended for production)\n  - If auth isn’t enabled yet, you’ll typically:\n    - create an admin user in admin\n    - restart mongod with --auth\n  - Example (in admin):\n    - use admin\n    - db.createUser({ user: \"admin\", pwd: \"strongpassword\", roles: [{ role: \"root\", db: \"admin\" }] })\n\n- Back up or migrate\n  - mongodump to back up\n  - mongorestore to restore\n\nTell me your goal (explore data, configure security, monitor, backup, etc.) and your environment (shell, driver language, whether auth is enabled). I can give you exact commands tailored to you."
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 391
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_0c6dbce448cc8b0b006a2327ec0ec8819c97c1bfafd8b8a560",
+      "object": "response",
+      "created_at": 1780688876,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1780688889,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "moderation": null,
+      "output": [
+        {
+          "id": "rs_0c6dbce448cc8b0b006a2327ec5c94819c876f5101a9cf1405",
+          "type": "reasoning",
+          "content": [],
+          "summary": []
+        },
+        {
+          "id": "msg_0c6dbce448cc8b0b006a2327f6ea8c819c8d23cd8cb5a9221e",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "Since the only databases shown are admin, config, and local, you’re looking at MongoDB’s system databases. What you do next depends on your goal. Here are practical options:\n\n- Explore data (if you plan to add your own data)\n  - In the shell:\n    - use mydb\n    - db.createCollection(\"mycollection\")\n    - db.mycollection.insertOne({ name: \"Alice\", age: 30 })\n    - db.mycollection.find({})\n\n- Inspect what's in the system databases\n  - Admin users (in admin):\n    - use admin\n    - show collections\n    - db.getUsers()\n  - Config (in config):\n    - use config\n    - db.shards.find()\n    - db.chunks.find({})  // if sharding is configured\n  - Local (in local):\n    - use local\n    - db.oplog.rs.find().limit(5)  // only if you’re running a replica set\n\n- Check server health and status\n  - db.serverStatus()\n  - db.stats()\n  - If you’re on a replica set: rs.status() and rs.config()\n\n- Set up authentication (recommended for production)\n  - If auth isn’t enabled yet, you’ll typically:\n    - create an admin user in admin\n    - restart mongod with --auth\n  - Example (in admin):\n    - use admin\n    - db.createUser({ user: \"admin\", pwd: \"strongpassword\", roles: [{ role: \"root\", db: \"admin\" }] })\n\n- Back up or migrate\n  - mongodump to back up\n  - mongorestore to restore\n\nTell me your goal (explore data, configure security, monitor, backup, etc.) and your environment (shell, driver language, whether auth is enabled). I can give you exact commands tailored to you."
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": "in_memory",
+      "reasoning": {
+        "context": "current_turn",
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "function",
+          "description": "List databases in the connected MongoDB instance.",
+          "name": "list_databases",
+          "parameters": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+          },
+          "strict": false
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 137,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 2555,
+        "output_tokens_details": {
+          "reasoning_tokens": 2112
+        },
+        "total_tokens": 2692
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 392
+  }
+]

--- a/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/followup-response.json
+++ b/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/followup-response.json
@@ -1,0 +1,92 @@
+{
+  "id": "resp_0c6dbce448cc8b0b006a2327ec2744819cb8ef3094020385cb",
+  "object": "response",
+  "created_at": 1780688876,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1780688885,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "moderation": null,
+  "output": [
+    {
+      "id": "rs_0c6dbce448cc8b0b006a2327ec8c44819caf91c4401b570b9e",
+      "type": "reasoning",
+      "content": [],
+      "summary": []
+    },
+    {
+      "id": "msg_0c6dbce448cc8b0b006a2327f3dfdc819ca834be2ee19bf8d4",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Great question. The next steps depend on what you want to achieve. Here are some common options and concrete next steps you can take:\n\n- Explore data\n  - Pick a database (admin, config, or local) and list its collections.\n  - In the Mongo shell or a driver:\n    - Use the database: use admin (or use config/local)\n    - List collections: show collections (shell) or db.getCollectionNames()\n    - Peek at data: db.<collection>.findOne() or db.<collection>.find().limit(5).toArray()\n\n- Inspect security and users\n  - In the admin database, list users and roles:\n    - In the shell: use admin; db.getUsers(); db.getUser(\"<username>\")\n\n- Check health and configuration\n  - Get server status and replica set info:\n    - In the shell: db.serverStatus(); rs.status() (if part of a replica set)\n\n- Plan backups or maintenance\n  - Confirm backup schedules, oplog size, and storage configuration.\n\nIf you tell me which database you want to start with (admin, config, or local) and what you want to learn (structure, data, users, health), I can provide exact commands or guide you through the steps. I can also help draft small scripts or queries in your preferred driver (Node.js, Python, etc.)."
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": "current_turn",
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "function",
+      "description": "List databases in the connected MongoDB instance.",
+      "name": "list_databases",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "strict": false
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 137,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1860,
+    "output_tokens_details": {
+      "reasoning_tokens": 1536
+    },
+    "total_tokens": 1997
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "Great question. The next steps depend on what you want to achieve. Here are some common options and concrete next steps you can take:\n\n- Explore data\n  - Pick a database (admin, config, or local) and list its collections.\n  - In the Mongo shell or a driver:\n    - Use the database: use admin (or use config/local)\n    - List collections: show collections (shell) or db.getCollectionNames()\n    - Peek at data: db.<collection>.findOne() or db.<collection>.find().limit(5).toArray()\n\n- Inspect security and users\n  - In the admin database, list users and roles:\n    - In the shell: use admin; db.getUsers(); db.getUser(\"<username>\")\n\n- Check health and configuration\n  - Get server status and replica set info:\n    - In the shell: db.serverStatus(); rs.status() (if part of a replica set)\n\n- Plan backups or maintenance\n  - Confirm backup schedules, oplog size, and storage configuration.\n\nIf you tell me which database you want to start with (admin, config, or local) and what you want to learn (structure, data, users, health), I can provide exact commands or guide you through the steps. I can also help draft small scripts or queries in your preferred driver (Node.js, Python, etc.)."
+}

--- a/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/request.json
+++ b/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/request.json
@@ -1,0 +1,39 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "What databases exist in the connected MongoDB instance? Use the list_databases tool."
+        }
+      ]
+    },
+    {
+      "type": "function_call",
+      "call_id": "6k7x6c84",
+      "name": "list_databases",
+      "arguments": "{}"
+    },
+    {
+      "type": "function_call_output",
+      "call_id": "6k7x6c84",
+      "output": "[{\"type\":\"text\",\"text\":\"{\\\"databases\\\":[\\\"admin\\\",\\\"config\\\",\\\"local\\\"]}\"}]"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "name": "list_databases",
+      "description": "List databases in the connected MongoDB instance.",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "strict": false
+    }
+  ],
+  "tool_choice": "auto"
+}

--- a/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/response-streaming.json
+++ b/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/response-streaming.json
@@ -1,0 +1,674 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_02a0b1f044f50241006a2327e2d550819287710615c3d4f5cb",
+      "object": "response",
+      "created_at": 1780688866,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "moderation": null,
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": "in_memory",
+      "reasoning": {
+        "context": "current_turn",
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "function",
+          "description": "List databases in the connected MongoDB instance.",
+          "name": "list_databases",
+          "parameters": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+          },
+          "strict": false
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "resp_02a0b1f044f50241006a2327e2d550819287710615c3d4f5cb",
+      "object": "response",
+      "created_at": 1780688866,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "moderation": null,
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": "in_memory",
+      "reasoning": {
+        "context": "current_turn",
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "auto",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "function",
+          "description": "List databases in the connected MongoDB instance.",
+          "name": "list_databases",
+          "parameters": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+          },
+          "strict": false
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "rs_02a0b1f044f50241006a2327e313f48192b20d4f6f1feee2a0",
+      "type": "reasoning",
+      "content": [],
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "rs_02a0b1f044f50241006a2327e313f48192b20d4f6f1feee2a0",
+      "type": "reasoning",
+      "content": [],
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Dat",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "HbB9SAKsa5qSW",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "abases",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "9LWNs3lZBn",
+    "output_index": 1,
+    "sequence_number": 7
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " in",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "rK5Lmd3yJMesG",
+    "output_index": 1,
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " the",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "SUgOzg3lOeVq",
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " connected",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "VdsUV9",
+    "output_index": 1,
+    "sequence_number": 10
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " Mongo",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "DKXyTLyWtq",
+    "output_index": 1,
+    "sequence_number": 11
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "DB",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "aKeSIETumv41sE",
+    "output_index": 1,
+    "sequence_number": 12
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " instance",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "LPocLsN",
+    "output_index": 1,
+    "sequence_number": 13
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":\n",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "ZKmaYdph3qctrJ",
+    "output_index": 1,
+    "sequence_number": 14
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "6hoy4HrJh8HuKSy",
+    "output_index": 1,
+    "sequence_number": 15
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " admin",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "hWuBPC9pCY",
+    "output_index": 1,
+    "sequence_number": 16
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "BiN8gjE7joJjWib",
+    "output_index": 1,
+    "sequence_number": 17
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "RemXy86SbVvPU22",
+    "output_index": 1,
+    "sequence_number": 18
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " config",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "ZOmZPNdsL",
+    "output_index": 1,
+    "sequence_number": 19
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "6QUi28Ndp2dj4lR",
+    "output_index": 1,
+    "sequence_number": 20
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "-",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "KAHC5VDpth26IA5",
+    "output_index": 1,
+    "sequence_number": 21
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " local",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "x3IznRHaKN",
+    "output_index": 1,
+    "sequence_number": 22
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n\n",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "OyEK8M66DFdj8E",
+    "output_index": 1,
+    "sequence_number": 23
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Total",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "ziIZUnXivUG",
+    "output_index": 1,
+    "sequence_number": 24
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": ":",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "NaySSAKlfGN9LOa",
+    "output_index": 1,
+    "sequence_number": 25
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " ",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "5rbwyExijmL9Q7x",
+    "output_index": 1,
+    "sequence_number": 26
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "3",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "djFBhDWJXqseGeB",
+    "output_index": 1,
+    "sequence_number": 27
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "\n\n",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "WfesJtCvjourKu",
+    "output_index": 1,
+    "sequence_number": 28
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "Would",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "HNL9Fp6Pr26",
+    "output_index": 1,
+    "sequence_number": 29
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " you",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "foHN37EgW5Ii",
+    "output_index": 1,
+    "sequence_number": 30
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " like",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "K3ksrvrlgYQ",
+    "output_index": 1,
+    "sequence_number": 31
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " me",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "tkN9Z9mWGPuEx",
+    "output_index": 1,
+    "sequence_number": 32
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " to",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "TrNA6uoL7UCLC",
+    "output_index": 1,
+    "sequence_number": 33
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " list",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "EfNWRdaeiOF",
+    "output_index": 1,
+    "sequence_number": 34
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " the",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "2dPvpNFYDWxW",
+    "output_index": 1,
+    "sequence_number": 35
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " collections",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "ToI4",
+    "output_index": 1,
+    "sequence_number": 36
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " in",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "RuhQHDM5aae3z",
+    "output_index": 1,
+    "sequence_number": 37
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " any",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "kJeNT0QwusFI",
+    "output_index": 1,
+    "sequence_number": 38
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " of",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "4I6HA34NMc7HQ",
+    "output_index": 1,
+    "sequence_number": 39
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " these",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "JBqfUKQoNy",
+    "output_index": 1,
+    "sequence_number": 40
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": " databases",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "8H7R4n",
+    "output_index": 1,
+    "sequence_number": 41
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "?",
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "obfuscation": "Vgc2yCnRxI0NKwj",
+    "output_index": 1,
+    "sequence_number": 42
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 43,
+    "text": "Databases in the connected MongoDB instance:\n- admin\n- config\n- local\n\nTotal: 3\n\nWould you like me to list the collections in any of these databases?"
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "Databases in the connected MongoDB instance:\n- admin\n- config\n- local\n\nTotal: 3\n\nWould you like me to list the collections in any of these databases?"
+    },
+    "sequence_number": 44
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Databases in the connected MongoDB instance:\n- admin\n- config\n- local\n\nTotal: 3\n\nWould you like me to list the collections in any of these databases?"
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 45
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_02a0b1f044f50241006a2327e2d550819287710615c3d4f5cb",
+      "object": "response",
+      "created_at": 1780688866,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1780688868,
+      "error": null,
+      "frequency_penalty": 0,
+      "incomplete_details": null,
+      "instructions": null,
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5-nano-2025-08-07",
+      "moderation": null,
+      "output": [
+        {
+          "id": "rs_02a0b1f044f50241006a2327e313f48192b20d4f6f1feee2a0",
+          "type": "reasoning",
+          "content": [],
+          "summary": []
+        },
+        {
+          "id": "msg_02a0b1f044f50241006a2327e48508819293a15c1fb489d657",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "Databases in the connected MongoDB instance:\n- admin\n- config\n- local\n\nTotal: 3\n\nWould you like me to list the collections in any of these databases?"
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0,
+      "previous_response_id": null,
+      "prompt_cache_key": null,
+      "prompt_cache_retention": "in_memory",
+      "reasoning": {
+        "context": "current_turn",
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": null,
+      "service_tier": "default",
+      "store": true,
+      "temperature": 1,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [
+        {
+          "type": "function",
+          "description": "List databases in the connected MongoDB instance.",
+          "name": "list_databases",
+          "parameters": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+          },
+          "strict": false
+        }
+      ],
+      "top_logprobs": 0,
+      "top_p": 1,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 104,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 334,
+        "output_tokens_details": {
+          "reasoning_tokens": 256
+        },
+        "total_tokens": 438
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 46
+  }
+]

--- a/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/response.json
+++ b/payloads/snapshots/responsesFunctionCallOutputWithoutThoughtSignatureParam/responses/response.json
@@ -1,0 +1,92 @@
+{
+  "id": "resp_0c6dbce448cc8b0b006a2327e35590819c90e13b4fd27d3f54",
+  "object": "response",
+  "created_at": 1780688867,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1780688873,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "moderation": null,
+  "output": [
+    {
+      "id": "rs_0c6dbce448cc8b0b006a2327e47c88819c81c61315bc2d1899",
+      "type": "reasoning",
+      "content": [],
+      "summary": []
+    },
+    {
+      "id": "msg_0c6dbce448cc8b0b006a2327e8fc20819c9edd24c2ca621d1b",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "The connected MongoDB instance has these databases:\n- admin\n- config\n- local"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": "current_turn",
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "function",
+      "description": "List databases in the connected MongoDB instance.",
+      "name": "list_databases",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "strict": false
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 104,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 246,
+    "output_tokens_details": {
+      "reasoning_tokens": 192
+    },
+    "total_tokens": 350
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "The connected MongoDB instance has these databases:\n- admin\n- config\n- local"
+}

--- a/payloads/transforms/anthropic_to_google/parallelToolCallsRequest.json
+++ b/payloads/transforms/anthropic_to_google/parallelToolCallsRequest.json
@@ -4,7 +4,8 @@
       "content": {
         "parts": [
           {
-            "text": "The weather in San Francisco, CA is 65°F and sunny. In New York, NY, it is 45°F and cloudy."
+            "text": "The current weather in San Francisco is 65°F and sunny, while in New York it is 45°F and cloudy.",
+            "thoughtSignature": "EjQKMgEMOdbHDCAaiPldOXhHyZobvZhH6bRNf5KOhXLeSkVEME0knNYIfaKmSq51K+m6aY/g"
           }
         ],
         "role": "model"
@@ -14,16 +15,17 @@
     }
   ],
   "usageMetadata": {
-    "promptTokenCount": 140,
-    "candidatesTokenCount": 32,
-    "totalTokenCount": 172,
+    "promptTokenCount": 151,
+    "candidatesTokenCount": 29,
+    "totalTokenCount": 180,
     "promptTokensDetails": [
       {
         "modality": "TEXT",
-        "tokenCount": 140
+        "tokenCount": 151
       }
-    ]
+    ],
+    "serviceTier": "standard"
   },
-  "modelVersion": "gemini-2.5-flash",
-  "responseId": "f57MacDBAZOb-8YP37yX4AE"
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "tzwjaoehHY2U_uMPopCm6A4"
 }

--- a/payloads/transforms/chat-completions_to_google/parallelToolCallsRequest-streaming.json
+++ b/payloads/transforms/chat-completions_to_google/parallelToolCallsRequest-streaming.json
@@ -5,7 +5,7 @@
         "content": {
           "parts": [
             {
-              "text": "The weather in San"
+              "text": "The weather in San Francisco is 65°F and sunny. In New York, it"
             }
           ],
           "role": "model"
@@ -14,18 +14,19 @@
       }
     ],
     "usageMetadata": {
-      "promptTokenCount": 140,
-      "candidatesTokenCount": 4,
-      "totalTokenCount": 144,
+      "promptTokenCount": 151,
+      "candidatesTokenCount": 19,
+      "totalTokenCount": 170,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
-          "tokenCount": 140
+          "tokenCount": 151
         }
-      ]
+      ],
+      "serviceTier": "standard"
     },
-    "modelVersion": "gemini-2.5-flash",
-    "responseId": "8jr6aarKHc2f1MkPlq-rgQM"
+    "modelVersion": "gemini-3.5-flash",
+    "responseId": "tjwjap2YAqCb9MoPjsLu8AE"
   },
   {
     "candidates": [
@@ -33,7 +34,7 @@
         "content": {
           "parts": [
             {
-              "text": " Francisco, CA is 65°F and sunny. In New York, NY"
+              "text": " is 45°F and cloudy."
             }
           ],
           "role": "model"
@@ -42,18 +43,19 @@
       }
     ],
     "usageMetadata": {
-      "promptTokenCount": 140,
-      "candidatesTokenCount": 21,
-      "totalTokenCount": 161,
+      "promptTokenCount": 151,
+      "candidatesTokenCount": 28,
+      "totalTokenCount": 179,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
-          "tokenCount": 140
+          "tokenCount": 151
         }
-      ]
+      ],
+      "serviceTier": "standard"
     },
-    "modelVersion": "gemini-2.5-flash",
-    "responseId": "8jr6aarKHc2f1MkPlq-rgQM"
+    "modelVersion": "gemini-3.5-flash",
+    "responseId": "tjwjap2YAqCb9MoPjsLu8AE"
   },
   {
     "candidates": [
@@ -61,7 +63,8 @@
         "content": {
           "parts": [
             {
-              "text": ", it is 45°F and cloudy."
+              "text": "",
+              "thoughtSignature": "EjQKMgEMOdbHOJySIIza8a3N6ADqxqUsPx0vnACleDwU5HBUkO172QSmDZZSOAzZ0nKYVoY7"
             }
           ],
           "role": "model"
@@ -71,17 +74,18 @@
       }
     ],
     "usageMetadata": {
-      "promptTokenCount": 140,
-      "candidatesTokenCount": 32,
-      "totalTokenCount": 172,
+      "promptTokenCount": 151,
+      "candidatesTokenCount": 28,
+      "totalTokenCount": 179,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
-          "tokenCount": 140
+          "tokenCount": 151
         }
-      ]
+      ],
+      "serviceTier": "standard"
     },
-    "modelVersion": "gemini-2.5-flash",
-    "responseId": "8jr6aarKHc2f1MkPlq-rgQM"
+    "modelVersion": "gemini-3.5-flash",
+    "responseId": "tjwjap2YAqCb9MoPjsLu8AE"
   }
 ]

--- a/payloads/transforms/chat-completions_to_google/parallelToolCallsRequest.json
+++ b/payloads/transforms/chat-completions_to_google/parallelToolCallsRequest.json
@@ -4,7 +4,8 @@
       "content": {
         "parts": [
           {
-            "text": "The weather in San Francisco, CA is 65°F and sunny. In New York, NY, it is 45°F and cloudy."
+            "text": "In San Francisco, the weather is currently 65°F and sunny. In New York, it is 45°F and cloudy.",
+            "thoughtSignature": "Eq4DCqsDAQw51sd9XgNAXrYmV0K+i2r3TrtHkJXrlbJ19RskrknMQYUlG+J1Idr5czNPBm8snZmy1kvwvhRT4fPImaRm0t7eFgAV+YG6rqZckL2s7yUWX3Oakgxnohs1WaujgY8gcVNl4ckv39J2GKCLdsucGZ8Jkf6CMPSuJyQyTeexZMjvabpAYDt7/kaWu8meRL4H32znl4eFGe+lhcMovSmBDTRLfM2j8b3zr3i/ubz6jqhLl3wpNLUCnw785s5L91DCAq1CCWqqiwKZZZi10+YhX2Agf1EehRDmSZ+bA7j5IYGu3eAlWpu8mP1DWAT60ZTvRBb+zmm8OkyuNcUS2lUJcRji3p/57MPmlndvFzU7j1ypRjcoIpjinsmTZwE9onK+p4fkHkB4K7v53+22Qg87/QJVPIwlIsITinHsFNZJFahHpK+Dawy8HZUMHQuPAfBcpqCbLaVV6BxIPlCutZrSLKgyX6KXPO/escwK4czn8hy5O097AYFIROXLOucV5XQB+5a+U+uddLbV/hkMng29rF6rh1Uepjdu1rfuw2cucROxgBkvX/X+fwAmgA=="
           }
         ],
         "role": "model"
@@ -14,16 +15,18 @@
     }
   ],
   "usageMetadata": {
-    "promptTokenCount": 140,
-    "candidatesTokenCount": 32,
-    "totalTokenCount": 172,
+    "promptTokenCount": 151,
+    "candidatesTokenCount": 30,
+    "totalTokenCount": 274,
     "promptTokensDetails": [
       {
         "modality": "TEXT",
-        "tokenCount": 140
+        "tokenCount": 151
       }
-    ]
+    ],
+    "thoughtsTokenCount": 93,
+    "serviceTier": "standard"
   },
-  "modelVersion": "gemini-2.5-flash",
-  "responseId": "TarMaYyfM9uD-8YPyLrg0AI"
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "tDwjavGBK_PQ1MkPrc60wAQ"
 }

--- a/payloads/transforms/responses_to_anthropic/responsesFunctionCallOutputWithoutThoughtSignatureParam.json
+++ b/payloads/transforms/responses_to_anthropic/responsesFunctionCallOutputWithoutThoughtSignatureParam.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_01JimcjPekKD1ZgMUksBLG27",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "The connected MongoDB instance contains the following databases:\n\n1. **admin** - The administrative database for MongoDB\n2. **config** - Used for sharded cluster configuration data\n3. **local** - Contains local-only data (e.g., replication configuration)\n\nThese are the standard system databases that come with a MongoDB installation. There don't appear to be any user-created databases in this instance yet."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 642,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 89,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/payloads/transforms/responses_to_google/parallelToolCallsRequest-streaming.json
+++ b/payloads/transforms/responses_to_google/parallelToolCallsRequest-streaming.json
@@ -5,7 +5,7 @@
         "content": {
           "parts": [
             {
-              "text": "The weather in San"
+              "text": "In San Francisco, CA, it is currently 65°"
             }
           ],
           "role": "model"
@@ -14,18 +14,19 @@
       }
     ],
     "usageMetadata": {
-      "promptTokenCount": 140,
-      "candidatesTokenCount": 4,
-      "totalTokenCount": 144,
+      "promptTokenCount": 151,
+      "candidatesTokenCount": 13,
+      "totalTokenCount": 164,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
-          "tokenCount": 140
+          "tokenCount": 151
         }
-      ]
+      ],
+      "serviceTier": "standard"
     },
-    "modelVersion": "gemini-2.5-flash",
-    "responseId": "im_VaZyKKI3m_uMPnpjMmQY"
+    "modelVersion": "gemini-3.5-flash",
+    "responseId": "ujwjap_VJNTQjMcP2rTuuA0"
   },
   {
     "candidates": [
@@ -33,7 +34,7 @@
         "content": {
           "parts": [
             {
-              "text": " Francisco, CA is 65°F and sunny. In New York, NY"
+              "text": "F and sunny. In New York, NY, it is 45°F and cloudy."
             }
           ],
           "role": "model"
@@ -42,18 +43,19 @@
       }
     ],
     "usageMetadata": {
-      "promptTokenCount": 140,
-      "candidatesTokenCount": 21,
-      "totalTokenCount": 161,
+      "promptTokenCount": 151,
+      "candidatesTokenCount": 33,
+      "totalTokenCount": 184,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
-          "tokenCount": 140
+          "tokenCount": 151
         }
-      ]
+      ],
+      "serviceTier": "standard"
     },
-    "modelVersion": "gemini-2.5-flash",
-    "responseId": "im_VaZyKKI3m_uMPnpjMmQY"
+    "modelVersion": "gemini-3.5-flash",
+    "responseId": "ujwjap_VJNTQjMcP2rTuuA0"
   },
   {
     "candidates": [
@@ -61,7 +63,8 @@
         "content": {
           "parts": [
             {
-              "text": ", it's 45°F and cloudy."
+              "text": "",
+              "thoughtSignature": "EjQKMgEMOdbHZWUb9BUMBhqbi7ACkvQaYlxZPZMV9Q4DvQtsPUDKXb5hOulyAYrkWkv+HICT"
             }
           ],
           "role": "model"
@@ -71,17 +74,18 @@
       }
     ],
     "usageMetadata": {
-      "promptTokenCount": 140,
+      "promptTokenCount": 151,
       "candidatesTokenCount": 33,
-      "totalTokenCount": 173,
+      "totalTokenCount": 184,
       "promptTokensDetails": [
         {
           "modality": "TEXT",
-          "tokenCount": 140
+          "tokenCount": 151
         }
-      ]
+      ],
+      "serviceTier": "standard"
     },
-    "modelVersion": "gemini-2.5-flash",
-    "responseId": "im_VaZyKKI3m_uMPnpjMmQY"
+    "modelVersion": "gemini-3.5-flash",
+    "responseId": "ujwjap_VJNTQjMcP2rTuuA0"
   }
 ]

--- a/payloads/transforms/responses_to_google/parallelToolCallsRequest.json
+++ b/payloads/transforms/responses_to_google/parallelToolCallsRequest.json
@@ -4,7 +4,8 @@
       "content": {
         "parts": [
           {
-            "text": "The weather in San Francisco, CA is 65°F and sunny. In New York, NY, it is 45°F and cloudy."
+            "text": "In San Francisco, it is currently 65°F and sunny. In New York, it is 45°F and cloudy.",
+            "thoughtSignature": "EpQDCpEDAQw51seltpJZbFFHK9rrRsbfyurKRncYKxtMNhh+fpvGXEeNHd/471P1yImG7C2F8By/ma/G904WZZU8l9mQHMiNHVEEmCSXpxVXoUT3MhSA3+Wvihvy7pBuDBQsr9svkwSx2sfwVudYQgS/FdcwbIJnqSmzRKGAS4JkjbYTvkm1m9H+bxJ2gdE78bnyacQeTWwUlSs/3k4N1+RdKZbNWYoPw8dUxTHOMIMktHNm+Le3Yxa4SbWlMPmDshK3BA+vgj4j3CUhkxvoO2+yXUQxNQv93AgQzwULw8ZxJbfxikEEkzkkMZBAMOXilbTnBPp+vM05smMyFcy7ugHCuWz+EYCZr65t354rTsFa7Q/4jdVehavscQDpQBmnYpyFC3eU8TaxYTs9Z/2Ul73h2cQPqsWl6p9/Yx0l0/pV74nwXuuCzJML8PmY53KKFOy7x7Vr8D88yWckO+bpdocp3DZxonj8xM2oFWZ/EY+P5PQKl1IJOcQKa7KsGmH5hXh2WXPxy7hMolTxT14xE1nr1EbF+gM="
           }
         ],
         "role": "model"
@@ -14,16 +15,18 @@
     }
   ],
   "usageMetadata": {
-    "promptTokenCount": 140,
-    "candidatesTokenCount": 32,
-    "totalTokenCount": 172,
+    "promptTokenCount": 151,
+    "candidatesTokenCount": 28,
+    "totalTokenCount": 264,
     "promptTokensDetails": [
       {
         "modality": "TEXT",
-        "tokenCount": 140
+        "tokenCount": 151
       }
-    ]
+    ],
+    "thoughtsTokenCount": 85,
+    "serviceTier": "standard"
   },
-  "modelVersion": "gemini-2.5-flash",
-  "responseId": "T6rMaZLHBZvwjrEPysPtgQI"
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "uTwjavi0DMzFjMcP1cWN4Ao"
 }

--- a/payloads/transforms/responses_to_google/responsesFunctionCallOutputWithoutThoughtSignatureParam.json
+++ b/payloads/transforms/responses_to_google/responsesFunctionCallOutputWithoutThoughtSignatureParam.json
@@ -1,0 +1,32 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The following databases exist in the connected MongoDB instance:\n\n* admin\n* config\n* local",
+            "thoughtSignature": "Eq4BCqsBAQw51sccpXKT3SDDj0U+Xm1hQXYesMrpMUZy0PCiYzf6gGu6QDdvbPYiz7BNiB9/zxvbWk9TptlkXdJn58Oci+wJPbUQ2ZE1C7zAg9pViAVGzu99WE/ZD6AoHJr/SbYolJRLKzEr8GHgeXwzKo7bi8knMsJbKDjspo6XEzjg5wE3He1esWZL3TuahSRwYAROdU6xQ4V+lUsTCBOZhRZaM8MnHLmzU09O7fQ6"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 78,
+    "candidatesTokenCount": 19,
+    "totalTokenCount": 125,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 78
+      }
+    ],
+    "thoughtsTokenCount": 28,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "-icjapXcArrL_uMPi4_H0A4"
+}

--- a/payloads/transforms/responses_to_google/responsesFunctionCallOutputWithoutThoughtSignatureParam.json
+++ b/payloads/transforms/responses_to_google/responsesFunctionCallOutputWithoutThoughtSignatureParam.json
@@ -4,8 +4,8 @@
       "content": {
         "parts": [
           {
-            "text": "The following databases exist in the connected MongoDB instance:\n\n* admin\n* config\n* local",
-            "thoughtSignature": "Eq4BCqsBAQw51sccpXKT3SDDj0U+Xm1hQXYesMrpMUZy0PCiYzf6gGu6QDdvbPYiz7BNiB9/zxvbWk9TptlkXdJn58Oci+wJPbUQ2ZE1C7zAg9pViAVGzu99WE/ZD6AoHJr/SbYolJRLKzEr8GHgeXwzKo7bi8knMsJbKDjspo6XEzjg5wE3He1esWZL3TuahSRwYAROdU6xQ4V+lUsTCBOZhRZaM8MnHLmzU09O7fQ6"
+            "text": "The databases that exist in the connected MongoDB instance are:\n\n*   **admin**\n*   **config**\n*   **local**",
+            "thoughtSignature": "EuMBCuABAQw51se5ZzrKp68e73j4RBzFcyA+bgRDplXU+XyjZa0iJqMJJsWefElYNq4FW5nM15SSgADVzsrH+9Fnj5LJr0Fo1i0gpTA9fms3Mzl6l6RjuyTgLFQyJ2mDmoL2LVvTTcnzZIH9cezM6bSxhJv6FQ6dDkzJn7FHDtxaSzxpZwx8IPG7FCrRArRol1FmyyYW1TW0KSAYKK347XAyICUtKXQrCjN6FwwaU/wCGvMA+h5rrEN0aK9F2gKvHdcJiuBh1o0o9F/rpBrGECmOG6+/RYWdUqbE7GnxvgG3sEz3N9s="
           }
         ],
         "role": "model"
@@ -15,18 +15,18 @@
     }
   ],
   "usageMetadata": {
-    "promptTokenCount": 78,
-    "candidatesTokenCount": 19,
-    "totalTokenCount": 125,
+    "promptTokenCount": 87,
+    "candidatesTokenCount": 29,
+    "totalTokenCount": 152,
     "promptTokensDetails": [
       {
         "modality": "TEXT",
-        "tokenCount": 78
+        "tokenCount": 87
       }
     ],
-    "thoughtsTokenCount": 28,
+    "thoughtsTokenCount": 36,
     "serviceTier": "standard"
   },
   "modelVersion": "gemini-3.5-flash",
-  "responseId": "-icjapXcArrL_uMPi4_H0A4"
+  "responseId": "vDwjap7zCNOb_uMP7Z__oA4"
 }


### PR DESCRIPTION
## Summary

Fixes Responses → Google transforms for AI SDK follow-up requests that include a `function_call` item followed by a matching `function_call_output`.

Gemini 3.5 rejects replayed Google `functionCall` history parts unless they include `thoughtSignature`. AI SDK Responses payloads include the tool call id/name, but not Google thought signatures. This PR uses the unsigned
`function_call` only to recover the tool result name, then omits it when the matching tool result is preserved as `functionResponse`.

## Changes

- Adds a Google capability for models that require `thoughtSignature` on replayed function-call history.
- Sanitizes Google function-call history for those models:
    - Keep signed function calls.
    - Drop unsigned function calls only when a later matching tool result exists.
    - Leave unpaired unsigned function calls intact so Google returns the native provider error.
- Adds a Responses payload repro:
    - `responsesFunctionCallOutputWithoutThoughtSignatureParam`
- Updates transform snapshots for the accepted Gemini 3.5 request shape.

## Validation

- `make capture FILTER=responsesFunctionCallOutputWithoutThoughtSignatureParam`
    - `responses → google`: passed
    - `responses → anthropic`: passed
    - transforms: `2 captured, 0 failed`