### PR TITLE
Rename serde_json fork package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ name = "anonymize"
 version = "0.1.0"
 dependencies = [
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 name = "big_serde_json"
 version = "0.1.0"
 dependencies = [
- "serde_json 1.0.145",
+ "braintrust_serde_json",
  "ts-rs",
 ]
 
@@ -570,7 +570,7 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-retry",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
  "serial_test",
  "sha2 0.10.9",
  "smallvec",
@@ -583,6 +583,18 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "wiremock",
+]
+
+[[package]]
+name = "braintrust_serde_json"
+version = "1.0.145"
+source = "git+https://github.com/braintrustdata/serde-json.git?rev=905b790b50e8922370f3e73ef93d7d5fb7010edc#905b790b50e8922370f3e73ef93d7d5fb7010edc"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -841,7 +853,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_derive",
- "serde_json 1.0.143",
+ "serde_json",
  "tinytemplate",
  "tokio",
  "walkdir",
@@ -1652,7 +1664,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.7.3",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
  "serde_qs",
  "serde_urlencoded",
  "url",
@@ -2058,7 +2070,7 @@ dependencies = [
  "rand 0.8.5",
  "rsa",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
  "sha2 0.10.9",
  "signature",
  "simple_asn1",
@@ -2107,7 +2119,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde-wasm-bindgen",
- "serde_json 1.0.143",
+ "serde_json",
  "serde_with",
  "serde_yaml",
  "thiserror 2.0.16",
@@ -3040,7 +3052,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -3279,7 +3291,7 @@ dependencies = [
  "schemafy_lib",
  "serde",
  "serde_derive",
- "serde_json 1.0.143",
+ "serde_json",
  "serde_repr",
  "syn 1.0.109",
 ]
@@ -3291,7 +3303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bec29dddcfe60f92f3c0d422707b8b56473983ef0481df8d5236ed3ab8fdf24"
 dependencies = [
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
 ]
 
 [[package]]
@@ -3306,7 +3318,7 @@ dependencies = [
  "schemafy_core",
  "serde",
  "serde_derive",
- "serde_json 1.0.143",
+ "serde_json",
  "syn 1.0.109",
  "uriparse",
 ]
@@ -3320,7 +3332,7 @@ dependencies = [
  "dyn-clone",
  "schemars_derive",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
 ]
 
 [[package]]
@@ -3332,7 +3344,7 @@ dependencies = [
  "dyn-clone",
  "ref-cast",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
 ]
 
 [[package]]
@@ -3344,7 +3356,7 @@ dependencies = [
  "dyn-clone",
  "ref-cast",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
 ]
 
 [[package]]
@@ -3483,18 +3495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.145"
-source = "git+https://github.com/ankrgyl/serde-json.git?rev=efa66e3a1d61459ab2d325f92ebe3acbd6ca18b1#efa66e3a1d61459ab2d325f92ebe3acbd6ca18b1"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,7 +3555,7 @@ dependencies = [
  "schemars 1.0.4",
  "serde",
  "serde_derive",
- "serde_json 1.0.143",
+ "serde_json",
  "serde_with_macros",
  "time",
 ]
@@ -3919,7 +3919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
 ]
 
 [[package]]
@@ -4135,7 +4135,7 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -4203,7 +4203,7 @@ dependencies = [
  "schemars 0.8.22",
  "semver",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
  "syn 2.0.117",
  "thiserror 2.0.16",
  "unicode-ident",
@@ -4220,7 +4220,7 @@ dependencies = [
  "schemars 0.8.22",
  "semver",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
  "serde_tokenstream",
  "syn 2.0.117",
  "typify-impl",
@@ -4792,7 +4792,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "serde_json 1.0.143",
+ "serde_json",
  "tokio",
 ]
 

--- a/serde_json/Cargo.lock
+++ b/serde_json/Cargo.lock
@@ -3,48 +3,60 @@
 version = 4
 
 [[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "lingua_serde_json"
+name = "big_serde_json"
 version = "0.1.0"
 dependencies = [
- "serde_json",
+ "braintrust_serde_json",
  "ts-rs",
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.6"
+name = "braintrust_serde_json"
+version = "1.0.145"
+source = "git+https://github.com/braintrustdata/serde-json.git?rev=905b790b50e8922370f3e73ef93d7d5fb7010edc#905b790b50e8922370f3e73ef93d7d5fb7010edc"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"
@@ -76,22 +88,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.145"
-source = "git+https://github.com/ankrgyl/serde-json.git?rev=efa66e3a1d61459ab2d325f92ebe3acbd6ca18b1#efa66e3a1d61459ab2d325f92ebe3acbd6ca18b1"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -109,18 +109,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "winapi-util"

--- a/serde_json/Cargo.toml
+++ b/serde_json/Cargo.toml
@@ -6,10 +6,12 @@ rust-version = "1.95"
 description = "Wrapper for serde_json with arbitrary_precision feature"
 
 [dependencies]
-# This is a known issue with turning on `arbitrary_precision` (https://github.com/serde-rs/json/issues/1157)
-# If we use serde_json directly, Rust will deduplicate the package and force everything
-# (across crates) to use the same feature flags. So, we fork it and use the commit corresponding to:
-# v1.0.145
-# (https://github.com/serde-rs/json/commit/efa66e3a1d61459ab2d325f92ebe3acbd6ca18b1)
-serde_json = { package = "serde_json", git = "https://github.com/ankrgyl/serde-json.git", rev = "efa66e3a1d61459ab2d325f92ebe3acbd6ca18b1", features = ["arbitrary_precision"] }
+# This is a known issue with turning on `arbitrary_precision`
+# (https://github.com/serde-rs/json/issues/1157) If we use serde_json directly,
+# Rust will deduplicate the package and force everything (across crates) to use
+# the same feature flags. So, we fork it and use the commit corresponding to:
+# v1.0.145, with the fork package renamed so build systems can distinguish it
+# from the normal serde_json package while the Rust library crate remains named
+# serde_json.
+serde_json = { package = "braintrust_serde_json", git = "https://github.com/braintrustdata/serde-json.git", rev = "905b790b50e8922370f3e73ef93d7d5fb7010edc", features = ["arbitrary_precision"] }
 ts-rs = { version = "11.0", features = ["serde-compat"] }


### PR DESCRIPTION
This lets build systems treat it as a separate package which has the same internal crates as serde_json, so they can be resolved separately but still share type/trait definitions.