### PR TITLE
Fix Responses-to-Anthropic streaming for tool-call turns

### DIFF
--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -57,6 +57,7 @@ pub struct StreamTransformSession {
     buffered_stop: Option<StreamOutputChunk>,
     anthropic_message_started: bool,
     anthropic_tool_use_started: bool,
+    anthropic_open_content_block_index: Option<u32>,
     bedrock_tool_call_indexes: BTreeMap<u32, u32>,
     next_bedrock_tool_call_index: u32,
 }
@@ -77,6 +78,7 @@ impl StreamTransformSession {
             buffered_stop: None,
             anthropic_message_started: false,
             anthropic_tool_use_started: false,
+            anthropic_open_content_block_index: None,
             bedrock_tool_call_indexes: BTreeMap::new(),
             next_bedrock_tool_call_index: 0,
         }
@@ -235,16 +237,34 @@ impl StreamTransformSession {
         let is_delta = chunk.event_type.as_deref() == Some("message_delta");
         let is_stop = chunk.event_type.as_deref() == Some("message_stop");
         let is_start = chunk.event_type.as_deref() == Some("message_start");
+        let is_content_block_start = chunk.event_type.as_deref() == Some("content_block_start");
+        let is_content_block_stop = chunk.event_type.as_deref() == Some("content_block_stop");
+        let content_block_start_index = content_block_index(&chunk);
         let is_tool_use_start = is_anthropic_tool_use_start(&chunk);
         let chunk = if is_delta && self.anthropic_tool_use_started {
             with_anthropic_tool_use_stop_reason(chunk)
         } else {
             chunk
         };
+        let mut prefix = Vec::new();
 
         if is_start {
             self.anthropic_message_started = true;
             self.anthropic_tool_use_started = false;
+            self.anthropic_open_content_block_index = None;
+        }
+        if (is_content_block_start || is_delta || is_stop)
+            && self.anthropic_open_content_block_index.is_some()
+        {
+            if let Some(index) = self.anthropic_open_content_block_index.take() {
+                prefix.push(anthropic_content_block_stop_chunk(index));
+            }
+        }
+        if is_content_block_start {
+            self.anthropic_open_content_block_index = content_block_start_index;
+        }
+        if is_content_block_stop {
+            self.anthropic_open_content_block_index = None;
         }
         if is_tool_use_start {
             self.anthropic_tool_use_started = true;
@@ -257,10 +277,12 @@ impl StreamTransformSession {
                     .unwrap_or_else(|| StreamOutputChunk::data(Bytes::new())),
                 chunk,
             );
-            let mut out = vec![merged];
+            let mut out = prefix;
+            out.push(merged);
             if let Some(stop) = self.buffered_stop.take() {
                 self.anthropic_message_started = false;
                 self.anthropic_tool_use_started = false;
+                self.anthropic_open_content_block_index = None;
                 out.push(stop);
             }
             return out;
@@ -268,20 +290,22 @@ impl StreamTransformSession {
 
         if is_delta {
             self.buffered_delta = Some(chunk);
-            return Vec::new();
+            return prefix;
         }
 
         if is_stop && self.buffered_delta.is_some() {
             self.buffered_stop = Some(chunk);
-            return Vec::new();
+            return prefix;
         }
 
         if is_stop {
             self.anthropic_message_started = false;
             self.anthropic_tool_use_started = false;
+            self.anthropic_open_content_block_index = None;
         }
 
-        let mut out = self.flush_buffered();
+        let mut out = prefix;
+        out.extend(self.flush_buffered());
         out.push(chunk);
         out
     }
@@ -294,10 +318,29 @@ impl StreamTransformSession {
         if let Some(stop) = self.buffered_stop.take() {
             self.anthropic_message_started = false;
             self.anthropic_tool_use_started = false;
+            self.anthropic_open_content_block_index = None;
             out.push(stop);
         }
         out
     }
+}
+
+fn content_block_index(chunk: &StreamOutputChunk) -> Option<u32> {
+    let data = crate::serde_json::from_slice::<Value>(&chunk.data).ok()?;
+    data.get("index")
+        .and_then(Value::as_u64)
+        .and_then(|index| u32::try_from(index).ok())
+}
+
+fn anthropic_content_block_stop_chunk(index: u32) -> StreamOutputChunk {
+    StreamOutputChunk::with_event(
+        serialize_stream_value(&crate::serde_json::json!({
+            "type": "content_block_stop",
+            "index": index
+        }))
+        .unwrap_or_else(|_| Bytes::new()),
+        "content_block_stop".to_string(),
+    )
 }
 
 fn is_anthropic_tool_use_start(chunk: &StreamOutputChunk) -> bool {
@@ -499,6 +542,10 @@ fn expand_anthropic_session_chunks(
             .is_none_or(|d| d.content.as_deref().is_none_or(str::is_empty));
 
     let mut out = Vec::new();
+
+    if is_initial_metadata && anthropic_message_started {
+        return out;
+    }
 
     if is_initial_metadata && !anthropic_message_started {
         if let Some(message_start) = chunks.first() {
@@ -921,6 +968,13 @@ mod tests {
                 }
             }
         }));
+        let in_progress = to_bytes(&json!({
+            "type": "response.in_progress",
+            "response": {
+                "id": "resp_123",
+                "model": "gpt-5.5-2026-04-23"
+            }
+        }));
         let tool_start = to_bytes(&json!({
             "type": "response.output_item.added",
             "output_index": 1,
@@ -951,16 +1005,19 @@ mod tests {
             vec![Some("message_start"), Some("content_block_start")]
         );
 
-        let second = session.push(tool_start).unwrap();
+        let second = session.push(in_progress).unwrap();
+        assert!(second.is_empty());
+
+        let third = session.push(tool_start).unwrap();
         assert_eq!(
-            second
+            third
                 .iter()
                 .map(|chunk| chunk.event_type.as_deref())
                 .collect::<Vec<_>>(),
-            vec![Some("content_block_start")]
+            vec![Some("content_block_stop"), Some("content_block_start")]
         );
 
-        let tool_block: Value = crate::serde_json::from_slice(&second[0].data).unwrap();
+        let tool_block: Value = crate::serde_json::from_slice(&third[1].data).unwrap();
         assert_eq!(
             tool_block
                 .get("content_block")
@@ -969,8 +1026,14 @@ mod tests {
             Some("tool_use")
         );
 
-        let third = session.push(completed).unwrap();
-        assert!(third.is_empty());
+        let fourth = session.push(completed).unwrap();
+        assert_eq!(
+            fourth
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_stop")]
+        );
 
         let final_chunks = session.finish();
         assert_eq!(

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -55,8 +55,17 @@ pub struct StreamTransformSession {
     allow_full_response_fallback: bool,
     buffered_delta: Option<StreamOutputChunk>,
     buffered_stop: Option<StreamOutputChunk>,
+    // Whether the target Anthropic stream has an open message. Some source
+    // providers emit repeated metadata chunks; only the first should become
+    // Anthropic `message_start`.
     anthropic_message_started: bool,
+    // Whether the open Anthropic message has emitted a `tool_use` block. OpenAI
+    // Responses may report a generic `stop`, but Anthropic clients need
+    // `stop_reason: "tool_use"` once a tool block appeared.
     anthropic_tool_use_started: bool,
+    // Anthropic streams require content blocks to be explicitly closed before a
+    // new block or the terminal message delta. Some source providers do not have
+    // an equivalent event, so the session synthesizes `content_block_stop`.
     anthropic_open_content_block_index: Option<u32>,
     bedrock_tool_call_indexes: BTreeMap<u32, u32>,
     next_bedrock_tool_call_index: u32,
@@ -234,6 +243,9 @@ impl StreamTransformSession {
     }
 
     fn process_anthropic_chunk(&mut self, chunk: StreamOutputChunk) -> Vec<StreamOutputChunk> {
+        // Enforce Anthropic event ordering after provider adapters have produced
+        // Anthropic-shaped chunks: one message_start, balanced content blocks,
+        // tool_use stop reasons, and merged finish/usage message_delta events.
         let is_delta = chunk.event_type.as_deref() == Some("message_delta");
         let is_stop = chunk.event_type.as_deref() == Some("message_stop");
         let is_start = chunk.event_type.as_deref() == Some("message_start");
@@ -599,10 +611,10 @@ fn expand_anthropic_session_chunks(
             .as_ref()
             .and_then(|d| d.content.as_deref())
             .filter(|s| !s.is_empty());
-        let is_full_anthropic_response =
-            source_format == ProviderFormat::Anthropic && !source_is_native_stream;
+        let needs_message_start = !anthropic_message_started
+            && (source_format != ProviderFormat::Anthropic || !source_is_native_stream);
 
-        if is_full_anthropic_response && !anthropic_message_started {
+        if needs_message_start {
             out.push(StreamOutputChunk::with_event(
                 anthropic_message_start_bytes(universal),
                 "message_start".to_string(),
@@ -630,7 +642,7 @@ fn expand_anthropic_session_chunks(
                 .unwrap_or_else(|_| Bytes::new()),
                 "content_block_delta".to_string(),
             ));
-            if is_full_anthropic_response && !anthropic_message_started {
+            if needs_message_start {
                 out.push(StreamOutputChunk::with_event(
                     serialize_stream_value(&crate::serde_json::json!({
                         "type": "content_block_stop",
@@ -824,7 +836,10 @@ mod tests {
             }
         }));
 
-        assert!(session.push(finish_delta).unwrap().is_empty());
+        let start = session.push(finish_delta).unwrap();
+        assert_eq!(start.len(), 1);
+        assert_eq!(start[0].event_type.as_deref(), Some("message_start"));
+
         let out = session.push(usage_delta).unwrap();
 
         assert_eq!(out.len(), 2);
@@ -852,7 +867,7 @@ mod tests {
     #[cfg(feature = "anthropic")]
     fn test_stream_session_flushes_buffered_anthropic_events_on_finish() {
         let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
-        assert!(session
+        let start = session
             .push(to_bytes(&json!({
                 "id": "chatcmpl-123",
                 "object": "chat.completion.chunk",
@@ -864,8 +879,9 @@ mod tests {
                     "finish_reason": "stop"
                 }]
             })))
-            .unwrap()
-            .is_empty());
+            .unwrap();
+        assert_eq!(start.len(), 1);
+        assert_eq!(start[0].event_type.as_deref(), Some("message_start"));
 
         let out = session.finish();
         assert_eq!(out.len(), 2);
@@ -1051,6 +1067,62 @@ mod tests {
                 .and_then(|delta| delta.get("stop_reason"))
                 .and_then(Value::as_str),
             Some("tool_use")
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "anthropic"))]
+    fn test_stream_session_google_final_text_chunk_opens_anthropic_message() {
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+        let final_text = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-3.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "text": "There are 100 projects."
+                    }]
+                },
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5,
+                "totalTokenCount": 15
+            }
+        }));
+
+        let out = session.push(final_text).unwrap();
+        assert_eq!(
+            out.iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("message_start"),
+                Some("content_block_start"),
+                Some("content_block_delta"),
+                Some("content_block_stop")
+            ]
+        );
+
+        let final_chunks = session.finish();
+        assert_eq!(
+            final_chunks
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("message_delta"), Some("message_stop")]
+        );
+
+        let message_delta: Value = crate::serde_json::from_slice(&final_chunks[0].data).unwrap();
+        assert_eq!(
+            message_delta
+                .get("delta")
+                .and_then(|delta| delta.get("stop_reason"))
+                .and_then(Value::as_str),
+            Some("end_turn")
         );
     }
 

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -56,6 +56,7 @@ pub struct StreamTransformSession {
     buffered_delta: Option<StreamOutputChunk>,
     buffered_stop: Option<StreamOutputChunk>,
     anthropic_message_started: bool,
+    anthropic_tool_use_started: bool,
     bedrock_tool_call_indexes: BTreeMap<u32, u32>,
     next_bedrock_tool_call_index: u32,
 }
@@ -75,6 +76,7 @@ impl StreamTransformSession {
             buffered_delta: None,
             buffered_stop: None,
             anthropic_message_started: false,
+            anthropic_tool_use_started: false,
             bedrock_tool_call_indexes: BTreeMap::new(),
             next_bedrock_tool_call_index: 0,
         }
@@ -233,9 +235,19 @@ impl StreamTransformSession {
         let is_delta = chunk.event_type.as_deref() == Some("message_delta");
         let is_stop = chunk.event_type.as_deref() == Some("message_stop");
         let is_start = chunk.event_type.as_deref() == Some("message_start");
+        let is_tool_use_start = is_anthropic_tool_use_start(&chunk);
+        let chunk = if is_delta && self.anthropic_tool_use_started {
+            with_anthropic_tool_use_stop_reason(chunk)
+        } else {
+            chunk
+        };
 
         if is_start {
             self.anthropic_message_started = true;
+            self.anthropic_tool_use_started = false;
+        }
+        if is_tool_use_start {
+            self.anthropic_tool_use_started = true;
         }
 
         if is_delta && self.buffered_delta.is_some() {
@@ -247,6 +259,8 @@ impl StreamTransformSession {
             );
             let mut out = vec![merged];
             if let Some(stop) = self.buffered_stop.take() {
+                self.anthropic_message_started = false;
+                self.anthropic_tool_use_started = false;
                 out.push(stop);
             }
             return out;
@@ -264,6 +278,7 @@ impl StreamTransformSession {
 
         if is_stop {
             self.anthropic_message_started = false;
+            self.anthropic_tool_use_started = false;
         }
 
         let mut out = self.flush_buffered();
@@ -278,9 +293,47 @@ impl StreamTransformSession {
         }
         if let Some(stop) = self.buffered_stop.take() {
             self.anthropic_message_started = false;
+            self.anthropic_tool_use_started = false;
             out.push(stop);
         }
         out
+    }
+}
+
+fn is_anthropic_tool_use_start(chunk: &StreamOutputChunk) -> bool {
+    if chunk.event_type.as_deref() != Some("content_block_start") {
+        return false;
+    }
+
+    let Ok(data) = crate::serde_json::from_slice::<Value>(&chunk.data) else {
+        return false;
+    };
+
+    data.get("content_block")
+        .and_then(|block| block.get("type"))
+        .and_then(Value::as_str)
+        == Some("tool_use")
+}
+
+fn with_anthropic_tool_use_stop_reason(chunk: StreamOutputChunk) -> StreamOutputChunk {
+    let Ok(mut data) = crate::serde_json::from_slice::<Value>(&chunk.data) else {
+        return chunk;
+    };
+
+    let Some(delta) = data.get_mut("delta").and_then(Value::as_object_mut) else {
+        return chunk;
+    };
+    let Some(stop_reason) = delta.get_mut("stop_reason") else {
+        return chunk;
+    };
+    if !matches!(stop_reason.as_str(), Some("end_turn" | "stop")) {
+        return chunk;
+    }
+
+    *stop_reason = Value::String("tool_use".to_string());
+    StreamOutputChunk {
+        data: serialize_stream_value(&data).unwrap_or(chunk.data),
+        event_type: chunk.event_type,
     }
 }
 
@@ -850,6 +903,92 @@ mod tests {
         let second = session.push(tool_args).unwrap();
         assert_eq!(second.len(), 1);
         assert_eq!(second[0].event_type.as_deref(), Some("content_block_delta"));
+    }
+
+    #[test]
+    #[cfg(all(feature = "openai", feature = "anthropic"))]
+    fn test_stream_session_responses_tool_call_after_metadata_does_not_repeat_message_start() {
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+
+        let created = to_bytes(&json!({
+            "type": "response.created",
+            "response": {
+                "id": "resp_123",
+                "model": "gpt-5.5-2026-04-23",
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0
+                }
+            }
+        }));
+        let tool_start = to_bytes(&json!({
+            "type": "response.output_item.added",
+            "output_index": 1,
+            "item": {
+                "type": "function_call",
+                "call_id": "call_123",
+                "name": "mcp__braintrust__list_recent_objects"
+            }
+        }));
+        let completed = to_bytes(&json!({
+            "type": "response.completed",
+            "response": {
+                "id": "resp_123",
+                "model": "gpt-5.5-2026-04-23",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 20
+                }
+            }
+        }));
+
+        let first = session.push(created).unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("message_start"), Some("content_block_start")]
+        );
+
+        let second = session.push(tool_start).unwrap();
+        assert_eq!(
+            second
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_start")]
+        );
+
+        let tool_block: Value = crate::serde_json::from_slice(&second[0].data).unwrap();
+        assert_eq!(
+            tool_block
+                .get("content_block")
+                .and_then(|block| block.get("type"))
+                .and_then(Value::as_str),
+            Some("tool_use")
+        );
+
+        let third = session.push(completed).unwrap();
+        assert!(third.is_empty());
+
+        let final_chunks = session.finish();
+        assert_eq!(
+            final_chunks
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("message_delta"), Some("message_stop")]
+        );
+
+        let message_delta: Value = crate::serde_json::from_slice(&final_chunks[0].data).unwrap();
+        assert_eq!(
+            message_delta
+                .get("delta")
+                .and_then(|delta| delta.get("stop_reason"))
+                .and_then(Value::as_str),
+            Some("tool_use")
+        );
     }
 
     #[test]

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -8,6 +8,7 @@ use crate::processing::transform::{
 };
 use crate::serde_json::Value;
 use crate::universal::UniversalStreamChunk;
+use serde::Deserialize;
 
 static EMPTY_JSON: Bytes = Bytes::from_static(b"{}");
 static SSE_DATA_PREFIX: &[u8] = b"data: ";
@@ -121,7 +122,7 @@ impl StreamTransformSession {
             step.source_is_native_stream,
             self.anthropic_message_started,
         )?;
-        Ok(self.process_chunks(chunks))
+        self.process_chunks(chunks)
     }
 
     fn normalize_bedrock_to_openai_stream_result(
@@ -226,23 +227,29 @@ impl StreamTransformSession {
         sse_done_marker(self.target_format)
     }
 
-    fn process_chunks(&mut self, chunks: Vec<StreamOutputChunk>) -> Vec<StreamOutputChunk> {
+    fn process_chunks(
+        &mut self,
+        chunks: Vec<StreamOutputChunk>,
+    ) -> Result<Vec<StreamOutputChunk>, TransformError> {
         // Anthropic currently needs stateful post-processing after universal -> provider
         // conversion: some inputs expand into multiple SSE events, and finish/usage data
         // may arrive as adjacent chunks that must be merged before emission. The adapter
         // boundary is still single-chunk and stateless, so that sequencing lives here.
         if self.target_format != ProviderFormat::Anthropic {
-            return chunks;
+            return Ok(chunks);
         }
 
         let mut out = Vec::new();
         for chunk in chunks {
-            out.extend(self.process_anthropic_chunk(chunk));
+            out.extend(self.process_anthropic_chunk(chunk)?);
         }
-        out
+        Ok(out)
     }
 
-    fn process_anthropic_chunk(&mut self, chunk: StreamOutputChunk) -> Vec<StreamOutputChunk> {
+    fn process_anthropic_chunk(
+        &mut self,
+        chunk: StreamOutputChunk,
+    ) -> Result<Vec<StreamOutputChunk>, TransformError> {
         // Enforce Anthropic event ordering after provider adapters have produced
         // Anthropic-shaped chunks: one message_start, balanced content blocks,
         // tool_use stop reasons, and merged finish/usage message_delta events.
@@ -251,8 +258,11 @@ impl StreamTransformSession {
         let is_start = chunk.event_type.as_deref() == Some("message_start");
         let is_content_block_start = chunk.event_type.as_deref() == Some("content_block_start");
         let is_content_block_stop = chunk.event_type.as_deref() == Some("content_block_stop");
-        let content_block_start_index = content_block_index(&chunk);
-        let is_tool_use_start = is_anthropic_tool_use_start(&chunk);
+        let content_block_start = parse_anthropic_content_block_start_event(&chunk)?;
+        let content_block_start_index = content_block_start.as_ref().map(|event| event.index);
+        let is_tool_use_start = content_block_start
+            .as_ref()
+            .is_some_and(AnthropicContentBlockStartEventView::is_tool_use_start);
         let chunk = if is_delta && self.anthropic_tool_use_started {
             with_anthropic_tool_use_stop_reason(chunk)
         } else {
@@ -297,17 +307,17 @@ impl StreamTransformSession {
                 self.anthropic_open_content_block_index = None;
                 out.push(stop);
             }
-            return out;
+            return Ok(out);
         }
 
         if is_delta {
             self.buffered_delta = Some(chunk);
-            return prefix;
+            return Ok(prefix);
         }
 
         if is_stop && self.buffered_delta.is_some() {
             self.buffered_stop = Some(chunk);
-            return prefix;
+            return Ok(prefix);
         }
 
         if is_stop {
@@ -319,7 +329,7 @@ impl StreamTransformSession {
         let mut out = prefix;
         out.extend(self.flush_buffered());
         out.push(chunk);
-        out
+        Ok(out)
     }
 
     fn flush_buffered(&mut self) -> Vec<StreamOutputChunk> {
@@ -337,11 +347,50 @@ impl StreamTransformSession {
     }
 }
 
-fn content_block_index(chunk: &StreamOutputChunk) -> Option<u32> {
-    let data = crate::serde_json::from_slice::<Value>(&chunk.data).ok()?;
-    data.get("index")
-        .and_then(Value::as_u64)
-        .and_then(|index| u32::try_from(index).ok())
+#[derive(Debug, Deserialize)]
+struct AnthropicContentBlockStartEventView {
+    #[serde(rename = "type")]
+    _event_type: AnthropicStreamEventTypeView,
+    index: u32,
+    content_block: Option<AnthropicContentBlockView>,
+}
+
+impl AnthropicContentBlockStartEventView {
+    fn is_tool_use_start(&self) -> bool {
+        self.content_block
+            .as_ref()
+            .and_then(|block| block.block_type.as_deref())
+            == Some("tool_use")
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum AnthropicStreamEventTypeView {
+    ContentBlockStart,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicContentBlockView {
+    #[serde(rename = "type")]
+    block_type: Option<String>,
+}
+
+fn parse_anthropic_content_block_start_event(
+    chunk: &StreamOutputChunk,
+) -> Result<Option<AnthropicContentBlockStartEventView>, TransformError> {
+    if chunk.event_type.as_deref() != Some("content_block_start") {
+        return Ok(None);
+    }
+
+    crate::serde_json::from_slice::<AnthropicContentBlockStartEventView>(&chunk.data)
+        .map(Some)
+        .map_err(|e| {
+            TransformError::DeserializationFailed(format!(
+                "Anthropic content_block_start event: {}",
+                e
+            ))
+        })
 }
 
 fn anthropic_content_block_stop_chunk(index: u32) -> StreamOutputChunk {
@@ -353,21 +402,6 @@ fn anthropic_content_block_stop_chunk(index: u32) -> StreamOutputChunk {
         .unwrap_or_else(|_| Bytes::new()),
         "content_block_stop".to_string(),
     )
-}
-
-fn is_anthropic_tool_use_start(chunk: &StreamOutputChunk) -> bool {
-    if chunk.event_type.as_deref() != Some("content_block_start") {
-        return false;
-    }
-
-    let Ok(data) = crate::serde_json::from_slice::<Value>(&chunk.data) else {
-        return false;
-    };
-
-    data.get("content_block")
-        .and_then(|block| block.get("type"))
-        .and_then(Value::as_str)
-        == Some("tool_use")
 }
 
 fn with_anthropic_tool_use_stop_reason(chunk: StreamOutputChunk) -> StreamOutputChunk {
@@ -805,6 +839,27 @@ mod tests {
 
     fn to_bytes(value: &Value) -> Bytes {
         Bytes::from(crate::serde_json::to_vec(value).unwrap())
+    }
+
+    #[test]
+    #[cfg(feature = "anthropic")]
+    fn test_anthropic_content_block_start_requires_typed_index() {
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+        let malformed_start = StreamOutputChunk::with_event(
+            to_bytes(&json!({
+                "type": "content_block_start",
+                "content_block": {
+                    "type": "text",
+                    "text": ""
+                }
+            })),
+            "content_block_start".to_string(),
+        );
+
+        let err = session.process_chunks(vec![malformed_start]).unwrap_err();
+        assert!(matches!(err, TransformError::DeserializationFailed(_)));
+        assert!(err.to_string().contains("Anthropic content_block_start"));
+        assert!(err.to_string().contains("missing field `index`"));
     }
 
     #[test]

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -439,7 +439,7 @@ export const paramsCases: TestCaseCollection = {
           ],
         },
       ],
-    } as unknown as OpenAI.Responses.ResponseCreateParams,
+    },
     anthropic: null,
     google: null,
     bedrock: null,

--- a/payloads/package.json
+++ b/payloads/package.json
@@ -36,7 +36,7 @@
     "@google/adk": "1.1.0",
     "@google/genai": "1.51.0",
     "ai": "^6.0.116",
-    "openai": "^6.16.0"
+    "openai": "^6.42.0"
   },
   "devDependencies": {
     "@types/node": "^22.9.0",

--- a/payloads/scripts/providers/openai-responses.ts
+++ b/payloads/scripts/providers/openai-responses.ts
@@ -8,6 +8,7 @@ import {
 } from "../../cases";
 import {
   ResponseInputItem,
+  ResponseOutputItem,
   ResponseStreamEvent,
 } from "openai/resources/responses/responses";
 
@@ -39,6 +40,39 @@ type ParallelResponseResult =
       stream: false;
       data: OpenAI.Responses.Response;
     };
+
+type ReplayableResponseOutputItem = Extract<
+  ResponseOutputItem,
+  ResponseInputItem
+>;
+
+function isReplayableResponseOutputItem(
+  item: ResponseOutputItem
+): item is ReplayableResponseOutputItem {
+  switch (item.type) {
+    case "message":
+    case "file_search_call":
+    case "computer_call":
+    case "web_search_call":
+    case "function_call":
+    case "reasoning":
+    case "code_interpreter_call":
+    case "local_shell_call":
+    case "local_shell_call_output":
+    case "shell_call":
+    case "shell_call_output":
+    case "apply_patch_call":
+    case "apply_patch_call_output":
+    case "mcp_list_tools":
+    case "mcp_approval_request":
+    case "mcp_approval_response":
+    case "mcp_call":
+    case "custom_tool_call":
+      return true;
+    default:
+      return false;
+  }
+}
 
 export async function executeOpenAIResponses(
   caseName: string,
@@ -138,6 +172,10 @@ export async function executeOpenAIResponses(
 
       console.log(`📝 Creating followup request for ${caseName}...`);
 
+      const replayableAssistantOutput = assistantOutput.filter(
+        isReplayableResponseOutputItem
+      );
+
       // Build follow-up input, handling tool calls
       const followUpInput: ResponseInputItem[] = [
         ...(Array.isArray(payload.input)
@@ -150,7 +188,7 @@ export async function executeOpenAIResponses(
                 },
               ]
             : []),
-        ...assistantOutput,
+        ...replayableAssistantOutput,
       ];
 
       // Check if the assistant output contains tool calls and add tool responses

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -409,6 +409,9 @@ data: {"delta":{"text":" context","type":"text_delta"},"index":0,"type":"content
 event: content_block_delta
 data: {"delta":{"text":".","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+
 event: message_delta
 data: {"delta":{"stop_reason":"end_turn"},"type":"message_delta","usage":{"cache_read_input_tokens":0,"input_tokens":158,"output_tokens":1423}}
 
@@ -425,6 +428,9 @@ data: {"message":{"content":[],"id":"chatcmpl-DmKoKHtVYgdxqBqvTor9wW6MsS9pY","mo
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
 
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"cache_read_input_tokens":0,"input_tokens":51,"output_tokens":16}}
 
@@ -440,6 +446,9 @@ data: {"message":{"content":[],"id":"chatcmpl-Dp4RF3MuIGYlGOoQIJBvJ6q7UDIo9","mo
 
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
 
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"cache_read_input_tokens":0,"input_tokens":176,"output_tokens":1024}}
@@ -2410,6 +2419,9 @@ data: {"delta":{"text":" each","type":"text_delta"},"index":0,"type":"content_bl
 event: content_block_delta
 data: {"delta":{"text":".","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+
 event: message_delta
 data: {"delta":{"stop_reason":"end_turn"},"type":"message_delta","usage":{"output_tokens":0}}
 
@@ -2425,6 +2437,9 @@ data: {"message":{"content":[],"id":"chatcmpl-DQJks6CVOvWns8GNiynFRRn4ehgOp","mo
 
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
 
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"output_tokens":0}}
@@ -2588,6 +2603,9 @@ data: {"delta":{"text":" well","type":"text_delta"},"index":0,"type":"content_bl
 
 event: content_block_delta
 data: {"delta":{"text":".","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
 
 event: message_delta
 data: {"delta":{"stop_reason":"end_turn"},"type":"message_delta","usage":{"output_tokens":0}}
@@ -3013,6 +3031,9 @@ data: {"delta":{"text":" mph","type":"text_delta"},"index":0,"type":"content_blo
 event: content_block_delta
 data: {"delta":{"text":")","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+
 event: message_delta
 data: {"delta":{"stop_reason":"end_turn"},"type":"message_delta","usage":{"output_tokens":0}}
 
@@ -3028,6 +3049,9 @@ data: {"message":{"content":[],"id":"chatcmpl-DQJkrNrNugghqC0hWDiKrEWQqNEAl","mo
 
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
 
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"output_tokens":0}}
@@ -3291,6 +3315,9 @@ data: {"delta":{"text":" it","type":"text_delta"},"index":0,"type":"content_bloc
 event: content_block_delta
 data: {"delta":{"text":".","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+
 event: message_delta
 data: {"delta":{"stop_reason":"end_turn"},"type":"message_delta","usage":{"output_tokens":0}}
 
@@ -3340,6 +3367,9 @@ data: {"delta":{"text":" city","type":"text_delta"},"index":0,"type":"content_bl
 event: content_block_delta
 data: {"delta":{"text":"?","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+
 event: message_delta
 data: {"delta":{"stop_reason":"end_turn"},"type":"message_delta","usage":{"output_tokens":0}}
 
@@ -3356,6 +3386,9 @@ data: {"message":{"content":[],"id":"chatcmpl-DSQdxzW4LeTU2buaGgT2o0rexbRw2","mo
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
 
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"cache_read_input_tokens":0,"input_tokens":15,"output_tokens":16}}
 
@@ -3371,6 +3404,9 @@ data: {"message":{"content":[],"id":"chatcmpl-DQJkv4fvJmyemAFjFO7Exu2n0aL8u","mo
 
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
 
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"output_tokens":0}}
@@ -3411,6 +3447,9 @@ data: {"delta":{"partial_json":" CA","type":"input_json_delta"},"index":0,"type"
 
 event: content_block_delta
 data: {"delta":{"partial_json":"\\"}","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
 
 event: message_delta
 data: {"delta":{"stop_reason":"tool_use"},"type":"message_delta","usage":{"cache_read_input_tokens":0,"input_tokens":148,"output_tokens":218}}

--- a/payloads/scripts/transforms/transforms-streaming-invariants.test.ts
+++ b/payloads/scripts/transforms/transforms-streaming-invariants.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect } from "vitest";
+import { readFileSync } from "fs";
+import {
+  STREAMING_PAIRS,
+  flattenStreamChunks,
+  getFixtureSkipReason,
+  getStreamingTransformableCases,
+  getStreamingResponsePath,
+} from "./helpers";
+import { registerSkippedFixtureTest } from "./vitest-helpers";
+
+interface StreamChunk {
+  eventType?: string;
+  data: unknown;
+}
+
+interface AnthropicEventData {
+  index?: number;
+}
+
+function eventData(chunk: StreamChunk): AnthropicEventData {
+  if (typeof chunk.data !== "object" || chunk.data === null) {
+    return {};
+  }
+
+  return chunk.data;
+}
+
+function assertAnthropicStreamInvariants(chunks: StreamChunk[]): void {
+  let messageStarted = false;
+  let openBlockIndex: number | undefined;
+  let sawAnthropicEvent = false;
+
+  for (const [i, chunk] of chunks.entries()) {
+    const eventType = chunk.eventType;
+    const data = eventData(chunk);
+
+    if (eventType === "message_start") {
+      sawAnthropicEvent = true;
+      expect(messageStarted, `duplicate message_start at chunk ${i}`).toBe(
+        false
+      );
+      messageStarted = true;
+      expect(
+        openBlockIndex,
+        `message_start while block is open at chunk ${i}`
+      ).toBeUndefined();
+      continue;
+    }
+
+    if (eventType === "content_block_start") {
+      sawAnthropicEvent = true;
+      expect(
+        messageStarted,
+        `content_block_start before message_start at chunk ${i}`
+      ).toBe(true);
+      expect(
+        openBlockIndex,
+        `content_block_start while block ${openBlockIndex} is open at chunk ${i}`
+      ).toBeUndefined();
+      expect(
+        data.index,
+        `content_block_start missing index at chunk ${i}`
+      ).toEqual(expect.any(Number));
+      openBlockIndex = data.index;
+      continue;
+    }
+
+    if (eventType === "content_block_delta") {
+      sawAnthropicEvent = true;
+      expect(
+        openBlockIndex,
+        `content_block_delta without open block at chunk ${i}`
+      ).toEqual(expect.any(Number));
+      expect(
+        data.index,
+        `content_block_delta index mismatch at chunk ${i}`
+      ).toBe(openBlockIndex);
+      continue;
+    }
+
+    if (eventType === "content_block_stop") {
+      sawAnthropicEvent = true;
+      expect(
+        openBlockIndex,
+        `content_block_stop without open block at chunk ${i}`
+      ).toEqual(expect.any(Number));
+      expect(
+        data.index,
+        `content_block_stop index mismatch at chunk ${i}`
+      ).toBe(openBlockIndex);
+      openBlockIndex = undefined;
+      continue;
+    }
+
+    if (eventType === "message_delta") {
+      sawAnthropicEvent = true;
+      expect(
+        messageStarted,
+        `message_delta before message_start at chunk ${i}`
+      ).toBe(true);
+      expect(
+        openBlockIndex,
+        `message_delta while block is open at chunk ${i}`
+      ).toBeUndefined();
+      continue;
+    }
+
+    if (eventType === "message_stop") {
+      sawAnthropicEvent = true;
+      expect(
+        messageStarted,
+        `message_stop before message_start at chunk ${i}`
+      ).toBe(true);
+      expect(
+        openBlockIndex,
+        `message_stop while block is open at chunk ${i}`
+      ).toBeUndefined();
+      messageStarted = false;
+      continue;
+    }
+  }
+
+  expect(sawAnthropicEvent, "expected Anthropic stream events").toBe(true);
+  expect(
+    openBlockIndex,
+    "stream ended while content block is open"
+  ).toBeUndefined();
+}
+
+for (const pair of STREAMING_PAIRS) {
+  if (pair.wasmSource !== "Anthropic") {
+    continue;
+  }
+
+  describe(`streaming invariants: ${pair.source} -> ${pair.target}`, () => {
+    const cases = getStreamingTransformableCases(pair);
+
+    for (const caseName of cases) {
+      const streamingPath = getStreamingResponsePath(
+        pair.source,
+        pair.target,
+        caseName
+      );
+      const pairLabel = `${pair.source} -> ${pair.target}`;
+      const skipReason = getFixtureSkipReason(streamingPath, {
+        streaming: true,
+      });
+
+      if (skipReason) {
+        registerSkippedFixtureTest(pairLabel, caseName, skipReason);
+        continue;
+      }
+
+      test(caseName, () => {
+        const rawChunks = JSON.parse(readFileSync(streamingPath, "utf-8"));
+        const chunks = flattenStreamChunks(rawChunks, pair.wasmSource);
+        assertAnthropicStreamInvariants(chunks);
+      });
+    }
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: ^6.0.116
         version: 6.0.116(zod@4.3.6)
       openai:
-        specifier: ^6.16.0
-        version: 6.16.0(ws@8.20.1)(zod@4.3.6)
+        specifier: ^6.42.0
+        version: 6.42.0(ws@8.20.1)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^22.9.0
@@ -3025,6 +3025,17 @@ packages:
   openai@6.16.0:
     resolution: {integrity: sha512-fZ1uBqjFUjXzbGc35fFtYKEOxd20kd9fDpFeqWtsOZWiubY8CZ1NAlXHW3iathaFvqmNtCWMIsosCuyeI7Joxg==}
     hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openai@6.42.0:
+    resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
     peerDependencies:
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
@@ -7065,6 +7076,11 @@ snapshots:
       wsl-utils: 0.1.0
 
   openai@6.16.0(ws@8.20.1)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.1
+      zod: 4.3.6
+
+  openai@6.42.0(ws@8.20.1)(zod@4.3.6):
     optionalDependencies:
       ws: 8.20.1
       zod: 4.3.6


### PR DESCRIPTION
  ## Summary

  Fix Responses-to-Anthropic streaming semantics for tool-call turns. main PR -> https://github.com/braintrustdata/braintrust/pull/15605

  ## Problem

  Responses-originated streams could produce Anthropic-shaped tool calls but still terminate the message with
  stop_reason: "end_turn"/"stop". Native Anthropic tool-call streams terminate with stop_reason: "tool_use", and
  clients such as Claude Code use that signal to continue into tool execution.