### PR TITLE
always upgrade to responses regardless of requested output format for newer gpt models

### DIFF
--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -520,8 +520,7 @@ impl Router {
             Error::NoProvider(catalog_format)
         })?;
         let provider_formats = provider.provider_formats();
-        let format = if output_format == ProviderFormat::ChatCompletions
-            && provider_formats.contains(&ProviderFormat::Responses)
+        let format = if provider_formats.contains(&ProviderFormat::Responses)
             && spec.requires_responses_api()
         {
             ProviderFormat::Responses

--- a/crates/braintrust-llm-router/tests/router.rs
+++ b/crates/braintrust-llm-router/tests/router.rs
@@ -799,6 +799,54 @@ async fn reasoning_effort_with_tools_upgrades_format_to_responses() {
     );
 }
 
+#[tokio::test]
+async fn responses_required_model_uses_responses_for_anthropic_messages_output() {
+    let mut catalog = ModelCatalog::empty();
+    catalog.insert(
+        "gpt-5.5".into(),
+        ModelSpec {
+            model: "gpt-5.5".into(),
+            format: ProviderFormat::ChatCompletions,
+            flavor: ModelFlavor::Chat,
+            display_name: None,
+            parent: None,
+            input_cost_per_mil_tokens: None,
+            output_cost_per_mil_tokens: None,
+            input_cache_read_cost_per_mil_tokens: None,
+            multimodal: None,
+            reasoning: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            supports_streaming: true,
+            extra: Default::default(),
+            available_providers: Default::default(),
+        },
+    );
+    let (router, _recorded_format) = openai_router(Arc::new(catalog));
+
+    let body = to_body(json!({
+        "model": "gpt-5.5",
+        "max_tokens": 1024,
+        "messages": [{"role": "user", "content": "Ping"}]
+    }));
+
+    let (_request, metadata) = router
+        .create_request(body, "gpt-5.5", ProviderFormat::Anthropic)
+        .await
+        .expect("create request");
+
+    assert_eq!(
+        metadata.detected_input_format,
+        ProviderFormat::Anthropic,
+        "request should be detected as Anthropic messages input"
+    );
+    assert_eq!(
+        metadata.provider_format,
+        ProviderFormat::Responses,
+        "gpt-5.5 should use Responses transport even when the caller uses /v1/messages"
+    );
+}
+
 fn retry_model_catalog() -> Arc<ModelCatalog> {
     let mut catalog = ModelCatalog::empty();
     catalog.insert(


### PR DESCRIPTION
at this point, we shuoldn't pass through chat completions because its the depreacted api for gpt-5+ models . we constantly run into -> 
```
{
  "error": {
    "message": "Function tools with reasoning_effort are not supported for gpt-5.5 in /v1/chat/completions. Please use /v1/responses instead.",
    "type": "invalid_request_error",
    "param": "reasoning_effort",
    "code": null
  }
}
POST

/v1/messages

400 Bad Request
1334.87ms


```