### PR TITLE
route google catalog format models to google even when it uses chat completions endpoint

### DIFF
--- a/crates/braintrust-llm-router/src/catalog/mod.rs
+++ b/crates/braintrust-llm-router/src/catalog/mod.rs
@@ -1,6 +1,7 @@
 mod resolver;
 pub mod spec;
 
+pub(crate) use resolver::is_gemini_api_model;
 pub use resolver::ModelResolver;
 pub use spec::{ModelFlavor, ModelSpec};
 

--- a/crates/braintrust-llm-router/src/catalog/resolver.rs
+++ b/crates/braintrust-llm-router/src/catalog/resolver.rs
@@ -55,7 +55,7 @@ impl ModelResolver {
         } else if lingua::is_vertex_google_model(model) {
             // Force Google format regardless of what the spec says.
             ProviderFormat::Google
-        } else if is_gemini_api_model(model) {
+        } else if is_gemini_api_model(model) && spec.available_providers.is_empty() {
             ProviderFormat::Google
         } else {
             spec.format
@@ -284,6 +284,25 @@ mod tests {
 
         let (_, format, aliases) = resolver.resolve(model).expect("resolves");
         assert_eq!(format, ProviderFormat::Google);
+        assert_eq!(aliases, vec!["google".to_string()]);
+    }
+
+    #[test]
+    fn resolve_explicit_gemini_chat_completions_catalog_model_preserves_catalog_format() {
+        let model = "gemini-2.5-flash";
+        let mut catalog = ModelCatalog::empty();
+        catalog.insert(
+            model.into(),
+            spec_with_available_providers(
+                model,
+                ProviderFormat::ChatCompletions,
+                vec!["google".into()],
+            ),
+        );
+        let resolver = ModelResolver::new(Arc::new(catalog));
+
+        let (_, format, aliases) = resolver.resolve(model).expect("resolves");
+        assert_eq!(format, ProviderFormat::ChatCompletions);
         assert_eq!(aliases, vec!["google".to_string()]);
     }
 

--- a/crates/braintrust-llm-router/src/catalog/resolver.rs
+++ b/crates/braintrust-llm-router/src/catalog/resolver.rs
@@ -79,7 +79,7 @@ impl ModelResolver {
     }
 }
 
