### PR TITLE
accept openai legacy prompts

### DIFF
--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -934,6 +934,24 @@ mod tests {
 
     #[test]
     #[cfg(feature = "openai")]
+    fn test_transform_request_legacy_prompt_chat_completions_rejects_completion_only_params() {
+        let payload = json!({
+            "model": "gpt-4o",
+            "prompt": "Write a haiku about the ocean.",
+            "suffix": "End with a title.",
+            "max_tokens": 256
+        });
+        let input = to_bytes(&payload);
+
+        let err = transform_request(input, ProviderFormat::ChatCompletions, None).unwrap_err();
+
+        assert!(
+            matches!(err, TransformError::ToUniversalFailed(reason) if reason.contains("suffix"))
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
     fn test_transform_request_preserves_suffix_messages_in_chat_rewrite() {
         let payload = json!({
             "model": "brain-facet-1",

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -970,6 +970,24 @@ mod tests {
 
     #[test]
     #[cfg(feature = "openai")]
+    fn test_transform_request_legacy_prompt_chat_completions_rejects_numeric_logprobs() {
+        let payload = json!({
+            "model": "gpt-4o",
+            "prompt": "Write a haiku about the ocean.",
+            "logprobs": 5,
+            "max_tokens": 256
+        });
+        let input = to_bytes(&payload);
+
+        let err = transform_request(input, ProviderFormat::ChatCompletions, None).unwrap_err();
+
+        assert!(
+            matches!(err, TransformError::ToUniversalFailed(reason) if reason.contains("logprobs"))
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
     fn test_transform_request_preserves_suffix_messages_in_chat_rewrite() {
         let payload = json!({
             "model": "brain-facet-1",

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -868,6 +868,72 @@ mod tests {
 
     #[test]
     #[cfg(feature = "openai")]
+    fn test_transform_request_responses_string_input_to_chat_completions() {
+        let payload = json!({
+            "model": "gpt-5-mini",
+            "input": "Write a haiku about the ocean.",
+            "max_output_tokens": 256,
+            "temperature": 0.7,
+            "stream": false
+        });
+        let input = to_bytes(&payload);
+
+        let result = transform_request(input, ProviderFormat::ChatCompletions, None).unwrap();
+
+        assert!(!result.is_passthrough());
+        assert_eq!(result.source_format(), Some(ProviderFormat::Responses));
+
+        let output: Value = crate::serde_json::from_slice(result.as_bytes()).unwrap();
+        assert_eq!(output.get("input"), None);
+        assert_eq!(
+            output.get("messages"),
+            Some(&json!([
+                { "role": "user", "content": "Write a haiku about the ocean." }
+            ]))
+        );
+        assert_eq!(
+            output.get("max_completion_tokens").and_then(Value::as_i64),
+            Some(256)
+        );
+        assert_eq!(output.get("temperature"), None);
+        assert_eq!(output.get("stream").and_then(Value::as_bool), Some(false));
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
+    fn test_transform_request_legacy_prompt_chat_completions_to_messages() {
+        let payload = json!({
+            "model": "gpt-4o",
+            "prompt": "Write a haiku about the ocean.",
+            "max_tokens": 256,
+            "temperature": 0.7,
+            "stream": false
+        });
+        let input = to_bytes(&payload);
+
+        let result = transform_request(input, ProviderFormat::ChatCompletions, None).unwrap();
+
+        assert!(!result.is_passthrough());
+        assert_eq!(
+            result.source_format(),
+            Some(ProviderFormat::ChatCompletions)
+        );
+
+        let output: Value = crate::serde_json::from_slice(result.as_bytes()).unwrap();
+        assert_eq!(output.get("prompt"), None);
+        assert_eq!(
+            output.get("messages"),
+            Some(&json!([
+                { "role": "user", "content": "Write a haiku about the ocean." }
+            ]))
+        );
+        assert_eq!(output.get("max_tokens").and_then(Value::as_i64), Some(256));
+        assert_eq!(output.get("temperature").and_then(Value::as_f64), Some(0.7));
+        assert_eq!(output.get("stream").and_then(Value::as_bool), Some(false));
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
     fn test_transform_request_preserves_suffix_messages_in_chat_rewrite() {
         let payload = json!({
             "model": "brain-facet-1",

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -952,6 +952,24 @@ mod tests {
 
     #[test]
     #[cfg(feature = "openai")]
+    fn test_transform_request_legacy_prompt_chat_completions_rejects_null_completion_only_params() {
+        let payload = json!({
+            "model": "gpt-4o",
+            "prompt": "Write a haiku about the ocean.",
+            "suffix": null,
+            "max_tokens": 256
+        });
+        let input = to_bytes(&payload);
+
+        let err = transform_request(input, ProviderFormat::ChatCompletions, None).unwrap_err();
+
+        assert!(
+            matches!(err, TransformError::ToUniversalFailed(reason) if reason.contains("suffix"))
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
     fn test_transform_request_preserves_suffix_messages_in_chat_rewrite() {
         let payload = json!({
             "model": "brain-facet-1",

--- a/crates/lingua/src/providers/openai/adapter.rs
+++ b/crates/lingua/src/providers/openai/adapter.rs
@@ -22,7 +22,8 @@ use crate::providers::openai::convert::{
 };
 use crate::providers::openai::generated::WebSearch;
 use crate::providers::openai::params::{
-    OpenAIChatExtrasView, OpenAIChatParams, OpenAICompletionPrompt, OpenAIReasoningEffort,
+    OpenAIChatExtrasView, OpenAIChatLegacyPromptParams, OpenAIChatParams, OpenAICompletionPrompt,
+    OpenAIReasoningEffort,
 };
 use crate::providers::openai::tool_parsing::parse_openai_chat_tools_array;
 use crate::providers::openai::{try_parse_openai, try_parse_openai_legacy_prompt};
@@ -122,6 +123,18 @@ fn reject_legacy_prompt_only_extras(
     Ok(())
 }
 
+fn reject_untyped_legacy_prompt_params(
+    params: &OpenAIChatLegacyPromptParams,
+) -> Result<(), TransformError> {
+    if params.logprobs.is_some() {
+        return Err(TransformError::ToUniversalFailed(
+            "OpenAI legacy prompt compatibility does not support legacy completions-only parameter 'logprobs'".to_string(),
+        ));
+    }
+
+    reject_legacy_prompt_only_extras(&params.extras)
+}
+
 #[derive(serde::Deserialize)]
 struct OpenAIChatMessagesView {
     messages: Option<Vec<ChatCompletionRequestMessageExt>>,
@@ -150,8 +163,18 @@ impl ProviderAdapter for OpenAIAdapter {
 
     fn request_to_universal(&self, payload: Value) -> Result<UniversalRequest, TransformError> {
         // Parse params (messages will be parsed separately to preserve reasoning field)
-        let typed_params: OpenAIChatParams = serde_json::from_value(payload.clone())
-            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+        let typed_params: OpenAIChatParams = match serde_json::from_value(payload.clone()) {
+            Ok(params) => params,
+            Err(err) => {
+                let legacy_params: OpenAIChatLegacyPromptParams =
+                    serde_json::from_value(payload.clone())
+                        .map_err(|_| TransformError::ToUniversalFailed(err.to_string()))?;
+                if legacy_params.is_legacy_prompt_request() {
+                    reject_untyped_legacy_prompt_params(&legacy_params)?;
+                }
+                return Err(TransformError::ToUniversalFailed(err.to_string()));
+            }
+        };
 
         let messages_view: OpenAIChatMessagesView = serde_json::from_value(payload)
             .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;

--- a/crates/lingua/src/providers/openai/adapter.rs
+++ b/crates/lingua/src/providers/openai/adapter.rs
@@ -38,6 +38,7 @@ use crate::universal::{
     parse_stop_sequences, UniversalParams, UniversalRequest, UniversalResponse,
     UniversalStreamChoice, UniversalStreamChunk, UniversalUsage, PLACEHOLDER_MODEL,
 };
+use serde::{de::IgnoredAny, Deserialize};
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 
@@ -71,22 +72,33 @@ fn legacy_prompt_to_user_content(
     }
 }
 
+fn deserialize_present<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    IgnoredAny::deserialize(deserializer)?;
+    Ok(true)
+}
+
 #[derive(Default, serde::Deserialize)]
 struct OpenAICompletionLegacyOnlyExtras {
-    suffix: Option<Value>,
-    best_of: Option<Value>,
-    echo: Option<Value>,
+    #[serde(default, deserialize_with = "deserialize_present")]
+    suffix: bool,
+    #[serde(default, deserialize_with = "deserialize_present")]
+    best_of: bool,
+    #[serde(default, deserialize_with = "deserialize_present")]
+    echo: bool,
 }
 
 impl OpenAICompletionLegacyOnlyExtras {
     fn unsupported_field(&self) -> Option<&'static str> {
-        if self.suffix.is_some() {
+        if self.suffix {
             return Some("suffix");
         }
-        if self.best_of.is_some() {
+        if self.best_of {
             return Some("best_of");
         }
-        if self.echo.is_some() {
+        if self.echo {
             return Some("echo");
         }
         None

--- a/crates/lingua/src/providers/openai/adapter.rs
+++ b/crates/lingua/src/providers/openai/adapter.rs
@@ -22,13 +22,13 @@ use crate::providers::openai::convert::{
 };
 use crate::providers::openai::generated::WebSearch;
 use crate::providers::openai::params::{
-    OpenAIChatExtrasView, OpenAIChatParams, OpenAIReasoningEffort,
+    OpenAIChatExtrasView, OpenAIChatParams, OpenAICompletionPrompt, OpenAIReasoningEffort,
 };
 use crate::providers::openai::tool_parsing::parse_openai_chat_tools_array;
-use crate::providers::openai::try_parse_openai;
+use crate::providers::openai::{try_parse_openai, try_parse_openai_legacy_prompt};
 use crate::serde_json::{self, Map, Value};
 use crate::universal::convert::TryFromLLM;
-use crate::universal::message::Message;
+use crate::universal::message::{Message, UserContent};
 use crate::universal::reasoning::effort_to_budget;
 use crate::universal::request::{
     ReasoningConfig, ReasoningEffort, TokenBudget, UniversalMetadataUserView,
@@ -57,6 +57,24 @@ fn parse_openai_chat_extras(
         .map(|v: Option<OpenAIChatExtrasView>| v.unwrap_or_default())
 }
 
+fn legacy_prompt_to_user_content(
+    prompt: OpenAICompletionPrompt,
+) -> Result<UserContent, TransformError> {
+    match prompt {
+        OpenAICompletionPrompt::String(content) => Ok(UserContent::String(content)),
+        OpenAICompletionPrompt::StringArray(_)
+        | OpenAICompletionPrompt::TokenArray(_)
+        | OpenAICompletionPrompt::TokenArrayArray(_) => Err(TransformError::ToUniversalFailed(
+            "OpenAI legacy prompt compatibility only supports a single string prompt for Chat Completions".to_string(),
+        )),
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct OpenAIChatMessagesView {
+    messages: Option<Vec<ChatCompletionRequestMessageExt>>,
+}
+
 impl ProviderAdapter for OpenAIAdapter {
     fn format(&self) -> ProviderFormat {
         ProviderFormat::ChatCompletions
@@ -71,6 +89,10 @@ impl ProviderAdapter for OpenAIAdapter {
     }
 
     fn detect_request(&self, payload: &Value) -> bool {
+        try_parse_openai(payload).is_ok() || try_parse_openai_legacy_prompt(payload).is_ok()
+    }
+
+    fn detect_passthrough_request(&self, payload: &Value) -> bool {
         try_parse_openai(payload).is_ok()
     }
 
@@ -79,27 +101,20 @@ impl ProviderAdapter for OpenAIAdapter {
         let typed_params: OpenAIChatParams = serde_json::from_value(payload.clone())
             .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
 
-        // Extract and parse messages as extended type to capture reasoning field
-        let messages_val = payload
-            .get("messages")
-            .ok_or_else(|| {
-                TransformError::ToUniversalFailed("OpenAI: missing 'messages' field".to_string())
-            })?
-            .as_array()
-            .ok_or_else(|| {
-                TransformError::ToUniversalFailed("OpenAI: 'messages' must be an array".to_string())
-            })?;
-
-        let provider_messages: Vec<ChatCompletionRequestMessageExt> = messages_val
-            .iter()
-            .map(|msg_val| {
-                serde_json::from_value(msg_val.clone())
-                    .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let messages = <Vec<Message> as TryFromLLM<Vec<_>>>::try_from(provider_messages)
+        let messages_view: OpenAIChatMessagesView = serde_json::from_value(payload)
             .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+        let messages = if let Some(provider_messages) = messages_view.messages {
+            <Vec<Message> as TryFromLLM<Vec<_>>>::try_from(provider_messages)
+                .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?
+        } else if let Some(prompt) = typed_params.prompt.clone() {
+            vec![Message::User {
+                content: legacy_prompt_to_user_content(prompt)?,
+            }]
+        } else {
+            return Err(TransformError::ToUniversalFailed(
+                "OpenAI: missing 'messages' field".to_string(),
+            ));
+        };
 
         // Extract max_tokens first - needed for reasoning budget computation
         let max_tokens = typed_params

--- a/crates/lingua/src/providers/openai/adapter.rs
+++ b/crates/lingua/src/providers/openai/adapter.rs
@@ -38,6 +38,7 @@ use crate::universal::{
     parse_stop_sequences, UniversalParams, UniversalRequest, UniversalResponse,
     UniversalStreamChoice, UniversalStreamChunk, UniversalUsage, PLACEHOLDER_MODEL,
 };
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 
 const OPENAI_CHAT_MIN_MAX_COMPLETION_TOKENS: i64 = 16;
@@ -68,6 +69,45 @@ fn legacy_prompt_to_user_content(
             "OpenAI legacy prompt compatibility only supports a single string prompt for Chat Completions".to_string(),
         )),
     }
+}
+
+#[derive(Default, serde::Deserialize)]
+struct OpenAICompletionLegacyOnlyExtras {
+    suffix: Option<Value>,
+    best_of: Option<Value>,
+    echo: Option<Value>,
+}
+
+impl OpenAICompletionLegacyOnlyExtras {
+    fn unsupported_field(&self) -> Option<&'static str> {
+        if self.suffix.is_some() {
+            return Some("suffix");
+        }
+        if self.best_of.is_some() {
+            return Some("best_of");
+        }
+        if self.echo.is_some() {
+            return Some("echo");
+        }
+        None
+    }
+}
+
+fn reject_legacy_prompt_only_extras(
+    extras: &BTreeMap<String, Value>,
+) -> Result<(), TransformError> {
+    let legacy_extras: OpenAICompletionLegacyOnlyExtras =
+        serde_json::from_value(Value::Object(extras.clone().into_iter().collect()))
+            .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
+
+    if let Some(field) = legacy_extras.unsupported_field() {
+        return Err(TransformError::ToUniversalFailed(format!(
+            "OpenAI legacy prompt compatibility does not support legacy completions-only parameter '{}'",
+            field
+        )));
+    }
+
+    Ok(())
 }
 
 #[derive(serde::Deserialize)]
@@ -107,6 +147,7 @@ impl ProviderAdapter for OpenAIAdapter {
             <Vec<Message> as TryFromLLM<Vec<_>>>::try_from(provider_messages)
                 .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?
         } else if let Some(prompt) = typed_params.prompt.clone() {
+            reject_legacy_prompt_only_extras(&typed_params.extras)?;
             vec![Message::User {
                 content: legacy_prompt_to_user_content(prompt)?,
             }]

--- a/crates/lingua/src/providers/openai/detect.rs
+++ b/crates/lingua/src/providers/openai/detect.rs
@@ -7,6 +7,7 @@ the OpenAI struct types.
 */
 
 use crate::providers::openai::generated::{CreateChatCompletionRequestClass, CreateResponseClass};
+use crate::providers::openai::params::OpenAIChatParams;
 use crate::serde_json::{self, Value};
 use thiserror::Error;
 
@@ -40,6 +41,19 @@ pub fn try_parse_openai(
 ) -> Result<CreateChatCompletionRequestClass, DetectionError> {
     serde_json::from_value(payload.clone())
         .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))
+}
+
+pub fn try_parse_openai_legacy_prompt(payload: &Value) -> Result<OpenAIChatParams, DetectionError> {
+    let params: OpenAIChatParams = serde_json::from_value(payload.clone())
+        .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))?;
+
+    if params.model.is_some() && params.messages.is_none() && params.prompt.is_some() {
+        return Ok(params);
+    }
+
+    Err(DetectionError::DeserializationFailed(
+        "Not a legacy prompt payload: requires model and prompt without messages".to_string(),
+    ))
 }
 
 /// Attempt to parse a JSON Value as OpenAI Responses API CreateResponseClass.

--- a/crates/lingua/src/providers/openai/detect.rs
+++ b/crates/lingua/src/providers/openai/detect.rs
@@ -7,7 +7,7 @@ the OpenAI struct types.
 */
 
 use crate::providers::openai::generated::{CreateChatCompletionRequestClass, CreateResponseClass};
-use crate::providers::openai::params::OpenAIChatParams;
+use crate::providers::openai::params::OpenAIChatLegacyPromptParams;
 use crate::serde_json::{self, Value};
 use thiserror::Error;
 
@@ -43,11 +43,13 @@ pub fn try_parse_openai(
         .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))
 }
 
-pub fn try_parse_openai_legacy_prompt(payload: &Value) -> Result<OpenAIChatParams, DetectionError> {
-    let params: OpenAIChatParams = serde_json::from_value(payload.clone())
+pub fn try_parse_openai_legacy_prompt(
+    payload: &Value,
+) -> Result<OpenAIChatLegacyPromptParams, DetectionError> {
+    let params: OpenAIChatLegacyPromptParams = serde_json::from_value(payload.clone())
         .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))?;
 
-    if params.model.is_some() && params.messages.is_none() && params.prompt.is_some() {
+    if params.is_legacy_prompt_request() {
         return Ok(params);
     }
 

--- a/crates/lingua/src/providers/openai/mod.rs
+++ b/crates/lingua/src/providers/openai/mod.rs
@@ -26,7 +26,9 @@ pub mod test_responses;
 pub mod test_chat_completions;
 
 // Re-export detection functions
-pub use detect::{try_parse_openai, try_parse_responses, DetectionError};
+pub use detect::{
+    try_parse_openai, try_parse_openai_legacy_prompt, try_parse_responses, DetectionError,
+};
 
 // Re-export capability functions
 pub use capabilities::model_needs_transforms;

--- a/crates/lingua/src/providers/openai/params.rs
+++ b/crates/lingua/src/providers/openai/params.rs
@@ -19,6 +19,7 @@ pub struct OpenAIChatParams {
     // === Core fields ===
     pub model: Option<String>,
     pub messages: Option<Vec<ChatCompletionRequestMessage>>,
+    pub prompt: Option<OpenAICompletionPrompt>,
 
     // === Sampling parameters ===
     pub temperature: Option<f64>,
@@ -145,6 +146,15 @@ pub struct OpenAIChatExtrasView {
     pub max_tokens: Option<Value>,
     pub max_completion_tokens: Option<Value>,
     pub web_search_options: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum OpenAICompletionPrompt {
+    String(String),
+    StringArray(Vec<String>),
+    TokenArray(Vec<i64>),
+    TokenArrayArray(Vec<Vec<i64>>),
 }
 
 /// Typed view over `UniversalParams.extras[Responses]` used during universal

--- a/crates/lingua/src/providers/openai/params.rs
+++ b/crates/lingua/src/providers/openai/params.rs
@@ -77,6 +77,23 @@ pub struct OpenAIChatParams {
     pub extras: BTreeMap<String, Value>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OpenAIChatLegacyPromptParams {
+    pub model: Option<String>,
+    pub messages: Option<Value>,
+    pub prompt: Option<OpenAICompletionPrompt>,
+    pub logprobs: Option<Value>,
+
+    #[serde(flatten)]
+    pub extras: BTreeMap<String, Value>,
+}
+
+impl OpenAIChatLegacyPromptParams {
+    pub fn is_legacy_prompt_request(&self) -> bool {
+        self.model.is_some() && self.messages.is_none() && self.prompt.is_some()
+    }
+}
+
 /// OpenAI Responses API request parameters.
 ///
 /// The Responses API has different field names and structure than Chat Completions.


### PR DESCRIPTION
Legacy prompt compatibility now detects valid completions-era prompt shapes even when they contain parameters whose types differ from Chat Completions, and rejects unsupported options like numeric logprobs with a clear compatibility error.

## Test

```bash
curl -sS -i https://api.braintrust.dev/v1/proxy/chat/completions \

  -H "Authorization: Bearer $BRAINTRUST_API_KEY" \

  -H "Content-Type: application/json" \

  -d '{

    "model": "gpt-4o",

    "prompt": "Write a haiku about the ocean.",

    "max_tokens": 256,

    "temperature": 0.7,

    "stream": false

  }'
```