### PR TITLE
Preserve mixed Anthropic tool results in cross-provider transforms

### DIFF
--- a/bindings/python/tests/test_roundtrip.py
+++ b/bindings/python/tests/test_roundtrip.py
@@ -283,31 +283,25 @@ class TestRoundtrip:
 
                 test_name = f"{test_case}/{snapshot.provider}/{snapshot.turn}"
 
-                for i, original_message in enumerate(messages):
-                    try:
-                        # Perform the roundtrip
-                        result = perform_anthropic_roundtrip(original_message)
+                try:
+                    lingua_messages = anthropic_messages_to_lingua(messages)
+                    roundtripped = lingua_to_anthropic_messages(lingua_messages)
 
-                        # Verify Lingua conversion worked
-                        assert result["lingua"] is not None
-                        assert "role" in result["lingua"]
+                    assert lingua_messages
+                    assert "role" in lingua_messages[0]
 
-                        # Normalize both objects
-                        normalized_original = normalize_for_comparison(original_message)
-                        normalized_roundtripped = normalize_for_comparison(
-                            result["roundtripped"]
-                        )
+                    normalized_original = normalize_for_comparison(messages)
+                    normalized_roundtripped = normalize_for_comparison(roundtripped)
 
-                        # The normalized objects should be equal
-                        assert normalized_roundtripped == normalized_original, (
-                            f"Roundtrip mismatch in {test_name} message {i}:\n"
-                            f"Original: {json.dumps(normalized_original, indent=2)}\n"
-                            f"Roundtripped: {json.dumps(normalized_roundtripped, indent=2)}"
-                        )
+                    assert normalized_roundtripped == normalized_original, (
+                        f"Roundtrip mismatch in {test_name}:\n"
+                        f"Original: {json.dumps(normalized_original, indent=2)}\n"
+                        f"Roundtripped: {json.dumps(normalized_roundtripped, indent=2)}"
+                    )
 
-                    except ConversionError as e:
-                        # Skip unsupported message formats for now
-                        print(f"Skipping unsupported format in {test_name}: {e}")
+                except ConversionError as e:
+                    # Skip unsupported message formats for now
+                    print(f"Skipping unsupported format in {test_name}: {e}")
 
     def test_coverage(self, test_cases):
         """Display test coverage information"""

