### PR TITLE
Create path for user feedback on type generation PRs

### DIFF
--- a/.github/scripts/braintrust-provider-types.mjs
+++ b/.github/scripts/braintrust-provider-types.mjs
@@ -84,7 +84,7 @@ async function createWorkflowTrace() {
   const span = logger.startSpan({
     name: `Update ${provider} provider types`,
   });
-  const spanId = span.id || span.spanId;
+  const spanId = span.spanId || span.id;
   const rootSpanId = span.rootSpanId || span.root_span_id || spanId;
 
   span.log({

--- a/.github/scripts/braintrust-provider-types.mjs
+++ b/.github/scripts/braintrust-provider-types.mjs
@@ -116,6 +116,7 @@ function emitPrMetadata() {
     kind: "provider-type-update",
     project: requireEnv("BRAINTRUST_PROJECT"),
     root_span_id: requireEnv("BRAINTRUST_ROOT_SPAN_ID"),
+    span_id: requireEnv("BRAINTRUST_SPAN_ID"),
     provider: requireEnv("PROVIDER"),
     repository: requireEnv("GITHUB_REPOSITORY"),
     run_id: requireEnv("GITHUB_RUN_ID"),
@@ -171,7 +172,7 @@ function extractFeedbackEvent() {
   }
 
   const metadata = extractHiddenMetadata(event.issue?.body || "");
-  if (!metadata?.root_span_id || !metadata?.project) {
+  if (!metadata?.root_span_id || !metadata?.span_id || !metadata?.project) {
     writeGithubOutput({
       should_log: "false",
       reason: "Could not find Braintrust metadata in the PR body",
@@ -199,6 +200,7 @@ async function logFeedback() {
   const rating = requireEnv("BT_RATING");
   const score = rating === "good" ? 1 : 0;
   const projectName = metadata.project;
+  const parentSpanId = metadata.span_id || metadata.root_span_id;
   const logger = braintrust.initLogger({ projectName });
   const feedbackMetadata = workflowMetadata({
     provider: metadata.provider,
@@ -210,6 +212,7 @@ async function logFeedback() {
     feedback_author: optionalEnv("BT_COMMENT_AUTHOR"),
     pr_number: optionalEnv("BT_PR_NUMBER"),
     pr_url: optionalEnv("BT_PR_URL"),
+    target_span_id: parentSpanId,
     target_root_span_id: metadata.root_span_id,
     target_run_id: metadata.run_id,
     target_run_attempt: metadata.run_attempt,
@@ -228,7 +231,7 @@ async function logFeedback() {
       },
       {
         name: "github_pr_feedback",
-        parent: metadata.root_span_id,
+        parent: parentSpanId,
       },
     );
   } else {
@@ -240,6 +243,7 @@ async function logFeedback() {
       },
       output: {
         rating,
+        target_span_id: parentSpanId,
         target_root_span_id: metadata.root_span_id,
       },
       scores: {

--- a/.github/scripts/braintrust-provider-types.mjs
+++ b/.github/scripts/braintrust-provider-types.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+import { appendFileSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function optionalEnv(name) {
+  return process.env[name] || undefined;
+}
+
+function loadBraintrust() {
+  try {
+    return require("braintrust");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load the Braintrust SDK: ${message}`);
+  }
+}
+
+async function flushBraintrust(braintrust) {
+  if (typeof braintrust.flush === "function") {
+    await braintrust.flush();
+  }
+}
+
+function writeGithubOutput(values) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    return;
+  }
+
+  for (const [key, value] of Object.entries(values)) {
+    appendFileSync(outputPath, `${key}=${value ?? ""}\n`);
+  }
+}
+
+function writeGithubOutputValue(key, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    return;
+  }
+
+  const text = value == null ? "" : String(value);
+  if (!text.includes("\n")) {
+    appendFileSync(outputPath, `${key}=${text}\n`);
+    return;
+  }
+
+  const delimiter = `EOF_${key}_${Date.now()}`;
+  appendFileSync(outputPath, `${key}<<${delimiter}\n${text}\n${delimiter}\n`);
+}
+
+function workflowMetadata(extra = {}) {
+  return {
+    repository: optionalEnv("GITHUB_REPOSITORY"),
+    workflow: optionalEnv("GITHUB_WORKFLOW"),
+    job: optionalEnv("GITHUB_JOB"),
+    run_id: optionalEnv("GITHUB_RUN_ID"),
+    run_attempt: optionalEnv("GITHUB_RUN_ATTEMPT"),
+    ref: optionalEnv("GITHUB_REF"),
+    sha: optionalEnv("GITHUB_SHA"),
+    actor: optionalEnv("GITHUB_ACTOR"),
+    provider: optionalEnv("PROVIDER"),
+    ...extra,
+  };
+}
+
+async function createWorkflowTrace() {
+  requireEnv("BRAINTRUST_API_KEY");
+  const braintrust = loadBraintrust();
+  const projectName =
+    optionalEnv("BRAINTRUST_PROJECT") || "lingua-provider-type-updates";
+  const provider = requireEnv("PROVIDER");
+  const logger = braintrust.initLogger({ projectName });
+  const span = logger.startSpan({
+    name: `Update ${provider} provider types`,
+  });
+  const spanId = span.id || span.spanId;
+  const rootSpanId = span.rootSpanId || span.root_span_id || spanId;
+
+  span.log({
+    input: {
+      provider,
+      event: optionalEnv("GITHUB_EVENT_NAME"),
+      run_id: optionalEnv("GITHUB_RUN_ID"),
+      run_attempt: optionalEnv("GITHUB_RUN_ATTEMPT"),
+    },
+    metadata: workflowMetadata({
+      braintrust_project: projectName,
+      root_span_id: rootSpanId,
+      span_id: spanId,
+    }),
+  });
+  span.end();
+  await flushBraintrust(braintrust);
+
+  writeGithubOutput({
+    project: projectName,
+    root_span_id: rootSpanId,
+    span_id: spanId,
+  });
+}
+
+function emitPrMetadata() {
+  const metadata = {
+    version: 1,
+    kind: "provider-type-update",
+    project: requireEnv("BRAINTRUST_PROJECT"),
+    root_span_id: requireEnv("BRAINTRUST_ROOT_SPAN_ID"),
+    provider: requireEnv("PROVIDER"),
+    repository: requireEnv("GITHUB_REPOSITORY"),
+    run_id: requireEnv("GITHUB_RUN_ID"),
+    run_attempt: requireEnv("GITHUB_RUN_ATTEMPT"),
+    workflow: requireEnv("GITHUB_WORKFLOW"),
+    sha: requireEnv("GITHUB_SHA"),
+  };
+
+  console.log("<!-- braintrust-provider-type-update");
+  console.log(JSON.stringify(metadata));
+  console.log("-->");
+}
+
+function extractHiddenMetadata(body) {
+  const match = body.match(
+    /<!--\s*braintrust-provider-type-update\s*\n([\s\S]*?)\n-->/,
+  );
+  if (!match) {
+    return undefined;
+  }
+
+  return JSON.parse(match[1]);
+}
+
+function extractFeedbackEvent() {
+  const eventPath = requireEnv("GITHUB_EVENT_PATH");
+  const event = JSON.parse(readFileSync(eventPath, "utf8"));
+  const command = (event.comment?.body || "").trim();
+  const commandMatch = command.match(/^\/bt\s+(good|bad)\s*$/i);
+  const isPullRequest = Boolean(event.issue?.pull_request);
+  const labels = event.issue?.labels || [];
+  const labelNames = labels.map((label) => label.name);
+  const allowedAssociations = new Set([
+    "COLLABORATOR",
+    "MEMBER",
+    "OWNER",
+  ]);
+  const authorAssociation = event.comment?.author_association;
+
+  if (!commandMatch || !isPullRequest || !labelNames.includes("auto-sync")) {
+    writeGithubOutput({
+      should_log: "false",
+    });
+    return;
+  }
+
+  if (!allowedAssociations.has(authorAssociation)) {
+    writeGithubOutput({
+      should_log: "false",
+      reason: `Ignored /bt feedback from ${authorAssociation || "unknown"} author`,
+    });
+    return;
+  }
+
+  const metadata = extractHiddenMetadata(event.issue?.body || "");
+  if (!metadata?.root_span_id || !metadata?.project) {
+    writeGithubOutput({
+      should_log: "false",
+      reason: "Could not find Braintrust metadata in the PR body",
+    });
+    return;
+  }
+
+  writeGithubOutputValue("metadata", JSON.stringify(metadata));
+  writeGithubOutput({
+    should_log: "true",
+    rating: commandMatch[1].toLowerCase(),
+    command,
+    comment_id: event.comment.id,
+    comment_url: event.comment.html_url,
+    comment_author: event.comment.user?.login,
+    pr_number: event.issue.number,
+    pr_url: event.issue.html_url,
+  });
+}
+
+async function logFeedback() {
+  requireEnv("BRAINTRUST_API_KEY");
+  const braintrust = loadBraintrust();
+  const metadata = JSON.parse(requireEnv("BRAINTRUST_PR_METADATA"));
+  const rating = requireEnv("BT_RATING");
+  const score = rating === "good" ? 1 : 0;
+  const projectName = metadata.project;
+  const logger = braintrust.initLogger({ projectName });
+  const feedbackMetadata = workflowMetadata({
+    provider: metadata.provider,
+    rating,
+    feedback_source: "github_issue_comment",
+    feedback_command: optionalEnv("BT_COMMAND"),
+    feedback_comment_id: optionalEnv("BT_COMMENT_ID"),
+    feedback_comment_url: optionalEnv("BT_COMMENT_URL"),
+    feedback_author: optionalEnv("BT_COMMENT_AUTHOR"),
+    pr_number: optionalEnv("BT_PR_NUMBER"),
+    pr_url: optionalEnv("BT_PR_URL"),
+    target_root_span_id: metadata.root_span_id,
+    target_run_id: metadata.run_id,
+    target_run_attempt: metadata.run_attempt,
+  });
+
+  if (typeof logger.traced === "function") {
+    await logger.traced(
+      async (span) => {
+        span.log({
+          scores: {
+            github_pr_feedback: score,
+          },
+          comment: optionalEnv("BT_COMMENT_BODY"),
+          metadata: feedbackMetadata,
+        });
+      },
+      {
+        name: "github_pr_feedback",
+        parent: metadata.root_span_id,
+      },
+    );
+  } else {
+    logger.log({
+      id: `github-pr-feedback-${optionalEnv("BT_COMMENT_ID")}`,
+      input: {
+        command: optionalEnv("BT_COMMAND"),
+        pr_number: optionalEnv("BT_PR_NUMBER"),
+      },
+      output: {
+        rating,
+        target_root_span_id: metadata.root_span_id,
+      },
+      scores: {
+        github_pr_feedback: score,
+      },
+      metadata: feedbackMetadata,
+    });
+  }
+
+  await flushBraintrust(braintrust);
+}
+
+const command = process.argv[2];
+
+try {
+  if (command === "create-workflow-trace") {
+    await createWorkflowTrace();
+  } else if (command === "emit-pr-metadata") {
+    emitPrMetadata();
+  } else if (command === "extract-feedback-event") {
+    extractFeedbackEvent();
+  } else if (command === "log-feedback") {
+    await logFeedback();
+  } else {
+    throw new Error(
+      "Usage: braintrust-provider-types.mjs create-workflow-trace|emit-pr-metadata|extract-feedback-event|log-feedback",
+    );
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}

--- a/.github/workflows/provider-type-feedback.yml
+++ b/.github/workflows/provider-type-feedback.yml
@@ -1,0 +1,47 @@
+name: Provider type update feedback
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  log-feedback:
+    if: github.event.issue.pull_request
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+
+      - name: Parse feedback command
+        id: feedback
+        run: node .github/scripts/braintrust-provider-types.mjs extract-feedback-event
+
+      - name: Install Braintrust SDK
+        if: steps.feedback.outputs.should_log == 'true'
+        run: npm install -g braintrust
+
+      - name: Log feedback to Braintrust
+        if: steps.feedback.outputs.should_log == 'true'
+        env:
+          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+          BRAINTRUST_PR_METADATA: ${{ steps.feedback.outputs.metadata }}
+          BT_RATING: ${{ steps.feedback.outputs.rating }}
+          BT_COMMAND: ${{ steps.feedback.outputs.command }}
+          BT_COMMENT_ID: ${{ steps.feedback.outputs.comment_id }}
+          BT_COMMENT_URL: ${{ steps.feedback.outputs.comment_url }}
+          BT_COMMENT_AUTHOR: ${{ steps.feedback.outputs.comment_author }}
+          BT_PR_NUMBER: ${{ steps.feedback.outputs.pr_number }}
+          BT_PR_URL: ${{ steps.feedback.outputs.pr_url }}
+          BT_COMMENT_BODY: ${{ github.event.comment.body }}
+        run: NODE_PATH="$(npm root -g)" node .github/scripts/braintrust-provider-types.mjs log-feedback

--- a/.github/workflows/update-provider-types.yml
+++ b/.github/workflows/update-provider-types.yml
@@ -153,7 +153,7 @@ jobs:
                 "TRACE_TO_BRAINTRUST": "${{ steps.braintrust_trace.outputs.root_span_id != '' && 'true' || 'false' }}",
                 "BRAINTRUST_CC_PROJECT": "lingua-provider-type-updates",
                 "BRAINTRUST_API_KEY": "${{ secrets.BRAINTRUST_API_KEY }}",
-                "CC_PARENT_SPAN_ID": "${{ steps.braintrust_trace.outputs.root_span_id }}",
+                "CC_PARENT_SPAN_ID": "${{ steps.braintrust_trace.outputs.span_id }}",
                 "CC_ROOT_SPAN_ID": "${{ steps.braintrust_trace.outputs.root_span_id }}",
                 "BRAINTRUST_DEBUG": "false"
               }
@@ -260,7 +260,7 @@ jobs:
                 "TRACE_TO_BRAINTRUST": "${{ steps.braintrust_trace.outputs.root_span_id != '' && 'true' || 'false' }}",
                 "BRAINTRUST_CC_PROJECT": "lingua-provider-type-updates",
                 "BRAINTRUST_API_KEY": "${{ secrets.BRAINTRUST_API_KEY }}",
-                "CC_PARENT_SPAN_ID": "${{ steps.braintrust_trace.outputs.root_span_id }}",
+                "CC_PARENT_SPAN_ID": "${{ steps.braintrust_trace.outputs.span_id }}",
                 "CC_ROOT_SPAN_ID": "${{ steps.braintrust_trace.outputs.root_span_id }}",
                 "BRAINTRUST_DEBUG": "false"
               }
@@ -346,11 +346,12 @@ jobs:
         env:
           BRAINTRUST_PROJECT: lingua-provider-type-updates
           BRAINTRUST_ROOT_SPAN_ID: ${{ steps.braintrust_trace.outputs.root_span_id }}
+          BRAINTRUST_SPAN_ID: ${{ steps.braintrust_trace.outputs.span_id }}
           PROVIDER: ${{ matrix.provider }}
         run: |
           set -euo pipefail
           {
-            if [ -n "$BRAINTRUST_ROOT_SPAN_ID" ]; then
+            if [ -n "$BRAINTRUST_ROOT_SPAN_ID" ] && [ -n "$BRAINTRUST_SPAN_ID" ]; then
               NODE_PATH="$(npm root -g)" node .github/scripts/braintrust-provider-types.mjs emit-pr-metadata
               echo
             fi

--- a/.github/workflows/update-provider-types.yml
+++ b/.github/workflows/update-provider-types.yml
@@ -102,6 +102,17 @@ jobs:
           npm install -g braintrust || echo "::warning::Failed to install Braintrust SDK; parent trace setup will be skipped"
           pnpm add -g quicktype
 
+      - name: Create Braintrust workflow trace
+        id: braintrust_trace
+        continue-on-error: true
+        env:
+          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+          BRAINTRUST_PROJECT: lingua-provider-type-updates
+          PROVIDER: ${{ matrix.provider }}
+        run: |
+          set -euo pipefail
+          NODE_PATH="$(npm root -g)" node .github/scripts/braintrust-provider-types.mjs create-workflow-trace
+
       - name: Update provider specifications and types
         id: generate
         continue-on-error: true
@@ -122,83 +133,6 @@ jobs:
           echo "log_path=$log_path" >> "$GITHUB_OUTPUT"
           exit "$generate_status"
 
-      - name: Create Braintrust parent trace for repair
-        id: repair_trace
-        if: steps.generate.outcome == 'failure'
-        continue-on-error: true
-        env:
-          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-          BRAINTRUST_CC_PROJECT: lingua-provider-type-updates
-          PROVIDER: ${{ matrix.provider }}
-          TRACE_PHASE: repair failed generation
-        run: |
-          set -euo pipefail
-          NODE_PATH="$(npm root -g)" node --input-type=module <<'JS'
-          import { execFileSync } from "node:child_process";
-          import { createRequire } from "node:module";
-          import { appendFileSync } from "node:fs";
-
-          const require = createRequire(import.meta.url);
-          const { flush, initLogger } = require("braintrust");
-
-          function gitOutput(...args) {
-            try {
-              return execFileSync("git", args, {
-                encoding: "utf8",
-                stdio: ["ignore", "pipe", "pipe"],
-              });
-            } catch (error) {
-              return `${error.stdout ?? ""}${error.stderr ?? ""}`;
-            }
-          }
-
-          const provider = process.env.PROVIDER;
-          const phase = process.env.TRACE_PHASE;
-          const project = process.env.BRAINTRUST_CC_PROJECT;
-          const head = gitOutput("rev-parse", "HEAD").trim();
-          const status = gitOutput("status", "--short");
-          const diffStat = gitOutput("diff", "--stat");
-          const diffNames = gitOutput("diff", "--name-only");
-          const diff = gitOutput("diff", "--no-color", "--no-ext-diff");
-
-          const logger = initLogger({ projectName: project });
-          const span = logger.startSpan({
-            name: `Claude ${phase}: update ${provider} provider types`,
-          });
-
-          span.log({
-            input: {
-              provider,
-              phase,
-              head,
-              github_run_id: process.env.GITHUB_RUN_ID,
-              github_run_attempt: process.env.GITHUB_RUN_ATTEMPT,
-              github_workflow: process.env.GITHUB_WORKFLOW,
-              github_job: process.env.GITHUB_JOB,
-            },
-            output: {
-              git_status: status,
-              git_diff_stat: diffStat,
-              git_diff_names: diffNames,
-              git_diff: diff,
-            },
-            metadata: {
-              provider,
-              phase,
-              head,
-              repository: process.env.GITHUB_REPOSITORY,
-              ref: process.env.GITHUB_REF,
-              sha: process.env.GITHUB_SHA,
-            },
-          });
-
-          appendFileSync(process.env.GITHUB_OUTPUT, `parent_span_id=${span.spanId}\n`);
-          appendFileSync(process.env.GITHUB_OUTPUT, `root_span_id=${span.rootSpanId ?? span.spanId}\n`);
-
-          span.end();
-          await flush();
-          JS
-
       - name: Repair failed generation
         id: repair
         if: steps.generate.outcome == 'failure'
@@ -216,11 +150,11 @@ jobs:
           settings: |
             {
               "env": {
-                "TRACE_TO_BRAINTRUST": "true",
+                "TRACE_TO_BRAINTRUST": "${{ steps.braintrust_trace.outputs.root_span_id != '' && 'true' || 'false' }}",
                 "BRAINTRUST_CC_PROJECT": "lingua-provider-type-updates",
                 "BRAINTRUST_API_KEY": "${{ secrets.BRAINTRUST_API_KEY }}",
-                "CC_PARENT_SPAN_ID": "${{ steps.repair_trace.outputs.parent_span_id }}",
-                "CC_ROOT_SPAN_ID": "${{ steps.repair_trace.outputs.root_span_id }}",
+                "CC_PARENT_SPAN_ID": "${{ steps.braintrust_trace.outputs.root_span_id }}",
+                "CC_ROOT_SPAN_ID": "${{ steps.braintrust_trace.outputs.root_span_id }}",
                 "BRAINTRUST_DEBUG": "false"
               }
             }
@@ -306,83 +240,6 @@ jobs:
           echo "Changes detected:"
           git status --short
 
-      - name: Create Braintrust parent trace for integration review
-        id: integration_review_trace
-        if: steps.changes.outputs.has_changes == 'true'
-        continue-on-error: true
-        env:
-          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-          BRAINTRUST_CC_PROJECT: lingua-provider-type-updates
-          PROVIDER: ${{ matrix.provider }}
-          TRACE_PHASE: review generated provider integration
-        run: |
-          set -euo pipefail
-          NODE_PATH="$(npm root -g)" node --input-type=module <<'JS'
-          import { execFileSync } from "node:child_process";
-          import { createRequire } from "node:module";
-          import { appendFileSync } from "node:fs";
-
-          const require = createRequire(import.meta.url);
-          const { flush, initLogger } = require("braintrust");
-
-          function gitOutput(...args) {
-            try {
-              return execFileSync("git", args, {
-                encoding: "utf8",
-                stdio: ["ignore", "pipe", "pipe"],
-              });
-            } catch (error) {
-              return `${error.stdout ?? ""}${error.stderr ?? ""}`;
-            }
-          }
-
-          const provider = process.env.PROVIDER;
-          const phase = process.env.TRACE_PHASE;
-          const project = process.env.BRAINTRUST_CC_PROJECT;
-          const head = gitOutput("rev-parse", "HEAD").trim();
-          const status = gitOutput("status", "--short");
-          const diffStat = gitOutput("diff", "--stat");
-          const diffNames = gitOutput("diff", "--name-only");
-          const diff = gitOutput("diff", "--no-color", "--no-ext-diff");
-
-          const logger = initLogger({ projectName: project });
-          const span = logger.startSpan({
-            name: `Claude ${phase}: update ${provider} provider types`,
-          });
-
-          span.log({
-            input: {
-              provider,
-              phase,
-              head,
-              github_run_id: process.env.GITHUB_RUN_ID,
-              github_run_attempt: process.env.GITHUB_RUN_ATTEMPT,
-              github_workflow: process.env.GITHUB_WORKFLOW,
-              github_job: process.env.GITHUB_JOB,
-            },
-            output: {
-              git_status: status,
-              git_diff_stat: diffStat,
-              git_diff_names: diffNames,
-              git_diff: diff,
-            },
-            metadata: {
-              provider,
-              phase,
-              head,
-              repository: process.env.GITHUB_REPOSITORY,
-              ref: process.env.GITHUB_REF,
-              sha: process.env.GITHUB_SHA,
-            },
-          });
-
-          appendFileSync(process.env.GITHUB_OUTPUT, `parent_span_id=${span.spanId}\n`);
-          appendFileSync(process.env.GITHUB_OUTPUT, `root_span_id=${span.rootSpanId ?? span.spanId}\n`);
-
-          span.end();
-          await flush();
-          JS
-
       - name: Review generated provider integration
         id: integration_review
         if: steps.changes.outputs.has_changes == 'true'
@@ -400,11 +257,11 @@ jobs:
           settings: |
             {
               "env": {
-                "TRACE_TO_BRAINTRUST": "true",
+                "TRACE_TO_BRAINTRUST": "${{ steps.braintrust_trace.outputs.root_span_id != '' && 'true' || 'false' }}",
                 "BRAINTRUST_CC_PROJECT": "lingua-provider-type-updates",
                 "BRAINTRUST_API_KEY": "${{ secrets.BRAINTRUST_API_KEY }}",
-                "CC_PARENT_SPAN_ID": "${{ steps.integration_review_trace.outputs.parent_span_id }}",
-                "CC_ROOT_SPAN_ID": "${{ steps.integration_review_trace.outputs.root_span_id }}",
+                "CC_PARENT_SPAN_ID": "${{ steps.braintrust_trace.outputs.root_span_id }}",
+                "CC_ROOT_SPAN_ID": "${{ steps.braintrust_trace.outputs.root_span_id }}",
                 "BRAINTRUST_DEBUG": "false"
               }
             }
@@ -486,12 +343,22 @@ jobs:
 
       - name: Build PR body
         if: steps.changes.outputs.has_changes == 'true'
+        env:
+          BRAINTRUST_PROJECT: lingua-provider-type-updates
+          BRAINTRUST_ROOT_SPAN_ID: ${{ steps.braintrust_trace.outputs.root_span_id }}
+          PROVIDER: ${{ matrix.provider }}
         run: |
           set -euo pipefail
           {
+            if [ -n "$BRAINTRUST_ROOT_SPAN_ID" ]; then
+              NODE_PATH="$(npm root -g)" node .github/scripts/braintrust-provider-types.mjs emit-pr-metadata
+              echo
+            fi
             echo "Automated update of Lingua provider types."
             echo
             echo "Provider: \`${{ matrix.provider }}\`"
+            echo
+            echo "Feedback: comment \`/bt good\` or \`/bt bad\` to log review feedback to the Braintrust trace."
             echo
             echo "**Validation**"
             echo
@@ -501,10 +368,7 @@ jobs:
               echo "- Retry \`./pipelines/generate-provider-types.sh ${{ matrix.provider }}\`: ${{ steps.retry.outcome }}"
             fi
             echo "- \`make generate-types\`: ${{ steps.ts_types.outcome }}"
-            if [ "${{ steps.generate.outcome }}" = "failure" ]; then
-              echo "- Braintrust repair parent trace: ${{ steps.repair_trace.outcome }}"
-            fi
-            echo "- Braintrust integration-review parent trace: ${{ steps.integration_review_trace.outcome }}"
+            echo "- Braintrust workflow trace: ${{ steps.braintrust_trace.outcome }}"
             echo "- Claude integration review: ${{ steps.integration_review.outcome }}"
             echo "- Post-review \`make generate-types\`: ${{ steps.post_review_ts_types.outcome }}"
             echo "- \`cargo fmt --all\`: ${{ steps.fmt.outcome }}"
@@ -534,10 +398,8 @@ jobs:
         if: >-
           (
             (steps.generate.outcome == 'failure' && steps.retry.outcome != 'success') ||
-            steps.repair_trace.outcome == 'failure' ||
             steps.retry.outcome == 'failure' ||
             (steps.ts_types.outcome == 'failure' && steps.post_review_ts_types.outcome != 'success') ||
-            steps.integration_review_trace.outcome == 'failure' ||
             steps.integration_review.outcome == 'failure' ||
             steps.post_review_ts_types.outcome == 'failure' ||
             steps.fmt.outcome == 'failure' ||


### PR DESCRIPTION
Adds /bt good and /bt bad feedback for automated provider type update PRs.

Creates one Braintrust root trace per provider update workflow run
Passes that root span to both Claude repair/review invocations
Hides trace metadata in the generated PR body
Adds an issue_comment workflow that logs trusted /bt good|bad comments as child feedback spans in Braintrust
Includes reviewer, PR, comment, provider, and workflow metadata with each feedback event