### PR TITLE
Add `x-anthropic-prompt-cache` to enable prompt caching for anthropic models

### DIFF
--- a/crates/braintrust-llm-router/src/lib.rs
+++ b/crates/braintrust-llm-router/src/lib.rs
@@ -29,6 +29,7 @@ pub use providers::{
     AzureConfig, AzureProvider, BedrockConfig, BedrockProvider, ClientHeaders, DatabricksConfig,
     DatabricksProvider, GoogleConfig, GoogleProvider, MistralConfig, MistralProvider,
     OpenAICompatibleEndpoint, OpenAIConfig, OpenAIProvider, Provider, VertexConfig, VertexProvider,
+    ANTHROPIC_PROMPT_CACHE_HEADER,
 };
 pub use retry::{RetryPolicy, RetryStrategy};
 pub use router::{

--- a/crates/braintrust-llm-router/src/providers/anthropic.rs
+++ b/crates/braintrust-llm-router/src/providers/anthropic.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use crate::auth::AuthConfig;
@@ -8,17 +9,27 @@ use crate::providers::ClientHeaders;
 use crate::streaming::{sse_stream, RawResponseStream};
 use async_trait::async_trait;
 use bytes::Bytes;
+use lingua::providers::anthropic::generated::{CacheControlEphemeral, CacheControlEphemeralType};
 use lingua::serde_json::{self, Value};
 use lingua::ProviderFormat;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::Url;
 use reqwest_middleware::ClientWithMiddleware;
+use serde::{Deserialize, Serialize};
 
 pub const ANTHROPIC_VERSION: &str = "anthropic-version";
 pub const DEFAULT_ANTHROPIC_VERSION_VALUE: &str = "2023-06-01";
 pub const ANTHROPIC_PROMPT_CACHE_HEADER: &str = "x-anthropic-prompt-cache";
 const ANTHROPIC_BETA: &str = "anthropic-beta";
 const STRUCTURED_OUTPUTS_BETA: &str = "structured-outputs-2025-11-13";
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AnthropicPromptCacheRequestView {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<CacheControlEphemeral>,
+    #[serde(flatten)]
+    extras: BTreeMap<String, Value>,
+}
 
 fn prompt_cache_header_enabled(headers: &ClientHeaders) -> bool {
     headers
@@ -44,25 +55,16 @@ fn apply_prompt_cache_header(
         return Ok(payload);
     }
 
-    let mut value: Value = serde_json::from_slice(&payload)?;
-    let Some(object) = value.as_object_mut() else {
-        return Err(Error::InvalidRequest(
-            "Anthropic prompt cache header requires a JSON object request body".to_string(),
-        ));
-    };
-
-    if object
-        .get("cache_control")
-        .is_some_and(|cache_control| !cache_control.is_null())
-    {
+    let mut request: AnthropicPromptCacheRequestView = serde_json::from_slice(&payload)?;
+    if request.cache_control.is_some() {
         return Ok(payload);
     }
 
-    object.insert(
-        "cache_control".to_string(),
-        serde_json::json!({ "type": "ephemeral" }),
-    );
-    Ok(Bytes::from(serde_json::to_vec(&value)?))
+    request.cache_control = Some(CacheControlEphemeral {
+        ttl: None,
+        cache_control_ephemeral_type: CacheControlEphemeralType::Ephemeral,
+    });
+    Ok(Bytes::from(serde_json::to_vec(&request)?))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/braintrust-llm-router/src/providers/anthropic.rs
+++ b/crates/braintrust-llm-router/src/providers/anthropic.rs
@@ -8,6 +8,7 @@ use crate::providers::ClientHeaders;
 use crate::streaming::{sse_stream, RawResponseStream};
 use async_trait::async_trait;
 use bytes::Bytes;
+use lingua::serde_json::{self, Value};
 use lingua::ProviderFormat;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::Url;
@@ -15,8 +16,52 @@ use reqwest_middleware::ClientWithMiddleware;
 
 pub const ANTHROPIC_VERSION: &str = "anthropic-version";
 pub const DEFAULT_ANTHROPIC_VERSION_VALUE: &str = "2023-06-01";
+pub const ANTHROPIC_PROMPT_CACHE_HEADER: &str = "x-anthropic-prompt-cache";
 const ANTHROPIC_BETA: &str = "anthropic-beta";
 const STRUCTURED_OUTPUTS_BETA: &str = "structured-outputs-2025-11-13";
+
+fn prompt_cache_header_enabled(headers: &HeaderMap) -> bool {
+    headers
+        .get(ANTHROPIC_PROMPT_CACHE_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+}
+
+fn strip_prompt_cache_header(headers: &mut HeaderMap) {
+    headers.remove(ANTHROPIC_PROMPT_CACHE_HEADER);
+}
+
+fn apply_prompt_cache_header(
+    payload: Bytes,
+    format: ProviderFormat,
+    headers: &HeaderMap,
+) -> Result<Bytes> {
+    if format != ProviderFormat::Anthropic || !prompt_cache_header_enabled(headers) {
+        return Ok(payload);
+    }
+
+    let mut value: Value = serde_json::from_slice(&payload)?;
+    let Some(object) = value.as_object_mut() else {
+        return Err(Error::InvalidRequest(
+            "Anthropic prompt cache header requires a JSON object request body".to_string(),
+        ));
+    };
+
+    if object.contains_key("cache_control") {
+        return Ok(payload);
+    }
+
+    object.insert(
+        "cache_control".to_string(),
+        serde_json::json!({ "type": "ephemeral" }),
+    );
+    Ok(Bytes::from(serde_json::to_vec(&value)?))
+}
 
 #[derive(Debug, Clone)]
 pub struct AnthropicConfig {
@@ -33,6 +78,87 @@ impl Default for AnthropicConfig {
             version: "2023-06-01".to_string(),
             timeout: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers_with_prompt_cache(value: &str) -> HeaderMap {
+        let mut client_headers = ClientHeaders::new();
+        client_headers.insert_if_allowed(ANTHROPIC_PROMPT_CACHE_HEADER, value);
+        client_headers.to_json_headers()
+    }
+
+    #[test]
+    fn prompt_cache_header_adds_top_level_cache_control() {
+        let payload = Bytes::from_static(
+            br#"{"model":"claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#,
+        );
+        let updated = apply_prompt_cache_header(
+            payload,
+            ProviderFormat::Anthropic,
+            &headers_with_prompt_cache("true"),
+        )
+        .expect("cache header should apply");
+        let parsed: Value = serde_json::from_slice(&updated).expect("valid json");
+
+        assert_eq!(
+            parsed
+                .get("cache_control")
+                .and_then(|cache_control| cache_control.get("type"))
+                .and_then(Value::as_str),
+            Some("ephemeral")
+        );
+    }
+
+    #[test]
+    fn prompt_cache_header_preserves_existing_cache_control() {
+        let payload = Bytes::from_static(
+            br#"{"model":"claude-sonnet-4-5","max_tokens":1024,"cache_control":{"type":"ephemeral","ttl":"1h"},"messages":[{"role":"user","content":"Hi"}]}"#,
+        );
+        let updated = apply_prompt_cache_header(
+            payload,
+            ProviderFormat::Anthropic,
+            &headers_with_prompt_cache("true"),
+        )
+        .expect("cache header should apply");
+        let parsed: Value = serde_json::from_slice(&updated).expect("valid json");
+
+        assert_eq!(
+            parsed
+                .get("cache_control")
+                .and_then(|cache_control| cache_control.get("ttl"))
+                .and_then(Value::as_str),
+            Some("1h")
+        );
+    }
+
+    #[test]
+    fn prompt_cache_header_does_not_apply_to_chat_completions_format() {
+        let payload = Bytes::from_static(
+            br#"{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"Hi"}]}"#,
+        );
+        let updated = apply_prompt_cache_header(
+            payload,
+            ProviderFormat::ChatCompletions,
+            &headers_with_prompt_cache("true"),
+        )
+        .expect("cache header should be ignored");
+        let parsed: Value = serde_json::from_slice(&updated).expect("valid json");
+
+        assert!(parsed.get("cache_control").is_none());
+    }
+
+    #[test]
+    fn prompt_cache_control_header_is_stripped_before_upstream() {
+        let mut headers = headers_with_prompt_cache("true");
+        assert!(headers.contains_key(ANTHROPIC_PROMPT_CACHE_HEADER));
+
+        strip_prompt_cache_header(&mut headers);
+
+        assert!(!headers.contains_key(ANTHROPIC_PROMPT_CACHE_HEADER));
     }
 }
 
@@ -136,8 +262,13 @@ impl crate::providers::Provider for AnthropicProvider {
         format: ProviderFormat,
         client_headers: &ClientHeaders,
     ) -> Result<Bytes> {
+        let mut base_headers = self.build_headers(client_headers);
+        let payload = apply_prompt_cache_header(payload, format, &base_headers)?;
+        strip_prompt_cache_header(&mut base_headers);
+
         let (url, headers) = if format == ProviderFormat::ChatCompletions {
             let mut h = client_headers.to_json_headers();
+            strip_prompt_cache_header(&mut h);
             let key = auth.api_key().ok_or_else(|| {
                 Error::Auth("Anthropic /chat/completions requires an API key".to_string())
             })?;
@@ -148,9 +279,8 @@ impl crate::providers::Provider for AnthropicProvider {
             );
             (self.chat_completions_url(), h)
         } else {
-            let mut h = self.build_headers(client_headers);
-            auth.apply_headers(&mut h)?;
-            (self.messages_url(), h)
+            auth.apply_headers(&mut base_headers)?;
+            (self.messages_url(), base_headers)
         };
 
         let response = self
@@ -202,8 +332,13 @@ impl crate::providers::Provider for AnthropicProvider {
         }
 
         // Router should have already added stream options to payload
+        let mut base_headers = self.build_headers(client_headers);
+        let payload = apply_prompt_cache_header(payload, format, &base_headers)?;
+        strip_prompt_cache_header(&mut base_headers);
+
         let (url, headers) = if format == ProviderFormat::ChatCompletions {
             let mut h = client_headers.to_json_headers();
+            strip_prompt_cache_header(&mut h);
             let key = auth.api_key().ok_or_else(|| {
                 Error::Auth("Anthropic /chat/completions requires an API key".to_string())
             })?;
@@ -214,9 +349,8 @@ impl crate::providers::Provider for AnthropicProvider {
             );
             (self.chat_completions_url(), h)
         } else {
-            let mut h = self.build_headers(client_headers);
-            auth.apply_headers(&mut h)?;
-            (self.messages_url(), h)
+            auth.apply_headers(&mut base_headers)?;
+            (self.messages_url(), base_headers)
         };
 
         let response = self

--- a/crates/braintrust-llm-router/src/providers/anthropic.rs
+++ b/crates/braintrust-llm-router/src/providers/anthropic.rs
@@ -20,10 +20,9 @@ pub const ANTHROPIC_PROMPT_CACHE_HEADER: &str = "x-anthropic-prompt-cache";
 const ANTHROPIC_BETA: &str = "anthropic-beta";
 const STRUCTURED_OUTPUTS_BETA: &str = "structured-outputs-2025-11-13";
 
-fn prompt_cache_header_enabled(headers: &HeaderMap) -> bool {
+fn prompt_cache_header_enabled(headers: &ClientHeaders) -> bool {
     headers
         .get(ANTHROPIC_PROMPT_CACHE_HEADER)
-        .and_then(|value| value.to_str().ok())
         .is_some_and(|value| {
             matches!(
                 value.trim().to_ascii_lowercase().as_str(),
@@ -32,14 +31,10 @@ fn prompt_cache_header_enabled(headers: &HeaderMap) -> bool {
         })
 }
 
-fn strip_prompt_cache_header(headers: &mut HeaderMap) {
-    headers.remove(ANTHROPIC_PROMPT_CACHE_HEADER);
-}
-
 fn apply_prompt_cache_header(
     payload: Bytes,
     format: ProviderFormat,
-    headers: &HeaderMap,
+    headers: &ClientHeaders,
 ) -> Result<Bytes> {
     // Non-Anthropic request formats do not have a native way to ask for
     // Anthropic cache_control, and caching changes Anthropic billing behavior.
@@ -92,10 +87,10 @@ impl Default for AnthropicConfig {
 mod tests {
     use super::*;
 
-    fn headers_with_prompt_cache(value: &str) -> HeaderMap {
+    fn headers_with_prompt_cache(value: &str) -> ClientHeaders {
         let mut client_headers = ClientHeaders::new();
         client_headers.insert_if_allowed(ANTHROPIC_PROMPT_CACHE_HEADER, value);
-        client_headers.to_json_headers()
+        client_headers
     }
 
     #[test]
@@ -182,12 +177,12 @@ mod tests {
 
     #[test]
     fn prompt_cache_control_header_is_stripped_before_upstream() {
-        let mut headers = headers_with_prompt_cache("true");
-        assert!(headers.contains_key(ANTHROPIC_PROMPT_CACHE_HEADER));
+        let headers = headers_with_prompt_cache("true");
+        assert!(prompt_cache_header_enabled(&headers));
 
-        strip_prompt_cache_header(&mut headers);
-
-        assert!(!headers.contains_key(ANTHROPIC_PROMPT_CACHE_HEADER));
+        assert!(!headers
+            .to_json_headers()
+            .contains_key(ANTHROPIC_PROMPT_CACHE_HEADER));
     }
 }
 
@@ -292,12 +287,10 @@ impl crate::providers::Provider for AnthropicProvider {
         client_headers: &ClientHeaders,
     ) -> Result<Bytes> {
         let mut base_headers = self.build_headers(client_headers);
-        let payload = apply_prompt_cache_header(payload, format, &base_headers)?;
-        strip_prompt_cache_header(&mut base_headers);
+        let payload = apply_prompt_cache_header(payload, format, client_headers)?;
 
         let (url, headers) = if format == ProviderFormat::ChatCompletions {
             let mut h = client_headers.to_json_headers();
-            strip_prompt_cache_header(&mut h);
             let key = auth.api_key().ok_or_else(|| {
                 Error::Auth("Anthropic /chat/completions requires an API key".to_string())
             })?;
@@ -362,12 +355,10 @@ impl crate::providers::Provider for AnthropicProvider {
 
         // Router should have already added stream options to payload
         let mut base_headers = self.build_headers(client_headers);
-        let payload = apply_prompt_cache_header(payload, format, &base_headers)?;
-        strip_prompt_cache_header(&mut base_headers);
+        let payload = apply_prompt_cache_header(payload, format, client_headers)?;
 
         let (url, headers) = if format == ProviderFormat::ChatCompletions {
             let mut h = client_headers.to_json_headers();
-            strip_prompt_cache_header(&mut h);
             let key = auth.api_key().ok_or_else(|| {
                 Error::Auth("Anthropic /chat/completions requires an API key".to_string())
             })?;

--- a/crates/braintrust-llm-router/src/providers/anthropic.rs
+++ b/crates/braintrust-llm-router/src/providers/anthropic.rs
@@ -41,6 +41,10 @@ fn apply_prompt_cache_header(
     format: ProviderFormat,
     headers: &HeaderMap,
 ) -> Result<Bytes> {
+    // Non-Anthropic request formats do not have a native way to ask for
+    // Anthropic cache_control, and caching changes Anthropic billing behavior.
+    // Use this router-only header as the explicit opt-in bridge instead of
+    // enabling prompt caching for every transform to Anthropic.
     if format != ProviderFormat::Anthropic || !prompt_cache_header_enabled(headers) {
         return Ok(payload);
     }

--- a/crates/braintrust-llm-router/src/providers/anthropic.rs
+++ b/crates/braintrust-llm-router/src/providers/anthropic.rs
@@ -56,7 +56,10 @@ fn apply_prompt_cache_header(
         ));
     };
 
-    if object.contains_key("cache_control") {
+    if object
+        .get("cache_control")
+        .is_some_and(|cache_control| !cache_control.is_null())
+    {
         return Ok(payload);
     }
 
@@ -136,6 +139,28 @@ mod tests {
                 .and_then(|cache_control| cache_control.get("ttl"))
                 .and_then(Value::as_str),
             Some("1h")
+        );
+    }
+
+    #[test]
+    fn prompt_cache_header_replaces_null_cache_control() {
+        let payload = Bytes::from_static(
+            br#"{"model":"claude-sonnet-4-5","max_tokens":1024,"cache_control":null,"messages":[{"role":"user","content":"Hi"}]}"#,
+        );
+        let updated = apply_prompt_cache_header(
+            payload,
+            ProviderFormat::Anthropic,
+            &headers_with_prompt_cache("true"),
+        )
+        .expect("cache header should apply");
+        let parsed: Value = serde_json::from_slice(&updated).expect("valid json");
+
+        assert_eq!(
+            parsed
+                .get("cache_control")
+                .and_then(|cache_control| cache_control.get("type"))
+                .and_then(Value::as_str),
+            Some("ephemeral")
         );
     }
 

--- a/crates/braintrust-llm-router/src/providers/mod.rs
+++ b/crates/braintrust-llm-router/src/providers/mod.rs
@@ -36,6 +36,11 @@ use lingua::ProviderFormat;
 /// Header prefixes blocked from forwarding to upstream LLM providers.
 pub const BLOCKED_HEADER_PREFIXES: &[&str] = &["x-amzn", "x-bt", "sec-", "cf-"];
 
+// Router-control headers must remain readable from ClientHeaders so provider
+// adapters can act on them, but they are internal controls and must never be
+// forwarded to upstream provider APIs.
+const ROUTER_CONTROL_HEADERS: &[&str] = &[anthropic::ANTHROPIC_PROMPT_CACHE_HEADER];
+
 /// Exact header names blocked from forwarding to upstream LLM providers
 /// from https://github.com/braintrustdata/braintrust-proxy/blob/e992f51734c71e689ea0090f9e0a6759c9a593a4/packages/proxy/src/proxy.ts#L247
 pub const BLOCKED_HEADERS: &[&str] = &[
@@ -78,11 +83,26 @@ impl ClientHeaders {
             || BLOCKED_HEADERS.iter().any(|&blocked| name == blocked)
     }
 
+    fn is_router_control(name: &str) -> bool {
+        let name = name.to_lowercase();
+        ROUTER_CONTROL_HEADERS
+            .iter()
+            .any(|&control| name == control)
+    }
+
     pub fn insert_if_allowed(&mut self, name: impl Into<String>, value: impl Into<String>) {
         let name = name.into();
         if !Self::is_blocked(&name) {
             self.inner.insert(name.to_lowercase(), value.into());
         }
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Option<&str> {
+        let name = name.to_lowercase();
+        self.user_configured
+            .get(&name)
+            .or_else(|| self.inner.get(&name))
+            .map(String::as_str)
     }
 
     pub fn insert_user_configured(
@@ -105,8 +125,10 @@ impl ClientHeaders {
 
     fn apply_inner(&self, headers: &mut HeaderMap) {
         for (name, value) in &self.inner {
-            if name == "host" {
+            if name == "host" || Self::is_router_control(name) {
                 // Don't forward client Host; reqwest sets it from the upstream URL.
+                // Router-control headers are consumed internally and should not
+                // be sent to any upstream provider.
                 continue;
             }
             if let (Ok(header_name), Ok(header_value)) = (
@@ -120,6 +142,9 @@ impl ClientHeaders {
 
     fn apply_user_configured(&self, headers: &mut HeaderMap) {
         for (name, value) in &self.user_configured {
+            if Self::is_router_control(name) {
+                continue;
+            }
             if let (Ok(header_name), Ok(header_value)) = (
                 HeaderName::from_bytes(name.as_bytes()),
                 HeaderValue::from_str(value),

--- a/crates/braintrust-llm-router/src/providers/mod.rs
+++ b/crates/braintrust-llm-router/src/providers/mod.rs
@@ -7,7 +7,7 @@ mod mistral;
 mod openai;
 mod vertex;
 
-pub use anthropic::{AnthropicConfig, AnthropicProvider};
+pub use anthropic::{AnthropicConfig, AnthropicProvider, ANTHROPIC_PROMPT_CACHE_HEADER};
 pub use azure::{AzureConfig, AzureProvider};
 pub(crate) use bedrock::{prepare_bedrock_request, requires_bedrock_request_preparation};
 pub use bedrock::{BedrockConfig, BedrockProvider};

--- a/crates/braintrust-llm-router/tests/client_headers.rs
+++ b/crates/braintrust-llm-router/tests/client_headers.rs
@@ -1,4 +1,4 @@
-use braintrust_llm_router::ClientHeaders;
+use braintrust_llm_router::{ClientHeaders, ANTHROPIC_PROMPT_CACHE_HEADER};
 use http::HeaderMap;
 
 fn apply_headers(cases: &[(&str, &str, bool)]) -> HeaderMap {
@@ -26,6 +26,7 @@ fn client_headers_filter_and_host_behavior() {
         ("cache-control", "no-cache", false),
         ("host", "api.example.com", false),
         ("anthropic-beta", "tools-2024-05-16", true),
+        (ANTHROPIC_PROMPT_CACHE_HEADER, "true", false),
         ("accept", "application/json", true),
         ("x-custom-header", "1", true),
     ];
@@ -48,6 +49,9 @@ fn user_configured_headers_are_not_filtered() {
     client_headers
         .insert_user_configured("x-bt-project-id", "configured-project")
         .expect("x-bt-project-id header");
+    client_headers
+        .insert_user_configured(ANTHROPIC_PROMPT_CACHE_HEADER, "true")
+        .expect("prompt cache header");
     let mut headers = HeaderMap::new();
 
     client_headers.apply(&mut headers);
@@ -64,4 +68,5 @@ fn user_configured_headers_are_not_filtered() {
         headers.get("x-bt-project-id").and_then(|v| v.to_str().ok()),
         Some("configured-project")
     );
+    assert!(!headers.contains_key(ANTHROPIC_PROMPT_CACHE_HEADER));
 }

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -1066,6 +1066,30 @@ mod tests {
 
     #[test]
     #[cfg(all(feature = "openai", feature = "anthropic"))]
+    fn test_transform_request_chat_completions_does_not_add_anthropic_cache_control() {
+        let payload = json!({
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "system", "content": "Be helpful."},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let input = to_bytes(&payload);
+
+        let result = transform_request(input, ProviderFormat::Anthropic, None).unwrap();
+
+        assert_eq!(
+            result.source_format(),
+            Some(ProviderFormat::ChatCompletions)
+        );
+
+        let output: Value = crate::serde_json::from_slice(result.as_bytes()).unwrap();
+        assert!(output.get("cache_control").is_none());
+    }
+
+    #[test]
+    #[cfg(all(feature = "openai", feature = "anthropic"))]
     fn test_transform_request_claude_code_messages_to_openai() {
         let payload = json!({
             "model": "gpt-5.5",

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -607,6 +607,10 @@ impl ProviderAdapter for AnthropicAdapter {
             );
         }
 
+        if let Some(raw_cache_control) = anthropic_extras_view.cache_control.as_ref() {
+            obj.insert("cache_control".into(), raw_cache_control.clone());
+        }
+
         // Merge back provider-specific extras (only for Anthropic)
         if let Some(extras) = req.params.extras.get(&ProviderFormat::Anthropic) {
             for (k, v) in extras {

--- a/crates/lingua/src/providers/anthropic/params.rs
+++ b/crates/lingua/src/providers/anthropic/params.rs
@@ -6,7 +6,8 @@ eliminating the need for explicit KNOWN_KEYS arrays.
 */
 
 use crate::providers::anthropic::generated::{
-    InputMessage, JsonOutputFormat, Metadata, OutputConfig, System, Thinking, Tool, ToolChoice,
+    CacheControlEphemeral, InputMessage, JsonOutputFormat, Metadata, OutputConfig, System,
+    Thinking, Tool, ToolChoice,
 };
 use crate::serde_json::Value;
 use serde::{Deserialize, Serialize};
@@ -24,6 +25,7 @@ pub struct AnthropicParams {
 
     // === System prompt (string or array with cache_control) ===
     pub system: Option<System>,
+    pub cache_control: Option<CacheControlEphemeral>,
 
     // === Required output control ===
     pub max_tokens: Option<i64>,
@@ -69,6 +71,7 @@ pub struct AnthropicParams {
 pub struct AnthropicExtrasView {
     pub messages: Option<Value>,
     pub system: Option<Value>,
+    pub cache_control: Option<Value>,
     pub temperature: Option<Value>,
     pub tools: Option<Value>,
     pub tool_choice: Option<Value>,


### PR DESCRIPTION
when using other apis such as responses/gemini, you can't enable prompt caching for anthropic models so adding a header as a workaround. 