### PR TITLE
normalize json schemas so it is accepted by responses api

### DIFF
--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -562,6 +562,30 @@
       ]
     },
     {
+      "testCase": "textFormatJsonSchemaMissingRequiredPropertyParam",
+      "source": "ChatCompletions",
+      "target": "ChatCompletions",
+      "fields": [
+        { "pattern": "params.response_format.json_schema.schema.required", "reason": "Strict OpenAI-style targets require every object property to be listed in required" }
+      ]
+    },
+    {
+      "testCase": "textFormatJsonSchemaMissingRequiredPropertyParam",
+      "source": "ChatCompletions",
+      "target": "Responses",
+      "fields": [
+        { "pattern": "params.response_format.json_schema.schema.required", "reason": "Strict OpenAI-style targets require every object property to be listed in required" }
+      ]
+    },
+    {
+      "testCase": "textFormatJsonSchemaMissingRequiredPropertyParam",
+      "source": "Responses",
+      "target": "ChatCompletions",
+      "fields": [
+        { "pattern": "params.response_format.json_schema.schema.required", "reason": "Strict OpenAI-style targets require every object property to be listed in required" }
+      ]
+    },
+    {
       "testCase": "googleResponseSchemaPropertyOrderingParam",
       "source": "Google",
       "target": "ChatCompletions",

--- a/crates/lingua/src/providers/anthropic/convert.rs
+++ b/crates/lingua/src/providers/anthropic/convert.rs
@@ -1710,6 +1710,7 @@ impl TryFrom<&ResponseFormatConfig> for JsonOutputFormat {
                 match normalize_response_schema_for_strict_target(
                     &js.schema,
                     ProviderFormat::Anthropic,
+                    false,
                 )? {
                     Value::Object(m) => Ok(JsonOutputFormat {
                         schema: m,

--- a/crates/lingua/src/universal/response_format.rs
+++ b/crates/lingua/src/universal/response_format.rs
@@ -145,6 +145,10 @@ struct StrictTargetSchemaNodeView {
     minimum: Option<SchemaScalarConstraintView>,
     #[serde(rename = "maximum", default, skip_serializing_if = "Option::is_none")]
     maximum: Option<SchemaScalarConstraintView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    properties: Option<Map<String, Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    required: Option<Vec<String>>,
 }
 
 /// Anthropic structured outputs accept a narrower JSON Schema subset than the
@@ -170,6 +174,41 @@ fn strip_anthropic_unsupported_schema_keywords(
         map.remove("minimum");
         map.remove("maximum");
     }
+}
+
+fn normalize_openai_required_properties(
+    map: &mut Map<String, Value>,
+    node: &StrictTargetSchemaNodeView,
+    target_provider: ProviderFormat,
+) {
+    if !matches!(
+        target_provider,
+        ProviderFormat::ChatCompletions | ProviderFormat::Responses
+    ) {
+        return;
+    }
+
+    let Some(properties) = node.properties.as_ref() else {
+        return;
+    };
+
+    let mut required = node.required.clone().unwrap_or_default();
+    let mut property_names: Vec<&String> = properties.keys().collect();
+    property_names.sort();
+
+    for property_name in property_names {
+        if !required
+            .iter()
+            .any(|required_name| required_name == property_name)
+        {
+            required.push(property_name.clone());
+        }
+    }
+
+    map.insert(
+        "required".into(),
+        Value::Array(required.into_iter().map(Value::String).collect()),
+    );
 }
 
 pub(crate) fn normalize_response_schema_for_strict_target(
@@ -225,6 +264,8 @@ pub(crate) fn normalize_response_schema_for_strict_target(
                         });
                     }
                 }
+
+                normalize_openai_required_properties(map, &node, target_provider);
             }
 
             if let Some(Value::Object(properties)) = map.get_mut("properties") {
@@ -791,6 +832,78 @@ mod tests {
             normalized.pointer("/properties/outer/additionalProperties"),
             Some(&Value::Bool(false))
         );
+    }
+
+    #[test]
+    fn test_openai_strict_targets_require_all_object_properties() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "reasoning": { "type": "string" },
+                "answer": { "type": "string" },
+                "citation": { "type": "string" }
+            },
+            "required": ["answer", "legacy"]
+        });
+
+        for provider in [ProviderFormat::ChatCompletions, ProviderFormat::Responses] {
+            let normalized =
+                normalize_response_schema_for_strict_target(&schema, provider).unwrap();
+            assert_eq!(
+                normalized.pointer("/required"),
+                Some(&json!(["answer", "legacy", "citation", "reasoning"])),
+                "required should preserve existing entries and append missing properties for {provider:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_openai_strict_targets_add_required_recursively() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "outer": {
+                    "type": "object",
+                    "properties": {
+                        "inner": { "type": "string" },
+                        "details": { "type": "string" }
+                    },
+                    "required": ["inner"]
+                }
+            }
+        });
+
+        let normalized =
+            normalize_response_schema_for_strict_target(&schema, ProviderFormat::Responses)
+                .unwrap();
+
+        assert_eq!(normalized.pointer("/required"), Some(&json!(["outer"])));
+        assert_eq!(
+            normalized.pointer("/properties/outer/required"),
+            Some(&json!(["inner", "details"]))
+        );
+    }
+
+    #[test]
+    fn test_non_openai_strict_targets_do_not_auto_fill_required() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "reasoning": { "type": "string" },
+                "answer": { "type": "string" }
+            },
+            "required": ["answer"]
+        });
+
+        for provider in [ProviderFormat::Anthropic, ProviderFormat::Google] {
+            let normalized =
+                normalize_response_schema_for_strict_target(&schema, provider).unwrap();
+            assert_eq!(
+                normalized.pointer("/required"),
+                Some(&json!(["answer"])),
+                "required should be unchanged for {provider:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/lingua/src/universal/response_format.rs
+++ b/crates/lingua/src/universal/response_format.rs
@@ -180,7 +180,12 @@ fn normalize_openai_required_properties(
     map: &mut Map<String, Value>,
     node: &StrictTargetSchemaNodeView,
     target_provider: ProviderFormat,
+    require_openai_strict_required_properties: bool,
 ) {
+    if !require_openai_strict_required_properties {
+        return;
+    }
+
     if !matches!(
         target_provider,
         ProviderFormat::ChatCompletions | ProviderFormat::Responses
@@ -214,10 +219,12 @@ fn normalize_openai_required_properties(
 pub(crate) fn normalize_response_schema_for_strict_target(
     schema: &Value,
     target_provider: ProviderFormat,
+    require_openai_strict_required_properties: bool,
 ) -> Result<Value, ConvertError> {
     fn normalize_node(
         value: &mut Value,
         target_provider: ProviderFormat,
+        require_openai_strict_required_properties: bool,
     ) -> Result<(), ConvertError> {
         let node: StrictTargetSchemaNodeView =
             serde_json::from_value(value.clone()).map_err(|e| {
@@ -265,21 +272,38 @@ pub(crate) fn normalize_response_schema_for_strict_target(
                     }
                 }
 
-                normalize_openai_required_properties(map, &node, target_provider);
+                normalize_openai_required_properties(
+                    map,
+                    &node,
+                    target_provider,
+                    require_openai_strict_required_properties,
+                );
             }
 
             if let Some(Value::Object(properties)) = map.get_mut("properties") {
                 for prop_schema in properties.values_mut() {
-                    normalize_node(prop_schema, target_provider)?;
+                    normalize_node(
+                        prop_schema,
+                        target_provider,
+                        require_openai_strict_required_properties,
+                    )?;
                 }
             }
             if let Some(items) = map.get_mut("items") {
-                normalize_node(items, target_provider)?;
+                normalize_node(
+                    items,
+                    target_provider,
+                    require_openai_strict_required_properties,
+                )?;
             }
             for key in ["anyOf", "oneOf", "allOf", "prefixItems"] {
                 if let Some(Value::Array(items)) = map.get_mut(key) {
                     for item in items {
-                        normalize_node(item, target_provider)?;
+                        normalize_node(
+                            item,
+                            target_provider,
+                            require_openai_strict_required_properties,
+                        )?;
                     }
                 }
             }
@@ -289,7 +313,11 @@ pub(crate) fn normalize_response_schema_for_strict_target(
     }
 
     let mut normalized = schema.clone();
-    normalize_node(&mut normalized, target_provider)?;
+    normalize_node(
+        &mut normalized,
+        target_provider,
+        require_openai_strict_required_properties,
+    )?;
     Ok(normalized)
 }
 
@@ -420,6 +448,7 @@ fn to_openai_chat(config: &ResponseFormatConfig) -> Result<Option<Value>, Conver
                 normalize_response_schema_for_strict_target(
                     &js.schema,
                     ProviderFormat::ChatCompletions,
+                    js.strict == Some(true),
                 )?,
             );
             if let Some(strict) = js.strict {
@@ -448,33 +477,36 @@ fn to_openai_responses_text(config: &ResponseFormatConfig) -> Result<Option<Valu
         return Ok(None);
     };
 
-    let format_obj = match format_type {
-        ResponseFormatType::Text => json!({ "type": "text" }),
-        ResponseFormatType::JsonObject => json!({ "type": "json_object" }),
-        ResponseFormatType::JsonSchema => {
-            let js =
-                config
-                    .json_schema
-                    .as_ref()
-                    .ok_or_else(|| ConvertError::MissingRequiredField {
+    let format_obj =
+        match format_type {
+            ResponseFormatType::Text => json!({ "type": "text" }),
+            ResponseFormatType::JsonObject => json!({ "type": "json_object" }),
+            ResponseFormatType::JsonSchema => {
+                let js = config.json_schema.as_ref().ok_or_else(|| {
+                    ConvertError::MissingRequiredField {
                         field: "json_schema".to_string(),
-                    })?;
-            let mut obj = Map::new();
-            obj.insert("type".into(), Value::String("json_schema".into()));
-            obj.insert("name".into(), Value::String(js.name.clone()));
-            obj.insert(
-                "schema".into(),
-                normalize_response_schema_for_strict_target(&js.schema, ProviderFormat::Responses)?,
-            );
-            if let Some(strict) = js.strict {
-                obj.insert("strict".into(), Value::Bool(strict));
+                    }
+                })?;
+                let mut obj = Map::new();
+                obj.insert("type".into(), Value::String("json_schema".into()));
+                obj.insert("name".into(), Value::String(js.name.clone()));
+                obj.insert(
+                    "schema".into(),
+                    normalize_response_schema_for_strict_target(
+                        &js.schema,
+                        ProviderFormat::Responses,
+                        js.strict == Some(true),
+                    )?,
+                );
+                if let Some(strict) = js.strict {
+                    obj.insert("strict".into(), Value::Bool(strict));
+                }
+                if let Some(ref desc) = js.description {
+                    obj.insert("description".into(), Value::String(desc.clone()));
+                }
+                Value::Object(obj)
             }
-            if let Some(ref desc) = js.description {
-                obj.insert("description".into(), Value::String(desc.clone()));
-            }
-            Value::Object(obj)
-        }
-    };
+        };
 
     Ok(Some(json!({ "format": format_obj })))
 }
@@ -773,7 +805,7 @@ mod tests {
             ProviderFormat::Responses,
         ] {
             let normalized =
-                normalize_response_schema_for_strict_target(&schema, provider).unwrap();
+                normalize_response_schema_for_strict_target(&schema, provider, false).unwrap();
             assert_eq!(
                 normalized.pointer("/propertyOrdering"),
                 None,
@@ -814,7 +846,8 @@ mod tests {
         });
 
         let normalized =
-            normalize_response_schema_for_strict_target(&schema, ProviderFormat::Google).unwrap();
+            normalize_response_schema_for_strict_target(&schema, ProviderFormat::Google, false)
+                .unwrap();
 
         assert_eq!(
             normalized.pointer("/propertyOrdering"),
@@ -848,7 +881,7 @@ mod tests {
 
         for provider in [ProviderFormat::ChatCompletions, ProviderFormat::Responses] {
             let normalized =
-                normalize_response_schema_for_strict_target(&schema, provider).unwrap();
+                normalize_response_schema_for_strict_target(&schema, provider, true).unwrap();
             assert_eq!(
                 normalized.pointer("/required"),
                 Some(&json!(["answer", "legacy", "citation", "reasoning"])),
@@ -874,7 +907,7 @@ mod tests {
         });
 
         let normalized =
-            normalize_response_schema_for_strict_target(&schema, ProviderFormat::Responses)
+            normalize_response_schema_for_strict_target(&schema, ProviderFormat::Responses, true)
                 .unwrap();
 
         assert_eq!(normalized.pointer("/required"), Some(&json!(["outer"])));
@@ -882,6 +915,50 @@ mod tests {
             normalized.pointer("/properties/outer/required"),
             Some(&json!(["inner", "details"]))
         );
+    }
+
+    #[test]
+    fn test_openai_non_strict_targets_preserve_optional_properties() {
+        for strict in [None, Some(false)] {
+            let config = ResponseFormatConfig {
+                format_type: Some(ResponseFormatType::JsonSchema),
+                json_schema: Some(JsonSchemaConfig {
+                    name: "structured_response".into(),
+                    schema: json!({
+                        "type": "object",
+                        "properties": {
+                            "answer": { "type": "string" },
+                            "reasoning": { "type": "string" }
+                        },
+                        "required": ["answer"]
+                    }),
+                    strict,
+                    description: None,
+                }),
+            };
+
+            let chat_value = config
+                .to_provider(ProviderFormat::ChatCompletions)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                chat_value.pointer("/json_schema/schema/required"),
+                Some(&json!(["answer"])),
+                "non-strict chat schema should preserve optional properties for {strict:?}"
+            );
+
+            let responses_value = config
+                .to_provider(ProviderFormat::Responses)
+                .unwrap()
+                .unwrap();
+            let responses: OpenAiResponsesTextView = serde_json::from_value(responses_value)
+                .expect("responses text config should deserialize");
+            assert_eq!(
+                responses.format.schema.pointer("/required"),
+                Some(&json!(["answer"])),
+                "non-strict responses schema should preserve optional properties for {strict:?}"
+            );
+        }
     }
 
     #[test]
@@ -897,7 +974,7 @@ mod tests {
 
         for provider in [ProviderFormat::Anthropic, ProviderFormat::Google] {
             let normalized =
-                normalize_response_schema_for_strict_target(&schema, provider).unwrap();
+                normalize_response_schema_for_strict_target(&schema, provider, true).unwrap();
             assert_eq!(
                 normalized.pointer("/required"),
                 Some(&json!(["answer"])),
@@ -935,7 +1012,7 @@ mod tests {
         });
 
         let anthropic =
-            normalize_response_schema_for_strict_target(&schema, ProviderFormat::Anthropic)
+            normalize_response_schema_for_strict_target(&schema, ProviderFormat::Anthropic, false)
                 .unwrap();
         assert_eq!(anthropic.pointer("/properties/tuple/prefixItems"), None);
         assert_eq!(anthropic.pointer("/properties/tuple/minItems"), None);
@@ -945,9 +1022,12 @@ mod tests {
         assert_eq!(anthropic.pointer("/properties/ratio/minimum"), None);
         assert_eq!(anthropic.pointer("/properties/ratio/maximum"), None);
 
-        let chat =
-            normalize_response_schema_for_strict_target(&schema, ProviderFormat::ChatCompletions)
-                .unwrap();
+        let chat = normalize_response_schema_for_strict_target(
+            &schema,
+            ProviderFormat::ChatCompletions,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             chat.pointer("/properties/tuple/prefixItems/0/type"),
             Some(&Value::String("string".to_string()))

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -468,6 +468,62 @@ export const paramsCases: TestCaseCollection = {
     bedrock: null,
   },
 
+  textFormatJsonSchemaMissingRequiredPropertyParam: {
+    "chat-completions": {
+      model: OPENAI_MINI_REASONING_MODEL,
+      messages: [
+        {
+          role: "user",
+          content: "Return an answer and short reasoning.",
+        },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "structured_response",
+          schema: {
+            type: "object",
+            properties: {
+              answer: { type: "string" },
+              reasoning: { type: "string" },
+            },
+            required: ["answer"],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      },
+    },
+    responses: {
+      model: OPENAI_MINI_REASONING_MODEL,
+      input: [
+        {
+          role: "user",
+          content: "Return an answer and short reasoning.",
+        },
+      ],
+      text: {
+        format: {
+          type: "json_schema",
+          name: "structured_response",
+          schema: {
+            type: "object",
+            properties: {
+              answer: { type: "string" },
+              reasoning: { type: "string" },
+            },
+            required: ["answer"],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      },
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
   textFormatJsonSchemaWithDescriptionParam: {
     "chat-completions": {
       model: OPENAI_CHAT_COMPLETIONS_MODEL,

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -6191,6 +6191,62 @@ data: [DONE]
 "
 `;
 
+exports[`streaming: chat-completions → bedrock > textFormatJsonSchemaMissingRequiredPropertyParam > streaming 1`] = `
+"data: {"choices":[],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"#","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" I","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"'m ready to help!","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"\\n\\nI notice","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" you haven","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"'t aske","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"d a specific question yet. Could you please","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" provide","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"\\n\\n1. **","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"The question** you'd like me to","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" answer\\n2. **Any","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" relevant context** if","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" neede","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"d","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"\\n\\nOnce you share what","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" you're asking","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" about, I'll be happy to give","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" you a clear answer","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":" with conc","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{"content":"ise reasoning.","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[],"object":"chat.completion.chunk"}
+
+data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}],"object":"chat.completion.chunk"}
+
+data: {"choices":[],"object":"chat.completion.chunk","usage":{"completion_tokens":72,"prompt_tokens":14,"total_tokens":86}}
+
+data: [DONE]
+
+"
+`;
+
 exports[`streaming: chat-completions → bedrock > textFormatJsonSchemaNullableUnionTypeGpt54NanoParam > streaming 1`] = `
 "data: {"choices":[],"object":"chat.completion.chunk"}
 

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -9387,6 +9387,67 @@ exports[`chat-completions → anthropic > textFormatJsonObjectParam > response 1
 }
 `;
 
+exports[`chat-completions → anthropic > textFormatJsonSchemaMissingRequiredPropertyParam > request 1`] = `
+{
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "Return an answer and short reasoning.",
+      "role": "user",
+    },
+  ],
+  "model": "claude-sonnet-4-5-20250929",
+  "output_config": {
+    "format": {
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "answer": {
+            "type": "string",
+          },
+          "reasoning": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "answer",
+        ],
+        "type": "object",
+      },
+      "type": "json_schema",
+    },
+  },
+}
+`;
+
+exports[`chat-completions → anthropic > textFormatJsonSchemaMissingRequiredPropertyParam > response 1`] = `
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "{"answer": "I don't see a specific question in your message.", "reasoning": "You asked me to return an answer and short reasoning, but didn't provide a question to answer. Please provide a question so I can give you a meaningful response."}",
+        "role": "assistant",
+      },
+    },
+  ],
+  "created": 0,
+  "id": "chatcmpl-011EEoUMiJCZSHDPVAGK4NwL",
+  "model": "claude-sonnet-4-5-20250929",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 56,
+    "prompt_tokens": 172,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+    },
+    "total_tokens": 228,
+  },
+}
+`;
+
 exports[`chat-completions → anthropic > textFormatJsonSchemaNullableUnionTypeGpt54NanoParam > request 1`] = `
 {
   "max_tokens": 4096,
@@ -12238,6 +12299,54 @@ exports[`chat-completions → bedrock > textFormatJsonObjectParam > response 1`]
       "cached_tokens": 0,
     },
     "total_tokens": 32,
+  },
+}
+`;
+
+exports[`chat-completions → bedrock > textFormatJsonSchemaMissingRequiredPropertyParam > request 1`] = `
+{
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "Return an answer and short reasoning.",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "modelId": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+}
+`;
+
+exports[`chat-completions → bedrock > textFormatJsonSchemaMissingRequiredPropertyParam > response 1`] = `
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "I'm ready to help, but I don't see a specific question in your message. Could you please provide the question you'd like me to answer?
+
+Once you do, I'll give you:
+1. **A clear answer**
+2. **Short reasoning** explaining why",
+        "role": "assistant",
+      },
+    },
+  ],
+  "created": 0,
+  "id": "chatcmpl-transformed",
+  "model": "transformed",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 61,
+    "prompt_tokens": 14,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+    },
+    "total_tokens": 75,
   },
 }
 `;
@@ -15346,6 +15455,70 @@ exports[`chat-completions → google > textFormatJsonObjectParam > response 1`] 
 }
 `;
 
+exports[`chat-completions → google > textFormatJsonSchemaMissingRequiredPropertyParam > request 1`] = `
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "Return an answer and short reasoning.",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "generationConfig": {
+    "responseJsonSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "answer": {
+          "type": "string",
+        },
+        "reasoning": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "answer",
+      ],
+      "title": "structured_response",
+      "type": "object",
+    },
+    "responseMimeType": "application/json",
+    "responseSchema": null,
+  },
+  "model": "gemini-3.5-flash",
+}
+`;
+
+exports[`chat-completions → google > textFormatJsonSchemaMissingRequiredPropertyParam > response 1`] = `
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "{"answer":"Paris","reasoning":"Paris has been the capital of France since the late 10th century, serving as the country's political, cultural, and economic center."}",
+        "role": "assistant",
+      },
+    },
+  ],
+  "created": 0,
+  "id": "chatcmpl-transformed",
+  "model": "gemini-3.5-flash",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 435,
+    "completion_tokens_details": {
+      "reasoning_tokens": 396,
+    },
+    "prompt_tokens": 8,
+    "total_tokens": 443,
+  },
+}
+`;
+
 exports[`chat-completions → google > textFormatJsonSchemaNullableUnionTypeGpt54NanoParam > request 1`] = `
 {
   "contents": [
@@ -18395,6 +18568,69 @@ exports[`chat-completions → responses > textFormatJsonObjectParam > response 1
       "cached_tokens": 0,
     },
     "total_tokens": 260,
+  },
+}
+`;
+
+exports[`chat-completions → responses > textFormatJsonSchemaMissingRequiredPropertyParam > request 1`] = `
+{
+  "input": [
+    {
+      "content": "Return an answer and short reasoning.",
+      "role": "user",
+    },
+  ],
+  "model": "gpt-5.4-mini",
+  "text": {
+    "format": {
+      "name": "structured_response",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "answer": {
+            "type": "string",
+          },
+          "reasoning": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "answer",
+          "reasoning",
+        ],
+        "type": "object",
+      },
+      "strict": true,
+      "type": "json_schema",
+    },
+  },
+}
+`;
+
+exports[`chat-completions → responses > textFormatJsonSchemaMissingRequiredPropertyParam > response 1`] = `
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "{"answer":"Please provide the question or task you want answered.","reasoning":"Your message only asks for an answer and short reasoning, but no actual question was included."}",
+        "role": "assistant",
+      },
+    },
+  ],
+  "created": 0,
+  "id": "chatcmpl-016f4883d0291359006a26eb5eee04819eb1833217fbb168c2",
+  "model": "gpt-5.4-mini-2026-03-17",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 43,
+    "prompt_tokens": 43,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+    },
+    "total_tokens": 86,
   },
 }
 `;
@@ -30031,6 +30267,80 @@ exports[`responses → anthropic > textFormatJsonObjectParam > response 1`] = `
 }
 `;
 
+exports[`responses → anthropic > textFormatJsonSchemaMissingRequiredPropertyParam > request 1`] = `
+{
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "Return an answer and short reasoning.",
+      "role": "user",
+    },
+  ],
+  "model": "claude-sonnet-4-5-20250929",
+  "output_config": {
+    "format": {
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "answer": {
+            "type": "string",
+          },
+          "reasoning": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "answer",
+        ],
+        "type": "object",
+      },
+      "type": "json_schema",
+    },
+  },
+}
+`;
+
+exports[`responses → anthropic > textFormatJsonSchemaMissingRequiredPropertyParam > response 1`] = `
+{
+  "created_at": 0,
+  "id": "resp_01LLQwDeZ9UVfjscXv4vPPAR",
+  "incomplete_details": null,
+  "model": "claude-sonnet-4-5-20250929",
+  "object": "response",
+  "output": [
+    {
+      "content": [
+        {
+          "annotations": [],
+          "text": "{"answer": "I need a specific question to provide an answer.", "reasoning": "No question was provided in the prompt, so I cannot generate a meaningful answer or reasoning without knowing what is being asked."}",
+          "type": "output_text",
+        },
+      ],
+      "id": "msg_transformed_item_0",
+      "role": "assistant",
+      "status": "completed",
+      "type": "message",
+    },
+  ],
+  "output_text": "{"answer": "I need a specific question to provide an answer.", "reasoning": "No question was provided in the prompt, so I cannot generate a meaningful answer or reasoning without knowing what is being asked."}",
+  "parallel_tool_calls": false,
+  "status": "completed",
+  "tool_choice": "none",
+  "tools": [],
+  "usage": {
+    "input_tokens": 172,
+    "input_tokens_details": {
+      "cached_tokens": 0,
+    },
+    "output_tokens": 46,
+    "output_tokens_details": {
+      "reasoning_tokens": 0,
+    },
+    "total_tokens": 218,
+  },
+}
+`;
+
 exports[`responses → anthropic > textFormatJsonSchemaParam > request 1`] = `
 {
   "max_tokens": 4096,
@@ -33529,6 +33839,89 @@ exports[`responses → google > textFormatJsonObjectParam > response 1`] = `
       "reasoning_tokens": 28,
     },
     "total_tokens": 45,
+  },
+}
+`;
+
+exports[`responses → google > textFormatJsonSchemaMissingRequiredPropertyParam > request 1`] = `
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "Return an answer and short reasoning.",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "generationConfig": {
+    "responseJsonSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "answer": {
+          "type": "string",
+        },
+        "reasoning": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "answer",
+      ],
+      "title": "structured_response",
+      "type": "object",
+    },
+    "responseMimeType": "application/json",
+    "responseSchema": null,
+  },
+  "model": "gemini-3.5-flash",
+}
+`;
+
+exports[`responses → google > textFormatJsonSchemaMissingRequiredPropertyParam > response 1`] = `
+{
+  "created_at": 0,
+  "id": "resp_transformed",
+  "incomplete_details": null,
+  "model": "gemini-3.5-flash",
+  "object": "response",
+  "output": [
+    {
+      "content": [
+        {
+          "annotations": [],
+          "text": "{
+  "answer": "This is a placeholder answer.",
+  "reasoning": "The user did not provide a specific question or prompt, so a generic response has been generated to satisfy the schema requirements."
+}",
+          "type": "output_text",
+        },
+      ],
+      "id": "msg_transformed_item_0",
+      "role": "assistant",
+      "status": "completed",
+      "type": "message",
+    },
+  ],
+  "output_text": "{
+  "answer": "This is a placeholder answer.",
+  "reasoning": "The user did not provide a specific question or prompt, so a generic response has been generated to satisfy the schema requirements."
+}",
+  "parallel_tool_calls": false,
+  "status": "completed",
+  "tool_choice": "none",
+  "tools": [],
+  "usage": {
+    "input_tokens": 8,
+    "input_tokens_details": {
+      "cached_tokens": 0,
+    },
+    "output_tokens": 219,
+    "output_tokens_details": {
+      "reasoning_tokens": 173,
+    },
+    "total_tokens": 227,
   },
 }
 `;

--- a/payloads/snapshots/textFormatJsonSchemaMissingRequiredPropertyParam/chat-completions/error.json
+++ b/payloads/snapshots/textFormatJsonSchemaMissingRequiredPropertyParam/chat-completions/error.json
@@ -1,0 +1,3 @@
+{
+  "error": "Error: 400 Invalid schema for response_format 'structured_response': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'reasoning'."
+}

--- a/payloads/snapshots/textFormatJsonSchemaMissingRequiredPropertyParam/chat-completions/request.json
+++ b/payloads/snapshots/textFormatJsonSchemaMissingRequiredPropertyParam/chat-completions/request.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.4-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Return an answer and short reasoning."
+    }
+  ],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "structured_response",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "answer": {
+            "type": "string"
+          },
+          "reasoning": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "answer"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}

--- a/payloads/snapshots/textFormatJsonSchemaMissingRequiredPropertyParam/responses/error.json
+++ b/payloads/snapshots/textFormatJsonSchemaMissingRequiredPropertyParam/responses/error.json
@@ -1,0 +1,3 @@
+{
+  "error": "Error: 400 Invalid schema for response_format 'structured_response': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'reasoning'."
+}

--- a/payloads/snapshots/textFormatJsonSchemaMissingRequiredPropertyParam/responses/request.json
+++ b/payloads/snapshots/textFormatJsonSchemaMissingRequiredPropertyParam/responses/request.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.4-mini",
+  "input": [
+    {
+      "role": "user",
+      "content": "Return an answer and short reasoning."
+    }
+  ],
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "name": "structured_response",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "answer": {
+            "type": "string"
+          },
+          "reasoning": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "answer"
+        ],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}

--- a/payloads/transforms/chat-completions_to_anthropic/textFormatJsonSchemaMissingRequiredPropertyParam.json
+++ b/payloads/transforms/chat-completions_to_anthropic/textFormatJsonSchemaMissingRequiredPropertyParam.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011EEoUMiJCZSHDPVAGK4NwL",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"answer\": \"I don't see a specific question in your message.\", \"reasoning\": \"You asked me to return an answer and short reasoning, but didn't provide a question to answer. Please provide a question so I can give you a meaningful response.\"}"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 172,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 56,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/payloads/transforms/chat-completions_to_bedrock/textFormatJsonSchemaMissingRequiredPropertyParam-streaming.json
+++ b/payloads/transforms/chat-completions_to_bedrock/textFormatJsonSchemaMissingRequiredPropertyParam-streaming.json
@@ -1,0 +1,197 @@
+[
+  {
+    "messageStart": {
+      "role": "assistant"
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "#"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " I"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "'m ready to help!"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "\n\nI notice"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " you haven"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "'t aske"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "d a specific question yet. Could you please"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " provide"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": ":"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "\n\n1. **"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "The question** you'd like me to"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " answer\n2. **Any"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " relevant context** if"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " neede"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "d"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "\n\nOnce you share what"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " you're asking"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " about, I'll be happy to give"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " you a clear answer"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": " with conc"
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockDelta": {
+      "delta": {
+        "text": "ise reasoning."
+      },
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "contentBlockStop": {
+      "contentBlockIndex": 0
+    }
+  },
+  {
+    "messageStop": {
+      "stopReason": "end_turn"
+    }
+  },
+  {
+    "metadata": {
+      "usage": {
+        "inputTokens": 14,
+        "outputTokens": 72,
+        "totalTokens": 86
+      },
+      "metrics": {
+        "latencyMs": 2000
+      }
+    }
+  }
+]

--- a/payloads/transforms/chat-completions_to_bedrock/textFormatJsonSchemaMissingRequiredPropertyParam.json
+++ b/payloads/transforms/chat-completions_to_bedrock/textFormatJsonSchemaMissingRequiredPropertyParam.json
@@ -1,0 +1,29 @@
+{
+  "output": {
+    "message": {
+      "role": "assistant",
+      "content": [
+        {
+          "text": "I'm ready to help, but I don't see a specific question in your message. Could you please provide the question you'd like me to answer?\n\nOnce you do, I'll give you:\n1. **A clear answer**\n2. **Short reasoning** explaining why"
+        }
+      ]
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "inputTokens": 14,
+    "outputTokens": 61,
+    "totalTokens": 75,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokens": 0
+  },
+  "metrics": {
+    "latencyMs": 1307
+  },
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "c6e5c3e4-1569-4648-9b55-9ca3dd602c9f",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  }
+}

--- a/payloads/transforms/chat-completions_to_google/textFormatJsonSchemaMissingRequiredPropertyParam.json
+++ b/payloads/transforms/chat-completions_to_google/textFormatJsonSchemaMissingRequiredPropertyParam.json
@@ -1,0 +1,32 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "{\"answer\":\"Paris\",\"reasoning\":\"Paris has been the capital of France since the late 10th century, serving as the country's political, cultural, and economic center.\"}",
+            "thoughtSignature": "EvgMCvUMAQw51senVdlF2uWEzd+cLTe9hl8+BnJtHIljsbiAwo+D/8dMbmMHN76bIXiAiSyVR/I8RcCnnjtcRwFcv6LL6i668bbMpJ1ujHpF5/0Z/5wOdPNIueaU5CsliHmoQW3bg2SLQpEZ8vPETKX1X7ioqPQVeGRSmVj5GLuqnGKJJYtpKMwEDkVg9HLjEFM3cx309cGnoIAVlSrbEpPJGzin2q4Ltg1jHzOcRW2CJeu1Hn1XUSZlg1bdPNOgnEsu7RkLg8isnPjm047E6VkxAAgqAnuapxKxnN904MTM/LTowlOaUfz8qk6FHLXeWGsJ3Jx7xlClqAZCgRY0oNeNazM3LO8mCZybfukV2+7izSeSSAiktg6Yajnc7G205H4WR7YF4RFjOqwWXiqFjp+nryvw2Bgafed8SfxtgrqIwxVK7BvTtSqJz52O0aV0OxkjUDxmHQeUI5fq5OL7lozQS3Hy+dw9iWiAgwj4r9TNBv7QxihadgM+Jt3HW/5L01FS/bgbhyW9YlMrHUtIK3Jt+e64Bh/uz1QVDVNKufTAcJ7c3kK+JFXcU7GjAVScxeEtRV1vWHGwtjMZkXWc99ggTjer3zg95LdIJ4FTTW72g/72Z5hGJTM9/u7EIlRGa5h+iyVLW8/K+eRx0T1i4dN1WdmCHvrEDf4J7v6KMK8D23y5pSPgT/sG6WNgQn7Sx1Rh2iUaZpyQunxDggCYiNqa9Qb2THsKYy+KZHfKo4fnPStIk7Nzk1AD1C2FIsAjGjVAI/uPpmRv/aLFizilUL9QvIEigB55IWzZV8tEzRd4kznDCCBurtsVnuuXCUK9TqhB6RHWP1XvFyhzGqQioqHlY50OVtwEZLC1fdSYxG5tgiriNuy0wKky42prM5gJjzXWR+kxRd74Gy1UDsd99w3J1PpYiiYhPlj8gMR1VXT2Qus8GeSN4DJUMY8+jd4pJ2HLMTqYid/kMRkI33kQdbLPDNDX2ocm44EgLviVJA7ZsW/BWBb7yWqlluw/h2no88JxH2303BLHsFF4Ul89OH9vJ4NjjLR+7BMKggAoYWC52OrgXHc+9Cx7cCJXmYDxaWzWgCkw3XsJ7azHOtuEBbNwIlrBiMzZbD3kDIjNei3pxlCikpCDP6X+UrW8twhu/pKVqlsV1JfERmocFZH4lQq7teiOtUwtI6Mat0glRok6fdI3SECyE8ckmN876k8UjerCl4bDq8vwvzcE6KEPWS7HSfeljiljZCDvSwzDpzV8Y4wKDlxkj/z6MstmatevP0wXlOPh8OBZYg4sTnmQlW/Ggavd9KEvEqiNLRHboec8kJYrL6+cvD4a+O5OSlJxA3RGDW4pc0t5oySrNnDI/bWPm73wh7MXwkBVci1zBTbbwvXEkDZpeg0+/1C8WEEkAtzZ7pZdMVldzlcP/4VPlW+xf91RAaDtjXcmw3qz0ObDofVgCzeMyJVcJeq5V9iVpVSg41tSQ0v5UegyFRxzPFiomUXFIqWMhS6WeomXj4+s10K/stRdcaLvLx/UP9u02oOrlLGLltxjKNocylMUw5CcoZUTHh5j5dtOTnZHcIR9vmC+23smLnAvOTkEot2mQxgaL3p6mZuMlgrjjYk+pTwMNt43tMemjS01/lvv21aPFdpSUaZAlYdOd8v5ULEoqiBvAKTF6fSo1vKFUBDhSjfH+5EL2tGnjiJWb8sHpeX+FWC0WzvPT3UNOlGNyjTT+uQyvnb4zwFGRltukfmI3ZGdHjO8HDOmFfqG+jFFZSYOvEp9iKyt6xSg8IbhNqVPelSYpbfO/0iKjrjCLzSmecxg9XXgGuQb9PfElb69jekqrV9/Ig66cPLhxtEtJH8QHrmJqyMYc7sxCeIx1NPjSGM+QrigdpjWsC0qEP09w28vSR6WcHCZvtsutHa3JVTUv+ea6ntlDt6jaXkTPjDOAV4rZAgZJMjBzGDaWA7UXLp3zzUvPj621QCISjHwQGyFWZrZGauHYe9EwwKnafd9mgJJ2vgS7DaH9imcE5G0JItSMgwJUNbOoDbnjMAQgsdxFlhU0fmZLGn59LSXqLcTtvBoQd9Vwx7gV0olrYD0bch7kklnLhN1jIX0G3fs+OchfLYrkIPt54r80WKyawVm7pQwFv39cjuUc0lHLXS5GC0QljbZ6LmvNKH0CHdEeME7xv3QFfxdCusktQ3scWY8kuRmNF5CjHe0ghtf"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 8,
+    "candidatesTokenCount": 39,
+    "totalTokenCount": 443,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 8
+      }
+    ],
+    "thoughtsTokenCount": 396,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "X-smap-PB5fM-sAPvcG7kQo"
+}

--- a/payloads/transforms/chat-completions_to_responses/textFormatJsonSchemaMissingRequiredPropertyParam.json
+++ b/payloads/transforms/chat-completions_to_responses/textFormatJsonSchemaMissingRequiredPropertyParam.json
@@ -1,0 +1,94 @@
+{
+  "id": "resp_016f4883d0291359006a26eb5eee04819eb1833217fbb168c2",
+  "object": "response",
+  "created_at": 1780935518,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1780935519,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-5.4-mini-2026-03-17",
+  "moderation": null,
+  "output": [
+    {
+      "id": "msg_016f4883d0291359006a26eb5f4058819ebeb4d7dfc9fbaf43",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"answer\":\"Please provide the question or task you want answered.\",\"reasoning\":\"Your message only asks for an answer and short reasoning, but no actual question was included.\"}"
+        }
+      ],
+      "phase": "final_answer",
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "24h",
+  "reasoning": {
+    "context": "current_turn",
+    "effort": "none",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "description": null,
+      "name": "structured_response",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "answer": {
+            "type": "string"
+          },
+          "reasoning": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "answer",
+          "reasoning"
+        ],
+        "type": "object"
+      },
+      "strict": true
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 0.98,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 43,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 43,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 86
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "{\"answer\":\"Please provide the question or task you want answered.\",\"reasoning\":\"Your message only asks for an answer and short reasoning, but no actual question was included.\"}"
+}

--- a/payloads/transforms/responses_to_anthropic/textFormatJsonSchemaMissingRequiredPropertyParam.json
+++ b/payloads/transforms/responses_to_anthropic/textFormatJsonSchemaMissingRequiredPropertyParam.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_01LLQwDeZ9UVfjscXv4vPPAR",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"answer\": \"I need a specific question to provide an answer.\", \"reasoning\": \"No question was provided in the prompt, so I cannot generate a meaningful answer or reasoning without knowing what is being asked.\"}"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 172,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 46,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/payloads/transforms/responses_to_google/textFormatJsonSchemaMissingRequiredPropertyParam.json
+++ b/payloads/transforms/responses_to_google/textFormatJsonSchemaMissingRequiredPropertyParam.json
@@ -1,0 +1,32 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "{\n  \"answer\": \"This is a placeholder answer.\",\n  \"reasoning\": \"The user did not provide a specific question or prompt, so a generic response has been generated to satisfy the schema requirements.\"\n}",
+            "thoughtSignature": "EpsGCpgGAQw51sfX5aXuFfX5XZ23WLvW462+b8PXpLZSmek4L3If93gvzBzIS+tFPcuXv7jgCOdiDpgG/C+5xt+bNlx9NZydFYxgpo6JelIvO4b2m3q2PdQfAlPqw/5QxmqcghSEfAFi8Tn8u00uCeMq3/p2vUwhFsFA8roskbmLCqbswIVjvjjOdNkn+5ITn7gc+CNpWEKp0sGv93SU7S+c8hhAoLyArJzmEKi4B01sSf7BvjD4qx9ItIuZqbr/4jpqhwPmput9tjlf9jBfkNcNg0msR5O68WE2n+jjYFPxU8iPQSkR+/zY/cQoSkhWYvmuwImYqpKA9Xe301Rl45tO4uh9XfVLYM0AKUB07rQwDEqhnOeQd9gWAICzCe+nXXPXfCAPba2aKKuYcES4/54KLRcuruO2ijHLjnRvon9RieCc/xIDZQi4rOqsG1amh7oketrWj83Rii7/an4JzMbZxfagdESmvSbc8JhW8rxbv1Bhv0eOD75K+tx399SBzBAn/yUkkw7vgdVRtkFXlCVbRDSRIVzPwY+LCBO4eeXGc/UtwZ8TQCl5mHZkGzT2lFhSGf6f8P5OqvF7gStckcRX4Pj8lo33CLnRczygbTQg81937uv+ZSRO48hcVLL3Y7OciFfsvfmlROb5n0Y93Zi0QpM2BmLOf9se7DxhyKZb/eSSNvJzlghN4byoardoyS3S24irCUMhEPnT92R8CXZPj4fF0/nhCckBxpnKEryMqBbNWShMUmjUKui1+9ZS23GH9vbUSfESlGxxYbOaGahhW4NuT8JV6HuKxFJymJ1x9hZB1N+TlprGdhereDSRCqzca/BjhboFF+Nb7nUCbOV03tpFW7RmI58tRu7oCLfZe3OjJ8BF6EldC1BfalYiV5jNr6fKuEcInF3ottFv5fHhWu7uzkMa3nlioi+CM+8Vcbgn4WxTLfQiSmfjSmpI/dqIctJYe0HbhdZa8mEt2I1LPiAyvGhw4ZDEymriaFMY+V2wZcP1L4sooTlGuncl3T9gb3JMpuLPS9zSiNYIOmfCrCONDAmsQP/jTdHV"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 8,
+    "candidatesTokenCount": 46,
+    "totalTokenCount": 227,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 8
+      }
+    ],
+    "thoughtsTokenCount": 173,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "YOsmavD2CMXR1MkP6tWBsQo"
+}


### PR DESCRIPTION
seeing customers run into:

```
Invalid schema for response_format 'structured_response':
  'required' is required to be supplied and to be an array including every key in properties.
  Missing 'reasoning'
```

  
the other providers don't have this restriction so i think it's reasonable to trasnform this when we need to use responses api under the hood