### PR TITLE
Expose message_dedup_hash for source-aware deduplication

### DIFF
--- a/crates/lingua/src/processing/dedup.rs
+++ b/crates/lingua/src/processing/dedup.rs
@@ -9,6 +9,16 @@ use std::hash::{Hash, Hasher};
 #[cfg(test)]
 use crate::serde_json;
 
+/// Stable deduplication key for a message based on its role and normalized content.
+///
+/// Two messages that [`deduplicate_messages`] would treat as duplicates share the same
+/// key. Exposed so callers can implement source-aware deduplication (for example,
+/// preferring an LLM-derived copy of a message over a wrapper-span copy) while staying
+/// consistent with [`deduplicate_messages`].
+pub fn message_dedup_hash(msg: &Message) -> u64 {
+    hash_message(msg)
+}
+
 /// Computes a hash for a message based on its role and content.
 /// This is used for deduplication - messages with the same hash are considered duplicates.
 fn hash_message(msg: &Message) -> u64 {

--- a/crates/lingua/src/processing/mod.rs
+++ b/crates/lingua/src/processing/mod.rs
@@ -9,7 +9,7 @@ pub use adapters::{
     adapter_for_format, adapters, collect_extras, insert_opt_bool, insert_opt_f64, insert_opt_i64,
     insert_opt_string, insert_opt_value, ProviderAdapter,
 };
-pub use dedup::deduplicate_messages;
+pub use dedup::{deduplicate_messages, message_dedup_hash};
 pub use import::{import_and_deduplicate_messages, import_messages_from_spans, Span};
 pub use json_repair::normalize_json_lone_surrogate_escapes;
 pub use stream::{


### PR DESCRIPTION
Make the message deduplication key public so callers can build source-aware dedup (e.g. preferring an LLM-derived copy of a message over a wrapper-span copy) while staying consistent with deduplicate_messages.

LLM calls
```
// wrapper span (untyped, starts first) — just re-emits the final answer
{ "metrics": {"start": 10}, "output": "final answer" }

// LLM span (starts later) — the real conversation, also ending in "final answer"
{ "metrics": {"start": 11}, "type": "llm",
  "input":  [ {"role":"user","content":"hi"} ],
  "output": {"role":"assistant","content":"final answer"} }
```

final output (ordering)

```
// ❌ without source-aware dedup
[ {"role":"assistant","content":"final answer"},   // hoisted to the top!
  {"role":"user","content":"hi"} ]

// ✅ keeping the LLM-derived copy
[ {"role":"user","content":"hi"},
  {"role":"assistant","content":"final answer"} ]
```