--- a/bindings/typescript/tests/roundtrip.test.ts
+++ b/bindings/typescript/tests/roundtrip.test.ts
@@ -206,32 +206,24 @@ describe("TypeScript Roundtrip Tests", () => {
             ) {
               const messages = (snapshot.request as { messages: unknown }).messages;
               if (Array.isArray(messages) && messages.length > 0) {
-              // Test each message in the request
-              for (const originalMessage of messages) {
                 try {
-                  // Perform the roundtrip: Anthropic -> Lingua -> Anthropic
-                  const result = testAnthropicRoundtrip(originalMessage);
+                  const lingua = anthropicMessagesToLingua(messages);
+                  const roundtripped = linguaToAnthropicMessages(lingua);
 
-                  // Verify the roundtrip preserved the data
-                  expect(result.lingua).toBeDefined();
-                  expect(result.lingua.role).toBeDefined();
+                  expect(lingua.length).toBeGreaterThan(0);
+                  expect(lingua[0].role).toBeDefined();
 
-                  // First check for type consistency (e.g., Map vs Object)
-                  const typeError = checkTypeConsistency(originalMessage, result.roundtripped);
+                  const typeError = checkTypeConsistency(messages, roundtripped);
                   if (typeError) {
                     throw new Error(`Type consistency check failed: ${typeError}`);
                   }
 
-                  // Then normalize both objects to remove null/undefined/empty arrays
-                  // This matches how Rust's serde skips None values
-                  const normalizedOriginal = normalizeForComparison(originalMessage);
-                  const normalizedRoundtripped = normalizeForComparison(result.roundtripped);
+                  const normalizedOriginal = normalizeForComparison(messages);
+                  const normalizedRoundtripped = normalizeForComparison(roundtripped);
 
-                  // The normalized objects should be equal
                   expect(normalizedRoundtripped).toEqual(normalizedOriginal);
                 } catch (error) {
                   if (error instanceof ConversionError) {
-                    // Skip unsupported message formats for now
                     console.log(
                       `Skipping unsupported format in ${testName}:`,
                       error.message,
@@ -240,7 +232,6 @@ describe("TypeScript Roundtrip Tests", () => {
                     throw error;
                   }
                 }
-              }
               }
             }
           });
@@ -419,24 +410,6 @@ function testChatCompletionsRoundtrip(chatCompletionsMessage: unknown): {
   };
 }
 
-/**
- * Test roundtrip conversion: Provider -> Lingua -> Provider
- * @throws {ConversionError} If any conversion step fails
- */
-function testAnthropicRoundtrip(anthropicMessage: unknown): {
-  original: unknown;
-  lingua: LinguaMessage;
-  roundtripped: unknown;
-} {
-  const lingua = anthropicMessagesToLingua([anthropicMessage])[0];
-  const roundtripped = linguaToAnthropicMessages([lingua])[0];
-
-  return {
-    original: anthropicMessage,
-    lingua,
-    roundtripped
-  };
-}
 
 describe("Generated Types", () => {
     test("Module exports are available", async () => {

--- a/crates/lingua/build.rs
+++ b/crates/lingua/build.rs
@@ -14,6 +14,8 @@ fn workspace_root() -> PathBuf {
 
 fn main() {
     let workspace = workspace_root();
+    let target = env::var("TARGET").unwrap_or_default();
+    let generate_snapshot_tests = target != "wasm32-unknown-unknown";
 
     // Create TypeScript bindings directory structure
     let bindings_dir = workspace.join("bindings/typescript/src/generated");
@@ -30,23 +32,32 @@ fn main() {
     println!("cargo:rerun-if-changed=src/universal/");
 
     // Generate test cases from payloads directory
-    generate_test_cases(&workspace);
-    generate_chat_completions_test_cases(&workspace);
-    generate_anthropic_test_cases(&workspace);
-    generate_google_test_cases(&workspace);
+    generate_test_cases(&workspace, generate_snapshot_tests);
+    generate_chat_completions_test_cases(&workspace, generate_snapshot_tests);
+    generate_anthropic_test_cases(&workspace, generate_snapshot_tests);
+    generate_google_test_cases(&workspace, generate_snapshot_tests);
 }
 
 const RESPONSES_ROUNDTRIP_SKIP_CASES: &[&str] =
     &["responsesFunctionCallOutputWithoutThoughtSignatureParam"];
 
-fn generate_test_cases(workspace: &Path) {
+fn generate_test_cases(workspace: &Path, generate_snapshot_tests: bool) {
     let snapshots_dir = workspace.join("payloads/snapshots");
-
-    // Tell cargo to re-run if the snapshots directory changes
-    println!("cargo:rerun-if-changed={}", snapshots_dir.display());
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("generated_tests.rs");
+
+    if !generate_snapshot_tests {
+        fs::write(
+            &dest_path,
+            "// Snapshot-generated tests are disabled for this target",
+        )
+        .unwrap();
+        return;
+    }
+
+    // Tell cargo to re-run if the snapshots directory changes
+    println!("cargo:rerun-if-changed={}", snapshots_dir.display());
 
     if !snapshots_dir.exists() {
         // Create empty generated tests file if no snapshots directory
@@ -122,14 +133,23 @@ fn {test_fn_name}() {{
     fs::write(&dest_path, generated_tests).unwrap();
 }
 
-fn generate_chat_completions_test_cases(workspace: &Path) {
+fn generate_chat_completions_test_cases(workspace: &Path, generate_snapshot_tests: bool) {
     let snapshots_dir = workspace.join("payloads/snapshots");
-
-    // Tell cargo to re-run if the snapshots directory changes
-    println!("cargo:rerun-if-changed={}", snapshots_dir.display());
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("generated_chat_completions_tests.rs");
+
+    if !generate_snapshot_tests {
+        fs::write(
+            &dest_path,
+            "// Snapshot-generated tests are disabled for this target",
+        )
+        .unwrap();
+        return;
+    }
+
+    // Tell cargo to re-run if the snapshots directory changes
+    println!("cargo:rerun-if-changed={}", snapshots_dir.display());
 
     if !snapshots_dir.exists() {
         // Create empty generated tests file if no snapshots directory
@@ -203,14 +223,23 @@ fn {test_fn_name}() {{
     fs::write(&dest_path, generated_tests).unwrap();
 }
 
-fn generate_anthropic_test_cases(workspace: &Path) {
+fn generate_anthropic_test_cases(workspace: &Path, generate_snapshot_tests: bool) {
     let snapshots_dir = workspace.join("payloads/snapshots");
-
-    // Tell cargo to re-run if the snapshots directory changes
-    println!("cargo:rerun-if-changed={}", snapshots_dir.display());
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("generated_anthropic_tests.rs");
+
+    if !generate_snapshot_tests {
+        fs::write(
+            &dest_path,
+            "// Snapshot-generated tests are disabled for this target",
+        )
+        .unwrap();
+        return;
+    }
+
+    // Tell cargo to re-run if the snapshots directory changes
+    println!("cargo:rerun-if-changed={}", snapshots_dir.display());
 
     if !snapshots_dir.exists() {
         // Create empty generated tests file if no snapshots directory
@@ -283,14 +312,23 @@ fn {test_fn_name}() {{
     fs::write(&dest_path, generated_tests).unwrap();
 }
 
-fn generate_google_test_cases(workspace: &Path) {
+fn generate_google_test_cases(workspace: &Path, generate_snapshot_tests: bool) {
     let snapshots_dir = workspace.join("payloads/snapshots");
-
-    // Tell cargo to re-run if the snapshots directory changes
-    println!("cargo:rerun-if-changed={}", snapshots_dir.display());
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("generated_google_tests.rs");
+
+    if !generate_snapshot_tests {
+        fs::write(
+            &dest_path,
+            "// Snapshot-generated tests are disabled for this target",
+        )
+        .unwrap();
+        return;
+    }
+
+    // Tell cargo to re-run if the snapshots directory changes
+    println!("cargo:rerun-if-changed={}", snapshots_dir.display());
 
     if !snapshots_dir.exists() {
         // Create empty generated tests file if no snapshots directory

--- a/crates/lingua/src/import_parse.rs
+++ b/crates/lingua/src/import_parse.rs
@@ -42,15 +42,6 @@ where
     non_empty_messages(messages)
 }
 
-pub(crate) fn try_parse_and_convert<T>(data: &Value) -> Option<Vec<Message>>
-where
-    T: DeserializeOwned,
-    Vec<Message>: TryFromLLM<T>,
-{
-    let value = try_parse::<T>(data)?;
-    try_convert_non_empty(value)
-}
-
 pub(crate) fn try_parse_vec_or_single<T>(data: &Value) -> Option<Vec<T>>
 where
     T: DeserializeOwned,

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -15,7 +15,9 @@ use crate::processing::adapters::{
 };
 use crate::processing::transform::TransformError;
 use crate::providers::anthropic::capabilities;
-use crate::providers::anthropic::convert::system_to_user_content;
+use crate::providers::anthropic::convert::{
+    anthropic_input_messages_to_universal_messages, system_to_user_content,
+};
 use crate::providers::anthropic::detect::{
     system_messages_are_supported_and_well_placed, try_parse_anthropic_source,
 };
@@ -215,7 +217,7 @@ impl ProviderAdapter for AnthropicAdapter {
             TransformError::ToUniversalFailed("Anthropic: missing 'messages' field".to_string())
         })?;
 
-        let mut messages = <Vec<Message> as TryFromLLM<Vec<_>>>::try_from(input_messages)
+        let mut messages = anthropic_input_messages_to_universal_messages(input_messages)
             .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
 
         if let Some(system) = typed_params.system.clone() {

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -17,13 +17,14 @@ use crate::processing::transform::TransformError;
 use crate::providers::anthropic::capabilities;
 use crate::providers::anthropic::convert::{
     anthropic_input_messages_to_universal_messages, system_to_user_content,
+    universal_messages_to_anthropic_input_messages,
 };
 use crate::providers::anthropic::detect::{
     system_messages_are_supported_and_well_placed, try_parse_anthropic_source,
 };
 use crate::providers::anthropic::generated::{
-    ContentBlock, EffortLevel, InputMessage, OutputConfig, Thinking, ThinkingType, Tool,
-    ToolChoice, ToolChoiceType,
+    ContentBlock, EffortLevel, OutputConfig, Thinking, ThinkingType, Tool, ToolChoice,
+    ToolChoiceType,
 };
 use crate::providers::anthropic::params::{AnthropicExtrasView, AnthropicParams};
 use crate::providers::anthropic::try_parse_anthropic;
@@ -354,9 +355,8 @@ impl ProviderAdapter for AnthropicAdapter {
                     });
                 }
                 validate_no_non_leading_system_messages(&msgs)?;
-                let anthropic_messages: Vec<InputMessage> =
-                    <Vec<InputMessage> as TryFromLLM<Vec<Message>>>::try_from(msgs)
-                        .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+                let anthropic_messages = universal_messages_to_anthropic_input_messages(msgs)
+                    .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
                 obj.insert(
                     "messages".into(),
                     serde_json::to_value(anthropic_messages)
@@ -377,9 +377,8 @@ impl ProviderAdapter for AnthropicAdapter {
             }
             validate_no_non_leading_system_messages(&msgs)?;
             // Convert remaining messages
-            let anthropic_messages: Vec<InputMessage> =
-                <Vec<InputMessage> as TryFromLLM<Vec<Message>>>::try_from(msgs)
-                    .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
+            let anthropic_messages = universal_messages_to_anthropic_input_messages(msgs)
+                .map_err(|e| TransformError::FromUniversalFailed(e.to_string()))?;
             obj.insert(
                 "messages".into(),
                 serde_json::to_value(anthropic_messages)

--- a/crates/lingua/src/providers/anthropic/convert.rs
+++ b/crates/lingua/src/providers/anthropic/convert.rs
@@ -1302,24 +1302,6 @@ fn mixed_user_tool_result_groups(
     Some(groups)
 }
 
-fn input_message_content_contains_tool_result(content: &generated::MessageContent) -> bool {
-    match content {
-        generated::MessageContent::String(_) => false,
-        generated::MessageContent::InputContentBlockArray(blocks) => {
-            blocks.iter().any(input_content_block_is_tool_result)
-        }
-    }
-}
-
-fn input_message_content_contains_non_tool_result(content: &generated::MessageContent) -> bool {
-    match content {
-        generated::MessageContent::String(_) => true,
-        generated::MessageContent::InputContentBlockArray(blocks) => blocks
-            .iter()
-            .any(|block| !input_content_block_is_tool_result(block)),
-    }
-}
-
 fn text_input_content_block(text: String) -> generated::InputContentBlock {
     generated::InputContentBlock {
         cache_control: None,
@@ -1361,15 +1343,41 @@ fn try_merge_adjacent_user_tool_result_message(
         return Ok(Some(current));
     }
 
-    let previous_has_tool_result = input_message_content_contains_tool_result(&previous.content);
-    let current_has_tool_result = input_message_content_contains_tool_result(&current.content);
-    let previous_has_non_tool_result =
-        input_message_content_contains_non_tool_result(&previous.content);
-    let current_has_non_tool_result =
-        input_message_content_contains_non_tool_result(&current.content);
+    let previous_is_pure_tool_result = match &previous.content {
+        generated::MessageContent::String(_) => false,
+        generated::MessageContent::InputContentBlockArray(blocks) => {
+            !blocks.is_empty() && blocks.iter().all(input_content_block_is_tool_result)
+        }
+    };
+    let current_is_pure_tool_result = match &current.content {
+        generated::MessageContent::String(_) => false,
+        generated::MessageContent::InputContentBlockArray(blocks) => {
+            !blocks.is_empty() && blocks.iter().all(input_content_block_is_tool_result)
+        }
+    };
+    let previous_is_pure_non_tool_result = match &previous.content {
+        generated::MessageContent::String(_) => true,
+        generated::MessageContent::InputContentBlockArray(blocks) => {
+            !blocks.is_empty()
+                && blocks
+                    .iter()
+                    .all(|block| !input_content_block_is_tool_result(block))
+        }
+    };
+    let current_is_pure_non_tool_result = match &current.content {
+        generated::MessageContent::String(_) => true,
+        generated::MessageContent::InputContentBlockArray(blocks) => {
+            !blocks.is_empty()
+                && blocks
+                    .iter()
+                    .all(|block| !input_content_block_is_tool_result(block))
+        }
+    };
 
-    if !(previous_has_tool_result && current_has_non_tool_result
-        || current_has_tool_result && previous_has_non_tool_result)
+    // Only rejoin a pure tool-result segment with its adjacent pure user-content
+    // segment. Once merged, the mixed message must not absorb later user turns.
+    if !(previous_is_pure_tool_result && current_is_pure_non_tool_result
+        || current_is_pure_tool_result && previous_is_pure_non_tool_result)
     {
         return Ok(Some(current));
     }
@@ -2221,6 +2229,51 @@ mod tests {
         assert_eq!(text_from_user(&messages[0]), "Before");
         assert_eq!(tool_call_id_from_tool(&messages[1]), "call_repro_123");
         assert_eq!(text_from_user(&messages[2]), "After");
+    }
+
+    #[test]
+    fn universal_messages_to_anthropic_input_messages_does_not_absorb_later_user_turns() {
+        let messages = vec![
+            Message::Tool {
+                content: vec![ToolContentPart::ToolResult(ToolResultContentPart {
+                    tool_call_id: "call_repro_123".to_string(),
+                    tool_name: String::new(),
+                    output: json!({"records": [{"id": "record_1", "status": "ok"}]}),
+                    provider_options: None,
+                })],
+            },
+            Message::User {
+                content: UserContent::String("first".to_string()),
+            },
+            Message::User {
+                content: UserContent::String("second".to_string()),
+            },
+        ];
+
+        let input_messages = universal_messages_to_anthropic_input_messages(messages)
+            .expect("conversion should succeed");
+
+        assert_eq!(input_messages.len(), 2);
+        match &input_messages[0].content {
+            generated::MessageContent::InputContentBlockArray(blocks) => {
+                assert_eq!(blocks.len(), 2);
+                assert_eq!(
+                    blocks[0].input_content_block_type,
+                    generated::InputContentBlockType::ToolResult
+                );
+                assert_eq!(
+                    blocks[1].input_content_block_type,
+                    generated::InputContentBlockType::Text
+                );
+                assert_eq!(blocks[1].text.as_deref(), Some("first"));
+            }
+            other => panic!("expected mixed content blocks, got {other:?}"),
+        }
+        assert_eq!(input_messages[1].role, generated::MessageRole::User);
+        match &input_messages[1].content {
+            generated::MessageContent::String(text) => assert_eq!(text, "second"),
+            other => panic!("expected second user turn to remain separate, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/lingua/src/providers/anthropic/convert.rs
+++ b/crates/lingua/src/providers/anthropic/convert.rs
@@ -1302,9 +1302,95 @@ fn mixed_user_tool_result_groups(
     Some(groups)
 }
 
+fn input_message_content_contains_tool_result(content: &generated::MessageContent) -> bool {
+    match content {
+        generated::MessageContent::String(_) => false,
+        generated::MessageContent::InputContentBlockArray(blocks) => {
+            blocks.iter().any(input_content_block_is_tool_result)
+        }
+    }
+}
+
+fn input_message_content_contains_non_tool_result(content: &generated::MessageContent) -> bool {
+    match content {
+        generated::MessageContent::String(_) => true,
+        generated::MessageContent::InputContentBlockArray(blocks) => blocks
+            .iter()
+            .any(|block| !input_content_block_is_tool_result(block)),
+    }
+}
+
+fn text_input_content_block(text: String) -> generated::InputContentBlock {
+    generated::InputContentBlock {
+        cache_control: None,
+        citations: None,
+        text: Some(text),
+        input_content_block_type: generated::InputContentBlockType::Text,
+        source: None,
+        context: None,
+        title: None,
+        content: None,
+        signature: None,
+        thinking: None,
+        data: None,
+        caller: None,
+        id: None,
+        input: None,
+        name: None,
+        is_error: None,
+        tool_use_id: None,
+        file_id: None,
+    }
+}
+
+fn input_message_content_blocks(
+    content: generated::MessageContent,
+) -> Vec<generated::InputContentBlock> {
+    match content {
+        generated::MessageContent::String(text) => vec![text_input_content_block(text)],
+        generated::MessageContent::InputContentBlockArray(blocks) => blocks,
+    }
+}
+
+fn try_merge_adjacent_user_tool_result_message(
+    previous: &mut generated::InputMessage,
+    current: generated::InputMessage,
+) -> Result<Option<generated::InputMessage>, ConvertError> {
+    if previous.role != generated::MessageRole::User || current.role != generated::MessageRole::User
+    {
+        return Ok(Some(current));
+    }
+
+    let previous_has_tool_result = input_message_content_contains_tool_result(&previous.content);
+    let current_has_tool_result = input_message_content_contains_tool_result(&current.content);
+    let previous_has_non_tool_result =
+        input_message_content_contains_non_tool_result(&previous.content);
+    let current_has_non_tool_result =
+        input_message_content_contains_non_tool_result(&current.content);
+
+    if !(previous_has_tool_result && current_has_non_tool_result
+        || current_has_tool_result && previous_has_non_tool_result)
+    {
+        return Ok(Some(current));
+    }
+
+    let previous_content = std::mem::replace(
+        &mut previous.content,
+        generated::MessageContent::String(String::new()),
+    );
+    let mut blocks = input_message_content_blocks(previous_content);
+    blocks.extend(input_message_content_blocks(current.content));
+    previous.content = generated::MessageContent::InputContentBlockArray(blocks);
+    Ok(None)
+}
+
 pub(crate) fn anthropic_input_messages_to_universal_messages(
     input_messages: Vec<generated::InputMessage>,
 ) -> Result<Vec<Message>, ConvertError> {
+    // The blanket Vec TryFromLLM conversion is one input message to one universal
+    // message. Anthropic user messages can mix text and tool_result blocks in a
+    // single content array, which needs to become ordered user/tool messages so
+    // OpenAI targets receive the required tool output after each tool call.
     let mut messages = Vec::new();
 
     for input_message in input_messages {
@@ -1322,6 +1408,27 @@ pub(crate) fn anthropic_input_messages_to_universal_messages(
     }
 
     Ok(messages)
+}
+
+pub(crate) fn universal_messages_to_anthropic_input_messages(
+    messages: Vec<Message>,
+) -> Result<Vec<generated::InputMessage>, ConvertError> {
+    let mut input_messages = Vec::new();
+
+    for message in messages {
+        let input_message = <generated::InputMessage as TryFromLLM<Message>>::try_from(message)?;
+        if let Some(previous) = input_messages.last_mut() {
+            if let Some(unmerged) =
+                try_merge_adjacent_user_tool_result_message(previous, input_message)?
+            {
+                input_messages.push(unmerged);
+            }
+        } else {
+            input_messages.push(input_message);
+        }
+    }
+
+    Ok(input_messages)
 }
 
 pub(crate) fn try_parse_content_blocks_for_import(

--- a/crates/lingua/src/providers/anthropic/convert.rs
+++ b/crates/lingua/src/providers/anthropic/convert.rs
@@ -3,8 +3,7 @@ use std::convert::TryFrom;
 use crate::capabilities::ProviderFormat;
 use crate::error::ConvertError;
 use crate::import_parse::{
-    try_convert_non_empty, try_parse, try_parse_and_convert, try_parse_vec_or_single,
-    try_parsers_in_order, MessageParser,
+    try_convert_non_empty, try_parse, try_parse_vec_or_single, try_parsers_in_order, MessageParser,
 };
 use crate::providers::anthropic::generated;
 use crate::providers::anthropic::generated::{
@@ -1252,6 +1251,79 @@ impl TryFromLLM<Message> for generated::InputMessage {
     }
 }
 
+fn input_content_block_is_tool_result(block: &generated::InputContentBlock) -> bool {
+    matches!(
+        block.input_content_block_type,
+        generated::InputContentBlockType::ToolResult
+    )
+}
+
+fn mixed_user_tool_result_groups(
+    input_msg: generated::InputMessage,
+) -> Option<Vec<generated::InputMessage>> {
+    if !matches!(input_msg.role, generated::MessageRole::User) {
+        return None;
+    }
+
+    let generated::MessageContent::InputContentBlockArray(blocks) = input_msg.content else {
+        return None;
+    };
+
+    let has_tool_results = blocks.iter().any(input_content_block_is_tool_result);
+    if !has_tool_results || blocks.iter().all(input_content_block_is_tool_result) {
+        return None;
+    }
+
+    let mut groups = Vec::new();
+    let mut current_blocks = Vec::new();
+    let mut current_is_tool_result = None;
+
+    for block in blocks {
+        let is_tool_result = input_content_block_is_tool_result(&block);
+        if current_is_tool_result.is_some_and(|current| current != is_tool_result) {
+            groups.push(generated::InputMessage {
+                role: generated::MessageRole::User,
+                content: generated::MessageContent::InputContentBlockArray(current_blocks),
+            });
+            current_blocks = Vec::new();
+        }
+
+        current_is_tool_result = Some(is_tool_result);
+        current_blocks.push(block);
+    }
+
+    if !current_blocks.is_empty() {
+        groups.push(generated::InputMessage {
+            role: generated::MessageRole::User,
+            content: generated::MessageContent::InputContentBlockArray(current_blocks),
+        });
+    }
+
+    Some(groups)
+}
+
+pub(crate) fn anthropic_input_messages_to_universal_messages(
+    input_messages: Vec<generated::InputMessage>,
+) -> Result<Vec<Message>, ConvertError> {
+    let mut messages = Vec::new();
+
+    for input_message in input_messages {
+        if let Some(groups) = mixed_user_tool_result_groups(input_message.clone()) {
+            for group in groups {
+                messages.push(<Message as TryFromLLM<generated::InputMessage>>::try_from(
+                    group,
+                )?);
+            }
+        } else {
+            messages.push(<Message as TryFromLLM<generated::InputMessage>>::try_from(
+                input_message,
+            )?);
+        }
+    }
+
+    Ok(messages)
+}
+
 pub(crate) fn try_parse_content_blocks_for_import(
     data: &serde_json::Value,
 ) -> Option<Vec<Message>> {
@@ -1271,8 +1343,7 @@ fn try_messages_from_anthropic_request(
     }
 
     let mut request_messages =
-        <Vec<Message> as TryFromLLM<Vec<generated::InputMessage>>>::try_from(request.messages)
-            .ok()?;
+        anthropic_input_messages_to_universal_messages(request.messages).ok()?;
     messages.append(&mut request_messages);
 
     if messages.is_empty() {
@@ -1287,7 +1358,8 @@ fn try_messages_from_anthropic_response(response: generated::Message) -> Option<
 }
 
 fn try_parse_input_messages_for_import(data: &serde_json::Value) -> Option<Vec<Message>> {
-    try_parse_and_convert::<Vec<generated::InputMessage>>(data)
+    let messages = try_parse::<Vec<generated::InputMessage>>(data)?;
+    anthropic_input_messages_to_universal_messages(messages).ok()
 }
 
 fn try_parse_anthropic_request_for_import(data: &serde_json::Value) -> Option<Vec<Message>> {
@@ -1893,6 +1965,37 @@ mod tests {
         properties: Option<HashMap<String, ToolSchemaPropertyView>>,
     }
 
+    fn input_message(value: Value) -> generated::InputMessage {
+        serde_json::from_value(value).expect("input message should deserialize")
+    }
+
+    fn text_from_user(message: &Message) -> &str {
+        match message {
+            Message::User {
+                content: UserContent::String(text),
+            } => text,
+            Message::User {
+                content: UserContent::Array(parts),
+            } => match &parts[..] {
+                [UserContentPart::Text(TextContentPart { text, .. })] => text,
+                _ => panic!("expected single text user content part, got {message:?}"),
+            },
+            _ => panic!("expected user message, got {message:?}"),
+        }
+    }
+
+    fn tool_call_id_from_tool(message: &Message) -> &str {
+        match message {
+            Message::Tool { content } => match &content[..] {
+                [ToolContentPart::ToolResult(ToolResultContentPart { tool_call_id, .. })] => {
+                    tool_call_id
+                }
+                _ => panic!("expected single tool result, got {message:?}"),
+            },
+            _ => panic!("expected tool message, got {message:?}"),
+        }
+    }
+
     #[test]
     fn test_json_object_response_format_is_not_converted_to_anthropic_format() {
         let config = ResponseFormatConfig {
@@ -1922,6 +2025,95 @@ mod tests {
             } => assert_eq!(text, "Follow the project style guide."),
             other => panic!("expected system message, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn anthropic_input_messages_to_universal_messages_preserves_pure_tool_results() {
+        let input = input_message(json!({
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_1",
+                    "content": "result one"
+                },
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_2",
+                    "content": "result two"
+                }
+            ]
+        }));
+
+        let messages = anthropic_input_messages_to_universal_messages(vec![input])
+            .expect("conversion should succeed");
+
+        assert_eq!(messages.len(), 1);
+        match &messages[0] {
+            Message::Tool { content } => {
+                assert_eq!(content.len(), 2);
+                let ToolContentPart::ToolResult(first) = &content[0];
+                assert_eq!(first.tool_call_id, "call_1");
+                let ToolContentPart::ToolResult(second) = &content[1];
+                assert_eq!(second.tool_call_id, "call_2");
+            }
+            other => panic!("expected tool message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn anthropic_input_messages_to_universal_messages_splits_tool_result_then_text() {
+        let input = input_message(json!({
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_repro_123",
+                    "content": "{\"records\":[{\"id\":\"record_1\",\"status\":\"ok\"}]}"
+                },
+                {
+                    "type": "text",
+                    "text": "What details are available?"
+                }
+            ]
+        }));
+
+        let messages = anthropic_input_messages_to_universal_messages(vec![input])
+            .expect("conversion should succeed");
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(tool_call_id_from_tool(&messages[0]), "call_repro_123");
+        assert_eq!(text_from_user(&messages[1]), "What details are available?");
+    }
+
+    #[test]
+    fn anthropic_input_messages_to_universal_messages_preserves_interleaved_order() {
+        let input = input_message(json!({
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Before"
+                },
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_repro_123",
+                    "content": "tool output"
+                },
+                {
+                    "type": "text",
+                    "text": "After"
+                }
+            ]
+        }));
+
+        let messages = anthropic_input_messages_to_universal_messages(vec![input])
+            .expect("conversion should succeed");
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(text_from_user(&messages[0]), "Before");
+        assert_eq!(tool_call_id_from_tool(&messages[1]), "call_repro_123");
+        assert_eq!(text_from_user(&messages[2]), "After");
     }
 
     #[test]

--- a/crates/lingua/src/providers/anthropic/convert.rs
+++ b/crates/lingua/src/providers/anthropic/convert.rs
@@ -1349,21 +1349,6 @@ fn try_merge_adjacent_user_tool_result_message(
             !blocks.is_empty() && blocks.iter().all(input_content_block_is_tool_result)
         }
     };
-    let current_is_pure_tool_result = match &current.content {
-        generated::MessageContent::String(_) => false,
-        generated::MessageContent::InputContentBlockArray(blocks) => {
-            !blocks.is_empty() && blocks.iter().all(input_content_block_is_tool_result)
-        }
-    };
-    let previous_is_pure_non_tool_result = match &previous.content {
-        generated::MessageContent::String(_) => true,
-        generated::MessageContent::InputContentBlockArray(blocks) => {
-            !blocks.is_empty()
-                && blocks
-                    .iter()
-                    .all(|block| !input_content_block_is_tool_result(block))
-        }
-    };
     let current_is_pure_non_tool_result = match &current.content {
         generated::MessageContent::String(_) => true,
         generated::MessageContent::InputContentBlockArray(blocks) => {
@@ -1374,11 +1359,9 @@ fn try_merge_adjacent_user_tool_result_message(
         }
     };
 
-    // Only rejoin a pure tool-result segment with its adjacent pure user-content
-    // segment. Once merged, the mixed message must not absorb later user turns.
-    if !(previous_is_pure_tool_result && current_is_pure_non_tool_result
-        || current_is_pure_tool_result && previous_is_pure_non_tool_result)
-    {
+    // Anthropic requires tool_result blocks to come before text in a mixed user
+    // message, so only rejoin Tool -> User. User -> Tool must stay split.
+    if !(previous_is_pure_tool_result && current_is_pure_non_tool_result) {
         return Ok(Some(current));
     }
 
@@ -2273,6 +2256,42 @@ mod tests {
         match &input_messages[1].content {
             generated::MessageContent::String(text) => assert_eq!(text, "second"),
             other => panic!("expected second user turn to remain separate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn universal_messages_to_anthropic_input_messages_does_not_merge_user_before_tool_result() {
+        let messages = vec![
+            Message::User {
+                content: UserContent::String("before".to_string()),
+            },
+            Message::Tool {
+                content: vec![ToolContentPart::ToolResult(ToolResultContentPart {
+                    tool_call_id: "call_repro_123".to_string(),
+                    tool_name: String::new(),
+                    output: json!("result"),
+                    provider_options: None,
+                })],
+            },
+        ];
+
+        let input_messages = universal_messages_to_anthropic_input_messages(messages)
+            .expect("conversion should succeed");
+
+        assert_eq!(input_messages.len(), 2);
+        match &input_messages[0].content {
+            generated::MessageContent::String(text) => assert_eq!(text, "before"),
+            other => panic!("expected first user turn to remain separate, got {other:?}"),
+        }
+        match &input_messages[1].content {
+            generated::MessageContent::InputContentBlockArray(blocks) => {
+                assert_eq!(blocks.len(), 1);
+                assert_eq!(
+                    blocks[0].input_content_block_type,
+                    generated::InputContentBlockType::ToolResult
+                );
+            }
+            other => panic!("expected pure tool result content, got {other:?}"),
         }
     }
 

--- a/crates/lingua/src/providers/anthropic/test_anthropic.rs
+++ b/crates/lingua/src/providers/anthropic/test_anthropic.rs
@@ -1,3 +1,6 @@
+use crate::providers::anthropic::convert::{
+    anthropic_input_messages_to_universal_messages, universal_messages_to_anthropic_input_messages,
+};
 use crate::providers::anthropic::generated::{
     ContentBlock, CreateMessageParams, InputMessage, Message as AnthropicMessage,
 };
@@ -36,12 +39,12 @@ mod tests {
             |request: &CreateMessageParams| Ok(&request.messages),
             // Convert to universal
             |messages: &Vec<InputMessage>| {
-                <Vec<Message> as TryFromLLM<Vec<InputMessage>>>::try_from(messages.clone())
+                anthropic_input_messages_to_universal_messages(messages.clone())
                     .map_err(|e| format!("Failed to convert to universal format: {}", e))
             },
             // Convert from universal
             |messages: Vec<Message>| {
-                <Vec<InputMessage> as TryFromLLM<Vec<Message>>>::try_from(messages)
+                universal_messages_to_anthropic_input_messages(messages)
                     .map_err(|e| format!("Failed to roundtrip conversion: {}", e))
             },
             // Extract response content

--- a/crates/lingua/src/python.rs
+++ b/crates/lingua/src/python.rs
@@ -2,6 +2,9 @@ use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
 // Import our types and conversion traits
+use crate::providers::anthropic::convert::{
+    anthropic_input_messages_to_universal_messages, universal_messages_to_anthropic_input_messages,
+};
 use crate::providers::anthropic::generated as anthropic;
 use crate::providers::google::generated as google;
 use crate::providers::openai::convert::ChatCompletionRequestMessageExt;
@@ -122,7 +125,11 @@ fn anthropic_messages_to_lingua<'py>(
     py: Python<'py>,
     value: &Bound<'py, PyAny>,
 ) -> PyResult<Bound<'py, PyAny>> {
-    convert_to_lingua::<Vec<anthropic::InputMessage>, Vec<Message>>(py, value)
+    let input_messages: Vec<anthropic::InputMessage> = py_to_rust(py, value)?;
+    let messages = anthropic_input_messages_to_universal_messages(input_messages).map_err(|e| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Conversion error: {:?}", e))
+    })?;
+    rust_to_py(py, &messages)
 }
 
 /// Convert array of Lingua Messages to Anthropic messages
@@ -131,7 +138,11 @@ fn lingua_to_anthropic_messages<'py>(
     py: Python<'py>,
     value: &Bound<'py, PyAny>,
 ) -> PyResult<Bound<'py, PyAny>> {
-    convert_from_lingua::<Vec<Message>, Vec<anthropic::InputMessage>>(py, value)
+    let messages: Vec<Message> = py_to_rust(py, value)?;
+    let input_messages = universal_messages_to_anthropic_input_messages(messages).map_err(|e| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Conversion error: {:?}", e))
+    })?;
+    rust_to_py(py, &input_messages)
 }
 
 /// Convert array of Google Content items to Lingua Messages

--- a/crates/lingua/src/wasm.rs
+++ b/crates/lingua/src/wasm.rs
@@ -3,6 +3,9 @@ use serde_wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 // Import our types and conversion traits
+use crate::providers::anthropic::convert::{
+    anthropic_input_messages_to_universal_messages, universal_messages_to_anthropic_input_messages,
+};
 use crate::providers::anthropic::generated as anthropic;
 use crate::providers::google::generated as google;
 use crate::providers::openai::generated as openai;
@@ -141,13 +144,21 @@ pub fn lingua_to_responses_messages(value: JsValue) -> Result<JsValue, JsValue> 
 /// Convert array of Anthropic messages to Lingua Messages
 #[wasm_bindgen]
 pub fn anthropic_messages_to_lingua(value: JsValue) -> Result<JsValue, JsValue> {
-    convert_to_lingua::<Vec<anthropic::InputMessage>, Vec<Message>>(value)
+    let input_messages: Vec<anthropic::InputMessage> = serde_wasm_bindgen::from_value(value)
+        .map_err(|e| JsValue::from_str(&format!("Failed to parse input: {}", e)))?;
+    let messages = anthropic_input_messages_to_universal_messages(input_messages)
+        .map_err(|e| JsValue::from_str(&format!("Conversion error: {:?}", e)))?;
+    serialize_to_js(&messages, "result")
 }
 
 /// Convert array of Lingua Messages to Anthropic messages
 #[wasm_bindgen]
 pub fn lingua_to_anthropic_messages(value: JsValue) -> Result<JsValue, JsValue> {
-    convert_from_lingua::<Vec<Message>, Vec<anthropic::InputMessage>>(value)
+    let messages: Vec<Message> = serde_wasm_bindgen::from_value(value)
+        .map_err(|e| JsValue::from_str(&format!("Failed to parse input: {}", e)))?;
+    let input_messages = universal_messages_to_anthropic_input_messages(messages)
+        .map_err(|e| JsValue::from_str(&format!("Conversion error: {:?}", e)))?;
+    serialize_to_js(&input_messages, "result")
 }
 
 /// Convert array of Google Content items to Lingua Messages

--- a/payloads/cases/advanced.ts
+++ b/payloads/cases/advanced.ts
@@ -864,6 +864,62 @@ export const advancedCases: TestCaseCollection = {
     "vertex-anthropic": null,
   },
 
+  anthropicMixedToolResultWithText: {
+    "chat-completions": null,
+    responses: null,
+    anthropic: {
+      model: ANTHROPIC_MODEL,
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "user",
+          content: "Look up the latest records.",
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "call_repro_123",
+              name: "search_records",
+              input: { collection: "example_collection" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_repro_123",
+              content: JSON.stringify({
+                records: [{ id: "record_1", status: "ok" }],
+              }),
+            },
+            {
+              type: "text",
+              text: "What details are available?",
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          name: "search_records",
+          input_schema: {
+            type: "object",
+            properties: {
+              collection: { type: "string" },
+            },
+            required: ["collection"],
+          },
+        },
+      ],
+    },
+    google: null,
+    bedrock: null,
+  },
+
   systemMessageArrayContent: {
     "chat-completions": {
       model: OPENAI_CHAT_COMPLETIONS_MODEL,

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -434,6 +434,22 @@ data: {"type":"message_stop"}
 "
 `;
 
+exports[`streaming: anthropic → chat-completions > anthropicMixedToolResultWithText > streaming 1`] = `
+"event: message_start
+data: {"message":{"content":[],"id":"chatcmpl-Dp4RF3MuIGYlGOoQIJBvJ6q7UDIo9","model":"gpt-5-nano-2025-08-07","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{}},"type":"message_start"}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: message_delta
+data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"cache_read_input_tokens":0,"input_tokens":176,"output_tokens":1024}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+"
+`;
+
 exports[`streaming: anthropic → chat-completions > complexReasoningRequest > streaming 1`] = `
 "event: message_start
 data: {"message":{"content":[],"id":"chatcmpl-DQJkt7wWytDi8Nj25RE2kiFvAJAw7","model":"gpt-5-nano-2025-08-07","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{"input_tokens":0,"output_tokens":0}},"type":"message_start"}

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -137,6 +137,86 @@ exports[`anthropic → chat-completions > anthropicMidConversationSystemMessage 
 }
 `;
 
+exports[`anthropic → chat-completions > anthropicMixedToolResultWithText > request 1`] = `
+{
+  "max_completion_tokens": 1024,
+  "messages": [
+    {
+      "content": "Look up the latest records.",
+      "role": "user",
+    },
+    {
+      "role": "assistant",
+      "tool_calls": [
+        {
+          "function": {
+            "arguments": "{"collection":"example_collection"}",
+            "name": "search_records",
+          },
+          "id": "call_repro_123",
+          "type": "function",
+        },
+      ],
+    },
+    {
+      "content": "{"records":[{"id":"record_1","status":"ok"}]}",
+      "role": "tool",
+      "tool_call_id": "call_repro_123",
+    },
+    {
+      "content": [
+        {
+          "text": "What details are available?",
+          "type": "text",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "model": "gpt-5-nano",
+  "tools": [
+    {
+      "function": {
+        "name": "search_records",
+        "parameters": {
+          "properties": {
+            "collection": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "collection",
+          ],
+          "type": "object",
+        },
+      },
+      "type": "function",
+    },
+  ],
+}
+`;
+
+exports[`anthropic → chat-completions > anthropicMixedToolResultWithText > response 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "id": "msg_Dp4R7lfsjXtmqofXb3WVvWPgtkoek",
+  "model": "gpt-5-nano-2025-08-07",
+  "role": "assistant",
+  "stop_reason": "max_tokens",
+  "type": "message",
+  "usage": {
+    "cache_read_input_tokens": 0,
+    "input_tokens": 176,
+    "output_tokens": 1024,
+  },
+}
+`;
+
 exports[`anthropic → chat-completions > cacheControl1hParam > request 1`] = `
 {
   "max_completion_tokens": 1024,
@@ -2273,6 +2353,110 @@ exports[`anthropic → google > anthropicMidConversationSystemMessage > response
   "usage": {
     "input_tokens": 40,
     "output_tokens": 13,
+  },
+}
+`;
+
+exports[`anthropic → google > anthropicMixedToolResultWithText > request 1`] = `
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "Look up the latest records.",
+        },
+      ],
+      "role": "user",
+    },
+    {
+      "parts": [
+        {
+          "functionCall": {
+            "args": {
+              "collection": "example_collection",
+            },
+            "name": "search_records",
+          },
+        },
+      ],
+      "role": "model",
+    },
+    {
+      "parts": [
+        {
+          "functionResponse": {
+            "name": "search_records",
+            "response": {
+              "records": [
+                {
+                  "id": "record_1",
+                  "status": "ok",
+                },
+              ],
+            },
+          },
+        },
+      ],
+      "role": "user",
+    },
+    {
+      "parts": [
+        {
+          "text": "What details are available?",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "generationConfig": {
+    "maxOutputTokens": 1024,
+    "responseSchema": null,
+  },
+  "model": "gemini-3.5-flash",
+  "tools": [
+    {
+      "functionDeclarations": [
+        {
+          "name": "search_records",
+          "parameters": null,
+          "parametersJsonSchema": {
+            "properties": {
+              "collection": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "collection",
+            ],
+            "type": "object",
+          },
+          "response": null,
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`anthropic → google > anthropicMixedToolResultWithText > response 1`] = `
+{
+  "content": [
+    {
+      "text": "The latest record retrieved contains the following details:
+
+* **Record ID:** \`record_1\`
+* **Status:** \`ok\`",
+      "type": "text",
+    },
+  ],
+  "id": "msg_transformed",
+  "model": "gemini-3.5-flash",
+  "role": "assistant",
+  "stop_reason": "end_turn",
+  "type": "message",
+  "usage": {
+    "input_tokens": 88,
+    "output_tokens": 546,
   },
 }
 `;
@@ -5171,6 +5355,78 @@ exports[`anthropic → responses > anthropicMidConversationSystemMessage > respo
     "cache_read_input_tokens": 0,
     "input_tokens": 51,
     "output_tokens": 0,
+  },
+}
+`;
+
+exports[`anthropic → responses > anthropicMixedToolResultWithText > request 1`] = `
+{
+  "input": [
+    {
+      "content": "Look up the latest records.",
+      "role": "user",
+    },
+    {
+      "arguments": "{"collection":"example_collection"}",
+      "call_id": "call_repro_123",
+      "name": "search_records",
+      "status": "completed",
+      "type": "function_call",
+    },
+    {
+      "call_id": "call_repro_123",
+      "output": "{"records":[{"id":"record_1","status":"ok"}]}",
+      "type": "function_call_output",
+    },
+    {
+      "content": [
+        {
+          "text": "What details are available?",
+          "type": "input_text",
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "max_output_tokens": 1024,
+  "model": "gpt-5-nano",
+  "tools": [
+    {
+      "name": "search_records",
+      "parameters": {
+        "properties": {
+          "collection": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "collection",
+        ],
+        "type": "object",
+      },
+      "type": "function",
+    },
+  ],
+}
+`;
+
+exports[`anthropic → responses > anthropicMixedToolResultWithText > response 1`] = `
+{
+  "content": [
+    {
+      "thinking": "",
+      "type": "thinking",
+    },
+  ],
+  "id": "msg_01ec58571640ba5b006a28e1d8d5048195aaa85e1dac9efcd9",
+  "model": "gpt-5-nano-2025-08-07",
+  "role": "assistant",
+  "stop_reason": "max_tokens",
+  "type": "message",
+  "usage": {
+    "cache_read_input_tokens": 0,
+    "input_tokens": 92,
+    "output_tokens": 1024,
   },
 }
 `;

--- a/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/followup-request.json
+++ b/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/followup-request.json
@@ -1,0 +1,66 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "max_tokens": 1024,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Look up the latest records."
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "call_repro_123",
+          "name": "search_records",
+          "input": {
+            "collection": "example_collection"
+          }
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "call_repro_123",
+          "content": "{\"records\":[{\"id\":\"record_1\",\"status\":\"ok\"}]}"
+        },
+        {
+          "type": "text",
+          "text": "What details are available?"
+        }
+      ]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "Based on the record that was retrieved, the following details are available:\n\n- **ID**: record_1\n- **Status**: ok\n\nThe record appears to be quite minimal with just these two fields. If you'd like to search for records in a different collection or need more specific information, please let me know which collection you'd like me to search in."
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": "What should I do next?"
+    }
+  ],
+  "tools": [
+    {
+      "name": "search_records",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "collection": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "collection"
+        ]
+      }
+    }
+  ]
+}

--- a/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/followup-response-streaming.json
+++ b/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/followup-response-streaming.json
@@ -1,0 +1,152 @@
+[
+  {
+    "type": "message_start",
+    "message": {
+      "model": "claude-sonnet-4-5-20250929",
+      "id": "msg_01VpsWG9iYZE7YQN7aBvqh3k",
+      "type": "message",
+      "role": "assistant",
+      "content": [],
+      "stop_reason": null,
+      "stop_sequence": null,
+      "stop_details": null,
+      "usage": {
+        "input_tokens": 732,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation": {
+          "ephemeral_5m_input_tokens": 0,
+          "ephemeral_1h_input_tokens": 0
+        },
+        "output_tokens": 1,
+        "service_tier": "standard",
+        "inference_geo": "not_available"
+      }
+    }
+  },
+  {
+    "type": "content_block_start",
+    "index": 0,
+    "content_block": {
+      "type": "text",
+      "text": ""
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": "That"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " depends on what you're trying to accomplish! Here are some suggestions based on what we've seen:\n\n1. **Search"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " a specific collection** - If you know the name of a particular collection you need"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": ", I can search for records in it (the previous search used \"example_collection\""
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " as a default)\n\n2. **Investigate the record status** - The"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " record shows \"status: ok\" which suggests the system is functioning normally. If"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " you're monitoring something, this appears healthy.\n\n3. **Look for other"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " collections** - If you're exploring what data is available, you could tell"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " me which collection names to search\n\n4. **Take action based on the status** - If this is part"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " of a workflow or process, the \"ok\" status might indicate you can proceed with your"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " next step\n\nCould you provide more context about:\n- What you're trying to achieve?\n- What type of records or"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " data you're looking for?\n- What collection(s) you need to access?\n\nThis will help me assist you more effectively!"
+    }
+  },
+  {
+    "type": "content_block_stop",
+    "index": 0
+  },
+  {
+    "type": "message_delta",
+    "delta": {
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "stop_details": null
+    },
+    "usage": {
+      "input_tokens": 732,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 220
+    }
+  },
+  {
+    "type": "message_stop"
+  }
+]

--- a/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/followup-response.json
+++ b/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/followup-response.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_01DMmF8Lg2UnBT6q7oL36oU7",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "That depends on what you're trying to accomplish! Here are some suggestions based on what we've seen:\n\n1. **Search a specific collection** - If you know the name of a collection you want to explore, I can search for records in that collection (the previous search used \"example_collection\" as a default)\n\n2. **Analyze the record** - Since the record shows status \"ok\", this might indicate the system is functioning normally. You could investigate what this record represents in your system.\n\n3. **Look for other collections** - If you have specific collections you need to check (like users, orders, logs, etc.), let me know and I can search those.\n\n4. **Take action based on status** - Since the status is \"ok\", no immediate action may be needed, but this depends on your use case.\n\nWhat are you trying to accomplish? That would help me provide more specific guidance on the next steps."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 732,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 199,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/request.json
+++ b/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/request.json
@@ -1,0 +1,53 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "max_tokens": 1024,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Look up the latest records."
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "call_repro_123",
+          "name": "search_records",
+          "input": {
+            "collection": "example_collection"
+          }
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "call_repro_123",
+          "content": "{\"records\":[{\"id\":\"record_1\",\"status\":\"ok\"}]}"
+        },
+        {
+          "type": "text",
+          "text": "What details are available?"
+        }
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "name": "search_records",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "collection": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "collection"
+        ]
+      }
+    }
+  ]
+}

--- a/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/response-streaming.json
+++ b/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/response-streaming.json
@@ -1,0 +1,88 @@
+[
+  {
+    "type": "message_start",
+    "message": {
+      "model": "claude-sonnet-4-5-20250929",
+      "id": "msg_01D44y7bUebvwxxnwkucY6t5",
+      "type": "message",
+      "role": "assistant",
+      "content": [],
+      "stop_reason": null,
+      "stop_sequence": null,
+      "stop_details": null,
+      "usage": {
+        "input_tokens": 646,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation": {
+          "ephemeral_5m_input_tokens": 0,
+          "ephemeral_1h_input_tokens": 0
+        },
+        "output_tokens": 1,
+        "service_tier": "standard",
+        "inference_geo": "not_available"
+      }
+    }
+  },
+  {
+    "type": "content_block_start",
+    "index": 0,
+    "content_block": {
+      "type": "text",
+      "text": ""
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": "Based"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " on the search results, the available details for the record are:\n\n- **ID**: record_1\n- **Status**: ok\n\nThese are"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " the only two fields returned in the record. If you need more specific information or"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "text_delta",
+      "text": " want to search in a different collection, please let me know!"
+    }
+  },
+  {
+    "type": "content_block_stop",
+    "index": 0
+  },
+  {
+    "type": "message_delta",
+    "delta": {
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "stop_details": null
+    },
+    "usage": {
+      "input_tokens": 646,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 63
+    }
+  },
+  {
+    "type": "message_stop"
+  }
+]

--- a/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/response.json
+++ b/payloads/snapshots/anthropicMixedToolResultWithText/anthropic/response.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_018CecB79gHbNxV6rMmmMnP8",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "Based on the record that was retrieved, the following details are available:\n\n- **ID**: record_1\n- **Status**: ok\n\nThe record appears to be quite minimal with just these two fields. If you'd like to search for records in a different collection or need more specific information, please let me know which collection you'd like me to search in."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 646,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 77,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/payloads/transforms/anthropic_to_chat-completions/anthropicMixedToolResultWithText-streaming.json
+++ b/payloads/transforms/anthropic_to_chat-completions/anthropicMixedToolResultWithText-streaming.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "chatcmpl-Dp4RF3MuIGYlGOoQIJBvJ6q7UDIo9",
+    "object": "chat.completion.chunk",
+    "created": 1781064161,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "role": "assistant",
+          "content": "",
+          "refusal": null
+        },
+        "finish_reason": null
+      }
+    ],
+    "usage": null,
+    "obfuscation": "e3NqI"
+  },
+  {
+    "id": "chatcmpl-Dp4RF3MuIGYlGOoQIJBvJ6q7UDIo9",
+    "object": "chat.completion.chunk",
+    "created": 1781064161,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [
+      {
+        "index": 0,
+        "delta": {},
+        "finish_reason": "length"
+      }
+    ],
+    "usage": null,
+    "obfuscation": "TXvY2sbHa9RET0R"
+  },
+  {
+    "id": "chatcmpl-Dp4RF3MuIGYlGOoQIJBvJ6q7UDIo9",
+    "object": "chat.completion.chunk",
+    "created": 1781064161,
+    "model": "gpt-5-nano-2025-08-07",
+    "service_tier": "default",
+    "system_fingerprint": null,
+    "choices": [],
+    "usage": {
+      "prompt_tokens": 176,
+      "completion_tokens": 1024,
+      "total_tokens": 1200,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 1024,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "obfuscation": "7KT5pkWygpOHH7"
+  }
+]

--- a/payloads/transforms/anthropic_to_chat-completions/anthropicMixedToolResultWithText.json
+++ b/payloads/transforms/anthropic_to_chat-completions/anthropicMixedToolResultWithText.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Dp4R7lfsjXtmqofXb3WVvWPgtkoek",
+  "object": "chat.completion",
+  "created": 1781064153,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "length"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 176,
+    "completion_tokens": 1024,
+    "total_tokens": 1200,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 1024,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/transforms/anthropic_to_google/anthropicMixedToolResultWithText.json
+++ b/payloads/transforms/anthropic_to_google/anthropicMixedToolResultWithText.json
@@ -1,0 +1,32 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The latest record retrieved contains the following details:\n\n* **Record ID:** `record_1`\n* **Status:** `ok`",
+            "thoughtSignature": "Eq8QCqwQAQw51sfuoOA/XbbXfB/xd1P7TvslzTYit6y0rUF/4M/rWNoadMZH5LPBGtf87ZWhbOvtpRsTFyHQQZGnIzp6PfWxWaUKkQGgUqGcUjEcKbI4Ep0Pqu5FfRyIbdLMT/u/ANHSy2+VHcbxEXtO+L2s9C4KEZwhtXKgTMaFExUXsy4RCoKQ0uGgjNCn6F/wuUD0l0ImXa/qfDc0Q5DDxnJ0Uwcz4My+wpOvfCFAOogqZXX3I4AcoGOWMrBj/BHdtbHiSzS4vmsfWH0mu3AX4rDo+gSL84/pUgx6oj4DoTSX2OY5WamiEALEs5eDMPAK8YziK2ywo7FqVooen3mTvFgE9ie/AG2ouRsanCJVpXn0CqOGkTwwuW8ETeGTabQslEcEkFcOWo27MnXTEaiTK+uagshqVT1Vd0egBXHg6oaRIa3dZcUOzb895GRuQ3BriHzO2vkDOdIYS758/eRzg18uLqWyovKEj3qFcV+kVjvv7jfRGom9OUjL6e4FB0XfQA0s2EB5TKwk1NAIpJw8IfRBWfkSPgM9qEfU/drCS8EJZnXj4c3fuvgaNpUOj3MnRPDNJnmtjU9w/uPSjmyt6EIvt/cUh1Tmifl4ckrVdaFi6bSqROqEkGFUm89xk7iEoDn6Hy02uWJSQaH4XcEuWbS+nB0OpQ5Qa0hhOubIDeMalaJQMBA8mRwndKzAkoiyb6X1N6wXD7DNOvT0xt1zQVU2V3ZHGA2jbYbfKEBOVv9B/MMWwW58JbJlwRMTse/PmMGlABaDisPT4ipEI4h7omdfik3MxzO4Gh7rFwm7waGuN+ydZpaE5lV1aoASCxhEs1BRbK6yQreOW/pEimSskNvytBW3FSvDL62teBiqYsQhORm0Hijlt8UBeoWmDzivXq6C8k4q4P28LfcHc/nBqADiLIJmPDyp160BBwI8bpUYA8Rv70uZxQD63L2dVDX6cTGXz0s0mvjqXppls+GNVp6T5Agx1i8rHGTcrn9xgCjqsOC3hqned13plueJtW6E1CCs2NhLbK0Rc/K9x1+24CkBm/8BYi/Pe+P4Mx0auzMNgXhaNv3/uoSHi7JrGq3VFasm1K/zB/juNHr41cXcve14ERjcP0aw9Uy/A8D+KZt1W2DI0wfA3JyyjcucHTsIAjzLuzpAXCruGgBnVwVg1zbGfKHtExY6QJuJSOiI1jbGwBjE+7PaAd2KezZrkPckZrltLVF/Wn5t/vQl7dmzZUKpG6+/9+FIo4K5ypLIqkFI/d7crsfNrV4ijiQ9486wtnCwog8sm67p7gcG+PTRH0xt9896fB8lDo/joIqTw8Ix/hJSvQVFR+Eb1fG434jEsIvxdxjP+Mnb7wdBllErlpafj/UBbu08Ob0B4op+tan+szW16CIPMQ175HT6+7vfCzen5TMdqj8ifHVZLbIZVsfxsLd1f8xoAiYj3Z3+YgisY3NLAaoU39qsjCpdTEqdq8nez/UuVWiDNHrropG6rT3xcwyP7xe/wcR+3ZwHxNMUjxrsI2bpFj4sOXNaK7jwgyrEsvz6EFE6FKrCFg+tO8TPlwMxrVyYUbQnr4fbOMtZ9hwlUFnb4a474dCz39/plFUBHzRzC9Z4S4Jym/wxPW1N3tJJJMMCB5A2c+VAm4bZvXod5JzipC/kV6iJ0+HrKlKzFOyNn4X7Xd1M2bf0POs2wSJB9zhpDZkO0BF0PRAM5MAoFC31w5SK8+KOhNrZEuaSeFPWxXqvN07ickI2hQz+duDiDgNhss4j3rRHCtzlNrC5K6GE6+PRCit28jERiUrzM13bC9z9+uimGVo9ati7ie6LKI+cQHHoEunlnhJ1YggQsm9FQJXcP6EBxWpP5OMWxdy0bCERqusQPugyY5I5z0I+6GIpGUHKfMja8i2ZQ4Gx1vPEyfvRQ4CegyASj3YNwzLtRCJKikh7xJTqauKwNNC0iiARogfLKHCT4ij8gp/PmedcN24ZV2ZuFgSW/4O0d0SOrCuRSxDAmLdmosarhe3NNTAUTIJLYVa8InwEi7PdPBvibQkgptcaxEgi4QL2IumouK+EeC/b73gvoMxjLaPc4zrAqlA3DBGGU3KQN7fWwX7prxKnF8DR5/JZjskt08Olb7vmuRkwYJDxmsNRIlG1fPw+vrMqqahT9csTVQyfhxNevsV1Bnlo4QlOAgLIVHmtIUS7rhYLMXFGXknrMi/cNH+YLiupmzee5N1T+u+eotFSk2Jk3xJ8UYsI5+IezbObherOTIg+yOAtMv7YQKwQJqv9dBtr67DUrXga1pDDX6g6l6jpF8dSNEupZKreHsC37pweU439c8wtuQsz01XCAhPq5vyWqvF7sGAkkzH0zJmcMQPOllwogstvo6llUds29MaiE59R+dp11wu7+SLaH/1Qpjkk+zUZwlDV4+sgPyHsLST4nh89t686jzFi/rD8DKB6e3zwkIPcFKJ2e6YLglR+tLtD/emjBe6V2xL6TfAfnbLQ/mySmB70VJeB7tXnwRuoCCxzqxWpGJlMBSMYE407zlE82ww1w3ham3ALTgl6CFhZeOgvr24b39ue/SqRg8uvQg/4s/71eXniF8mmF6VxN/k9/CTy3elefK8J4istx4Yy5ondwDXgqrGDRlk4uPvqqZIGGk36rswuTQ74fPipv56V7eM1ED8ACFaqJORuPYAgERz/GCURi3MIByLoYx7jfu0ktPnRwzIwbD6ufwsV7JRdH+vfRql/CbpQ4cV2Oako5WfmEKgUwJcxYtmKiVZe5wgY+v8kT2F8ZnNh/57ngyJ+vCCx/w=="
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 88,
+    "candidatesTokenCount": 28,
+    "totalTokenCount": 634,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 88
+      }
+    ],
+    "thoughtsTokenCount": 518,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "2OEoar3KHrjV_uMPqbDRwAs"
+}

--- a/payloads/transforms/anthropic_to_responses/anthropicMixedToolResultWithText.json
+++ b/payloads/transforms/anthropic_to_responses/anthropicMixedToolResultWithText.json
@@ -1,0 +1,87 @@
+{
+  "id": "resp_01ec58571640ba5b006a28e1d8d5048195aaa85e1dac9efcd9",
+  "object": "response",
+  "created_at": 1781064152,
+  "status": "incomplete",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": null,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": {
+    "reason": "max_output_tokens"
+  },
+  "instructions": null,
+  "max_output_tokens": 1024,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "moderation": null,
+  "output": [
+    {
+      "id": "rs_01ec58571640ba5b006a28e1d955008195836590a14d06b051",
+      "type": "reasoning",
+      "content": [],
+      "summary": []
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": "current_turn",
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "type": "function",
+      "description": null,
+      "name": "search_records",
+      "parameters": {
+        "properties": {
+          "collection": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "collection"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  ],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 92,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 1024,
+    "output_tokens_details": {
+      "reasoning_tokens": 1024
+    },
+    "total_tokens": 1116
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": ""
+}


### PR DESCRIPTION
### Problem

Anthropic Messages allows a user message like:

```json
[
  { "type": "text", "text": "Use this output..." },
  { "type": "tool_result", "tool_use_id": "call_123", "content": "..." }
]

Lingua previously dropped the tool_result from mixed user content. That made OpenAI transforms invalid and made Google
transforms lose important context.
```



### Behavior change

This fixes mixed Anthropic user content where a message contains both text and a `tool_result`.

Before this change, Anthropic import dropped the `tool_result` from mixed user content blocks.

For OpenAI Responses, that produced an invalid request:

```json
[
  { "role": "user", "content": "Look up the latest records." },
  { "type": "function_call", "call_id": "call_repro_123" },
  { "role": "user", "content": [{ "type": "input_text", "text": "What details are available?" }] }
]
```

OpenAI rejected this with:

400 No tool output found for function call call_repro_123.

After this change, the transformed Responses request includes the required tool output:
```json
{
  "type": "function_call_output",
  "call_id": "call_repro_123",
  "output": "{\"records\":[{\"id\":\"record_1\",\"status\":\"ok\"}]}"
}
```

Chat Completions had the same protocol issue: an assistant tool_calls message was followed by a user message instead of a
matching role: "tool" message. The fixed transform now emits the required tool message.

For Google/Gemini, the request was accepted before, but the semantics were degraded because the function response was
dropped. Before, Gemini saw the function call and the follow-up user text, but not the actual tool result. After this
change, Gemini receives the preserved functionResponse:

```json
{
  "role": "user",
  "parts": [
    {
      "functionResponse": {
        "name": "search_records",
        "response": {
          "records": [{ "id": "record_1", "status": "ok" }]
        }
      }
    }
  ]
}
```

So this change should fix the translation for both when going from anthropic -> google / anthropic -> responses / anthropic -> chat completions