-fn is_gemini_api_model(model: &str) -> bool {
+pub(crate) fn is_gemini_api_model(model: &str) -> bool {
     !lingua::is_vertex_model(model)
         && (model.starts_with("gemini-") || model.starts_with("models/gemini-"))
 }

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -1221,6 +1221,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn explicit_gemini_chat_completions_catalog_uses_chat_completions_format() {
+        let model = "gemini-2.5-flash";
+        let mut spec = openai_spec(model, ModelFlavor::Chat);
+        spec.available_providers = vec!["google".into()];
+        let mut catalog = ModelCatalog::empty();
+        catalog.insert(model.into(), spec);
+        let router = Router::builder()
+            .with_catalog(Arc::new(catalog))
+            .add_provider(
+                "google",
+                FakeProvider {
+                    name: "google",
+                    formats: vec![ProviderFormat::Google, ProviderFormat::ChatCompletions],
+                },
+                dummy_auth(),
+                vec![ProviderFormat::Google],
+            )
+            .build()
+            .expect("router builds");
+        let body = Bytes::from_static(
+            br#"{"model":"gemini-2.5-flash","logprobs":true,"messages":[{"role":"user","content":"Ping"}]}"#,
+        );
+
+        let (request, metadata) = router
+            .create_request(body.clone(), model, ProviderFormat::ChatCompletions)
+            .await
+            .expect("create request");
+        let payload: Value = serde_json::from_slice(&request.inner.payload).expect("json");
+
+        assert_eq!(metadata.provider_alias, "google");
+        assert_eq!(metadata.provider_format, ProviderFormat::ChatCompletions);
+        assert_eq!(request.inner.format, ProviderFormat::ChatCompletions);
+        assert_eq!(request.inner.payload, body);
+        assert_eq!(payload.get("logprobs"), Some(&Value::Bool(true)));
+        assert!(payload.get("messages").is_some());
+        assert!(payload.get("contents").is_none());
+    }
+
+    #[tokio::test]
     async fn gemini_chat_completions_with_reasoning_and_tools_does_not_upgrade_to_responses() {
         let model = "gemini-2.5-flash";
         let router = google_chat_router(model);

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -9,7 +9,9 @@ use tracing::Instrument;
 use bytes::Bytes;
 
 use crate::auth::AuthConfig;
-use crate::catalog::{load_catalog_from_disk, ModelCatalog, ModelResolver, ModelSpec};
+use crate::catalog::{
+    is_gemini_api_model, load_catalog_from_disk, ModelCatalog, ModelResolver, ModelSpec,
+};
 use crate::client::ClientSettings;
 use crate::error::{Error, Result};
 use crate::providers::{
@@ -420,7 +422,6 @@ impl Router {
             .iter()
             .map(|alias| {
                 self.resolve_provider(
-                    model,
                     output_format,
                     spec.clone(),
                     catalog_format,
@@ -456,9 +457,11 @@ impl Router {
             }
         }
         if successes.is_empty() {
+            if is_gemini_api_model(model) && catalog_format != ProviderFormat::Google {
+                return Err(Error::NoProvider(ProviderFormat::Google));
+            }
             if let Some(fallback_alias) = self.formats.get(&catalog_format).cloned() {
                 match self.resolve_provider(
-                    model,
                     output_format,
                     spec,
                     catalog_format,
@@ -491,7 +494,6 @@ impl Router {
 
     fn resolve_provider(
         &self,
-        model: &str,
         output_format: ProviderFormat,
         spec: Arc<ModelSpec>,
         catalog_format: ProviderFormat,
@@ -549,11 +551,15 @@ impl Router {
             } else {
                 catalog_format
             }
-        } else if provider.id() == "google"
-            && output_format == ProviderFormat::ChatCompletions
-            && (model.starts_with("models/gemini-") || spec.model.starts_with("models/gemini-"))
-        {
-            ProviderFormat::Google
+        } else if provider.id() == "google" {
+            // Google supports both native GenerateContent and an OpenAI-compatible
+            // Chat Completions endpoint. Match Anthropic/Bedrock behavior: use the
+            // compatibility endpoint only when the catalog explicitly declares it.
+            if catalog_format == ProviderFormat::ChatCompletions {
+                ProviderFormat::ChatCompletions
+            } else {
+                catalog_format
+            }
         } else if provider.id() == "vertex"
             && output_format == ProviderFormat::ChatCompletions
             && spec.format == ProviderFormat::ChatCompletions
@@ -1024,7 +1030,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gemini_chat_completions_request_routes_to_google_chat_completions() {
+    async fn gemini_native_catalog_transforms_chat_completions_request_to_google() {
         let model = "gemini-2.5-flash";
         let router = google_chat_router(model);
         let body = Bytes::from_static(
@@ -1041,13 +1047,17 @@ mod tests {
             metadata.detected_input_format,
             ProviderFormat::ChatCompletions
         );
-        assert_eq!(metadata.provider_format, ProviderFormat::ChatCompletions);
-        assert_eq!(request.inner.format, ProviderFormat::ChatCompletions);
-        assert_eq!(request.inner.payload, body);
+        assert_eq!(metadata.provider_format, ProviderFormat::Google);
+        assert_eq!(request.inner.format, ProviderFormat::Google);
+        assert_ne!(request.inner.payload, body);
+
+        let payload: Value = serde_json::from_slice(&request.inner.payload).expect("json");
+        assert!(payload.get("contents").is_some());
+        assert!(payload.get("messages").is_none());
     }
 
     #[tokio::test]
-    async fn bare_gemini_route_normalizes_prefixed_chat_completions_payload_model() {
+    async fn bare_gemini_native_catalog_transforms_prefixed_chat_completions_payload() {
         let model = "gemini-2.5-flash";
         let router = google_chat_router(model);
         let body = Bytes::from_static(
@@ -1065,18 +1075,15 @@ mod tests {
             metadata.detected_input_format,
             ProviderFormat::ChatCompletions
         );
-        assert_eq!(metadata.provider_format, ProviderFormat::ChatCompletions);
-        assert_eq!(request.inner.format, ProviderFormat::ChatCompletions);
+        assert_eq!(metadata.provider_format, ProviderFormat::Google);
+        assert_eq!(request.inner.format, ProviderFormat::Google);
         assert_ne!(request.inner.payload, body);
-        assert_eq!(
-            payload.get("model").and_then(Value::as_str),
-            Some("gemini-2.5-flash")
-        );
-        assert!(payload.get("messages").is_some());
+        assert!(payload.get("contents").is_some());
+        assert!(payload.get("messages").is_none());
     }
 
     #[tokio::test]
-    async fn prefixed_gemini_chat_completions_request_uses_native_google_format() {
+    async fn prefixed_gemini_native_catalog_uses_native_google_format() {
         let model = "models/gemini-2.5-flash";
         let router = google_chat_router(model);
         let body = Bytes::from_static(
@@ -1156,7 +1163,7 @@ mod tests {
             .build()
             .expect("router builds");
         let body = Bytes::from_static(
-            br#"{"model":"models/gemini-2.5-flash","messages":[{"role":"user","content":"Ping"}]}"#,
+            br#"{"model":"models/gemini-2.5-flash","seed":42,"logprobs":true,"messages":[{"role":"user","content":"Ping"}]}"#,
         );
 
         let (request, metadata) = router
@@ -1169,6 +1176,46 @@ mod tests {
         assert_eq!(metadata.provider_format, ProviderFormat::Google);
         assert_eq!(request.inner.format, ProviderFormat::Google);
         assert_ne!(request.inner.payload, body);
+        assert!(payload.get("seed").is_none());
+        assert!(payload.get("logprobs").is_none());
+        assert!(payload.get("contents").is_some());
+        assert!(payload.get("messages").is_none());
+    }
+
+    #[tokio::test]
+    async fn gemini_chat_completions_catalog_uses_native_google_format() {
+        let model = "gemini-2.5-flash";
+        let mut catalog = ModelCatalog::empty();
+        catalog.insert(model.into(), openai_spec(model, ModelFlavor::Chat));
+        let router = Router::builder()
+            .with_catalog(Arc::new(catalog))
+            .add_provider(
+                "google",
+                FakeProvider {
+                    name: "google",
+                    formats: vec![ProviderFormat::Google, ProviderFormat::ChatCompletions],
+                },
+                dummy_auth(),
+                vec![ProviderFormat::Google],
+            )
+            .build()
+            .expect("router builds");
+        let body = Bytes::from_static(
+            br#"{"model":"gemini-2.5-flash","seed":42,"logprobs":true,"messages":[{"role":"user","content":"Ping"}]}"#,
+        );
+
+        let (request, metadata) = router
+            .create_request(body.clone(), model, ProviderFormat::ChatCompletions)
+            .await
+            .expect("create request");
+        let payload: Value = serde_json::from_slice(&request.inner.payload).expect("json");
+
+        assert_eq!(metadata.provider_alias, "google");
+        assert_eq!(metadata.provider_format, ProviderFormat::Google);
+        assert_eq!(request.inner.format, ProviderFormat::Google);
+        assert_ne!(request.inner.payload, body);
+        assert!(payload.get("seed").is_none());
+        assert!(payload.get("logprobs").is_none());
         assert!(payload.get("contents").is_some());
         assert!(payload.get("messages").is_none());
     }
@@ -1187,13 +1234,13 @@ mod tests {
             .expect("create request");
 
         assert_eq!(metadata.provider_alias, "google");
-        assert_eq!(metadata.provider_format, ProviderFormat::ChatCompletions);
-        assert_eq!(request.inner.format, ProviderFormat::ChatCompletions);
-        assert_eq!(request.inner.payload, body);
+        assert_eq!(metadata.provider_format, ProviderFormat::Google);
+        assert_eq!(request.inner.format, ProviderFormat::Google);
+        assert_ne!(request.inner.payload, body);
     }
 
     #[tokio::test]
-    async fn gemini_stream_chat_completions_request_sets_stream_flag() {
+    async fn gemini_stream_chat_completions_request_uses_native_google_streaming() {
         let model = "gemini-2.5-flash";
         let router = google_chat_router(model);
         let body = Bytes::from_static(
@@ -1207,8 +1254,9 @@ mod tests {
         let payload: Value = serde_json::from_slice(&request.inner.payload).expect("json");
 
         assert_eq!(metadata.provider_alias, "google");
-        assert_eq!(metadata.provider_format, ProviderFormat::ChatCompletions);
-        assert_eq!(payload.get("stream"), Some(&Value::Bool(true)));
+        assert_eq!(metadata.provider_format, ProviderFormat::Google);
+        assert_eq!(payload.get("stream"), None);
+        assert!(payload.get("contents").is_some());
     }
 
     #[test]
@@ -1333,33 +1381,6 @@ mod tests {
     }
 
     #[test]
-    fn gemini_model_without_google_provider_does_not_fallback_to_openai_chat_completions() {
-        let model = "gemini-2.5-flash";
-        let mut catalog = ModelCatalog::empty();
-        catalog.insert(model.into(), google_spec(model));
-        let router = Router::builder()
-            .with_catalog(Arc::new(catalog))
-            .add_provider(
-                "openai",
-                FakeProvider {
-                    name: "openai",
-                    formats: vec![ProviderFormat::ChatCompletions],
-                },
-                dummy_auth(),
-                vec![ProviderFormat::ChatCompletions],
-            )
-            .build()
-            .expect("router builds");
-
-        let err = match router.resolve_providers(model, ProviderFormat::ChatCompletions) {
-            Ok(_) => panic!("should not route Gemini model to OpenAI fallback"),
-            Err(err) => err,
-        };
-
-        assert!(matches!(err, Error::NoProvider(ProviderFormat::Google)));
-    }
-
-    #[test]
     fn gemini_chat_completions_catalog_without_google_provider_does_not_fallback_to_openai() {
         let model = "gemini-2.5-flash";
         let mut catalog = ModelCatalog::empty();
@@ -1384,6 +1405,36 @@ mod tests {
         };
 
         assert!(matches!(err, Error::NoProvider(ProviderFormat::Google)));
+    }
+
+    #[test]
+    fn gemini_model_falls_back_to_default_google_provider_alias() {
+        let model = "gemini-2.5-flash";
+        let mut catalog = ModelCatalog::empty();
+        catalog.insert(model.into(), openai_spec(model, ModelFlavor::Chat));
+        let router = Router::builder()
+            .with_catalog(Arc::new(catalog))
+            .add_provider(
+                "google-prod",
+                FakeProvider {
+                    name: "google",
+                    formats: vec![ProviderFormat::Google, ProviderFormat::ChatCompletions],
+                },
+                dummy_auth(),
+                vec![ProviderFormat::Google],
+            )
+            .build()
+            .expect("router builds");
+
+        let routes = router
+            .resolve_providers(model, ProviderFormat::ChatCompletions)
+            .expect("resolves via default Google provider");
+
+        assert_eq!(routes.len(), 1);
+        let (alias, provider, _, _, format, _) = &routes[0];
+        assert_eq!(alias, "google-prod");
+        assert_eq!(provider.id(), "google");
+        assert_eq!(*format, ProviderFormat::Google);
     }
 
     #[test]


### PR DESCRIPTION
if the model is registered as google catalog format, we should continue to route to google. lets only route gemini models to the chat completion endpoint if its configured as a custom model.