### PR TITLE
Add TTL cache + cache exclusion handling

### DIFF
--- a/crates/coverage-report/src/expected.rs
+++ b/crates/coverage-report/src/expected.rs
@@ -267,6 +267,50 @@ mod tests {
     // =========================================================================
 
     #[test]
+    fn anthropic_ttl_fields_are_not_expected_losses_for_anthropic_response_roundtrip() {
+        assert_eq!(
+            is_expected_field(
+                TestCategory::Responses,
+                "Anthropic",
+                "Anthropic",
+                Some("simpleRequest"),
+                "usage.prompt_cache_creation_5m_tokens",
+            ),
+            None
+        );
+        assert_eq!(
+            is_expected_field(
+                TestCategory::Responses,
+                "Anthropic",
+                "Anthropic",
+                Some("simpleRequest"),
+                "usage.prompt_tokens_exclude_cache",
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn anthropic_ttl_fields_are_expected_losses_for_openai_style_response_targets() {
+        assert!(is_expected_field(
+            TestCategory::Responses,
+            "Anthropic",
+            "ChatCompletions",
+            Some("simpleRequest"),
+            "usage.prompt_cache_creation_5m_tokens",
+        )
+        .is_some());
+        assert!(is_expected_field(
+            TestCategory::Responses,
+            "Anthropic",
+            "Responses",
+            Some("simpleRequest"),
+            "usage.prompt_tokens_exclude_cache",
+        )
+        .is_some());
+    }
+
+    #[test]
     fn test_test_case_exact_match() {
         assert!(is_expected_test_case(
             TestCategory::Requests,

--- a/crates/coverage-report/src/responses_expected_differences.json
+++ b/crates/coverage-report/src/responses_expected_differences.json
@@ -41,14 +41,43 @@
       "source": "Anthropic",
       "target": "*",
       "fields": [
-        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic reports cache creation tokens" }
+        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic reports cache creation tokens" },
+        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic reports split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic reports split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic usage reports prompt tokens exclusive of cache buckets; other providers do not expose this semantic flag" }
+      ]
+    },
+    {
+      "source": "Bedrock Anthropic",
+      "target": "*",
+      "fields": [
+        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Bedrock Anthropic usage follows Anthropic-style exclusive prompt-token semantics; other providers do not expose this semantic flag" }
+      ]
+    },
+    {
+      "source": "Vertex Anthropic",
+      "target": "*",
+      "fields": [
+        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Vertex Anthropic usage follows Anthropic-style exclusive prompt-token semantics; other providers do not expose this semantic flag" }
       ]
     },
     {
       "source": "*",
       "target": "Anthropic",
       "fields": [
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic usage follows exclusive prompt-token semantics; other providers do not expose this semantic flag" },
         { "pattern": "usage.completion_reasoning_tokens", "reason": "Anthropic doesn't expose reasoning tokens separately (included in output_tokens)" }
+      ]
+    },
+    {
+      "source": "*",
+      "target": "Vertex Anthropic",
+      "fields": [
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Vertex Anthropic usage follows exclusive prompt-token semantics; other providers do not expose this semantic flag" }
       ]
     },
     {

--- a/crates/coverage-report/src/responses_expected_differences.json
+++ b/crates/coverage-report/src/responses_expected_differences.json
@@ -81,6 +81,7 @@
       "source": "Responses",
       "target": "Anthropic",
       "fields": [
+        { "pattern": "usage.prompt_tokens", "reason": "Anthropic-style usage reports input_tokens exclusive of cache buckets, while Responses usage reports inclusive prompt totals" },
         { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style usage follows exclusive prompt-token semantics; Responses does not expose this semantic flag" },
         { "pattern": "usage.completion_reasoning_tokens", "reason": "Anthropic-style providers don't expose reasoning tokens separately (included in output_tokens)" }
       ]
@@ -89,6 +90,7 @@
       "source": "ChatCompletions",
       "target": "Anthropic",
       "fields": [
+        { "pattern": "usage.prompt_tokens", "reason": "Anthropic-style usage reports input_tokens exclusive of cache buckets, while ChatCompletions usage reports inclusive prompt totals" },
         { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style usage follows exclusive prompt-token semantics; ChatCompletions does not expose this semantic flag" },
         { "pattern": "usage.completion_reasoning_tokens", "reason": "Anthropic-style providers don't expose reasoning tokens separately (included in output_tokens)" }
       ]

--- a/crates/coverage-report/src/responses_expected_differences.json
+++ b/crates/coverage-report/src/responses_expected_differences.json
@@ -39,45 +39,74 @@
     },
     {
       "source": "Anthropic",
-      "target": "*",
+      "target": "Responses",
       "fields": [
-        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic reports cache creation tokens" },
-        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic reports split cache creation TTL buckets" },
-        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic reports split cache creation TTL buckets" },
-        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic usage reports prompt tokens exclusive of cache buckets; other providers do not expose this semantic flag" }
-      ]
-    },
-    {
-      "source": "Bedrock Anthropic",
-      "target": "*",
-      "fields": [
+        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic-style providers report cache creation tokens" },
         { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
         { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
-        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Bedrock Anthropic usage follows Anthropic-style exclusive prompt-token semantics; other providers do not expose this semantic flag" }
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style usage reports prompt tokens exclusive of cache buckets; Responses does not expose this semantic flag" }
       ]
     },
     {
-      "source": "Vertex Anthropic",
-      "target": "*",
+      "source": "Anthropic",
+      "target": "ChatCompletions",
       "fields": [
+        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic-style providers report cache creation tokens" },
         { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
         { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
-        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Vertex Anthropic usage follows Anthropic-style exclusive prompt-token semantics; other providers do not expose this semantic flag" }
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style usage reports prompt tokens exclusive of cache buckets; ChatCompletions does not expose this semantic flag" }
       ]
     },
     {
-      "source": "*",
+      "source": "Anthropic",
+      "target": "Google",
+      "fields": [
+        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic-style providers report cache creation tokens" },
+        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style usage reports prompt tokens exclusive of cache buckets; Google does not expose this semantic flag" }
+      ]
+    },
+    {
+      "source": "Anthropic",
+      "target": "Bedrock",
+      "fields": [
+        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic-style providers report cache creation tokens" },
+        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style usage reports prompt tokens exclusive of cache buckets; Bedrock Converse does not expose this semantic flag" }
+      ]
+    },
+    {
+      "source": "Responses",
       "target": "Anthropic",
       "fields": [
-        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic usage follows exclusive prompt-token semantics; other providers do not expose this semantic flag" },
-        { "pattern": "usage.completion_reasoning_tokens", "reason": "Anthropic doesn't expose reasoning tokens separately (included in output_tokens)" }
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style usage follows exclusive prompt-token semantics; Responses does not expose this semantic flag" },
+        { "pattern": "usage.completion_reasoning_tokens", "reason": "Anthropic-style providers don't expose reasoning tokens separately (included in output_tokens)" }
       ]
     },
     {
-      "source": "*",
-      "target": "Vertex Anthropic",
+      "source": "ChatCompletions",
+      "target": "Anthropic",
       "fields": [
-        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Vertex Anthropic usage follows exclusive prompt-token semantics; other providers do not expose this semantic flag" }
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style usage follows exclusive prompt-token semantics; ChatCompletions does not expose this semantic flag" },
+        { "pattern": "usage.completion_reasoning_tokens", "reason": "Anthropic-style providers don't expose reasoning tokens separately (included in output_tokens)" }
+      ]
+    },
+    {
+      "source": "Google",
+      "target": "Anthropic",
+      "fields": [
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style usage follows exclusive prompt-token semantics; Google does not expose this semantic flag" },
+        { "pattern": "usage.completion_reasoning_tokens", "reason": "Anthropic-style providers don't expose reasoning tokens separately (included in output_tokens)" }
+      ]
+    },
+    {
+      "source": "Bedrock",
+      "target": "Anthropic",
+      "fields": [
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style usage follows exclusive prompt-token semantics; Bedrock Converse does not expose this semantic flag" },
+        { "pattern": "usage.completion_reasoning_tokens", "reason": "Anthropic-style providers don't expose reasoning tokens separately (included in output_tokens)" }
       ]
     },
     {

--- a/crates/coverage-report/src/responses_expected_differences.json
+++ b/crates/coverage-report/src/responses_expected_differences.json
@@ -96,6 +96,27 @@
       ]
     },
     {
+      "source": "Anthropic",
+      "target": "Responses",
+      "fields": [
+        { "pattern": "usage.prompt_tokens", "reason": "Responses usage reports OpenAI-style inclusive prompt totals, while Anthropic reports input_tokens exclusive of cache buckets" }
+      ]
+    },
+    {
+      "source": "Anthropic",
+      "target": "ChatCompletions",
+      "fields": [
+        { "pattern": "usage.prompt_tokens", "reason": "ChatCompletions usage reports OpenAI-style inclusive prompt totals, while Anthropic reports input_tokens exclusive of cache buckets" }
+      ]
+    },
+    {
+      "source": "Anthropic",
+      "target": "Google",
+      "fields": [
+        { "pattern": "usage.prompt_tokens", "reason": "Google promptTokenCount uses inclusive prompt totals, while Anthropic reports input_tokens exclusive of cache buckets" }
+      ]
+    },
+    {
       "source": "Responses",
       "target": "ChatCompletions",
       "fields": [

--- a/crates/coverage-report/src/streaming_expected_differences.json
+++ b/crates/coverage-report/src/streaming_expected_differences.json
@@ -36,6 +36,27 @@
       ]
     },
     {
+      "source": "Anthropic",
+      "target": "Responses",
+      "fields": [
+        { "pattern": "usage.prompt_tokens", "reason": "Responses streaming usage reports OpenAI-style inclusive prompt totals, while Anthropic reports input_tokens exclusive of cache buckets" }
+      ]
+    },
+    {
+      "source": "Anthropic",
+      "target": "ChatCompletions",
+      "fields": [
+        { "pattern": "usage.prompt_tokens", "reason": "ChatCompletions streaming usage reports OpenAI-style inclusive prompt totals, while Anthropic reports input_tokens exclusive of cache buckets" }
+      ]
+    },
+    {
+      "source": "Anthropic",
+      "target": "Google",
+      "fields": [
+        { "pattern": "usage.prompt_tokens", "reason": "Google promptTokenCount uses inclusive prompt totals, while Anthropic reports input_tokens exclusive of cache buckets" }
+      ]
+    },
+    {
       "source": "Responses",
       "target": "*",
       "fields": [

--- a/crates/coverage-report/src/streaming_expected_differences.json
+++ b/crates/coverage-report/src/streaming_expected_differences.json
@@ -29,7 +29,10 @@
       "source": "Anthropic",
       "target": "*",
       "fields": [
-        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic reports cache creation tokens" }
+        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic reports cache creation tokens" },
+        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic reports split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic reports split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic streaming usage reports prompt tokens exclusive of cache buckets; other providers do not expose this semantic flag" }
       ]
     },
     {
@@ -73,7 +76,8 @@
       "source": "Bedrock Anthropic",
       "target": "*",
       "fields": [
-        { "pattern": "usage.prompt_tokens", "reason": "Bedrock Anthropic message_delta only has output_tokens; prompt_tokens=0 added during roundtrip" }
+        { "pattern": "usage.prompt_tokens", "reason": "Bedrock Anthropic message_delta only has output_tokens; prompt_tokens=0 added during roundtrip" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Bedrock Anthropic usage follows Anthropic-style exclusive prompt-token semantics; other providers do not expose this semantic flag" }
       ]
     },
     {

--- a/crates/coverage-report/src/streaming_expected_differences.json
+++ b/crates/coverage-report/src/streaming_expected_differences.json
@@ -27,12 +27,42 @@
     },
     {
       "source": "Anthropic",
-      "target": "*",
+      "target": "Responses",
       "fields": [
-        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic reports cache creation tokens" },
-        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic reports split cache creation TTL buckets" },
-        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic reports split cache creation TTL buckets" },
-        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic streaming usage reports prompt tokens exclusive of cache buckets; other providers do not expose this semantic flag" }
+        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic-style providers report cache creation tokens" },
+        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style streaming usage reports prompt tokens exclusive of cache buckets; Responses does not expose this semantic flag" }
+      ]
+    },
+    {
+      "source": "Anthropic",
+      "target": "ChatCompletions",
+      "fields": [
+        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic-style providers report cache creation tokens" },
+        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style streaming usage reports prompt tokens exclusive of cache buckets; ChatCompletions does not expose this semantic flag" }
+      ]
+    },
+    {
+      "source": "Anthropic",
+      "target": "Google",
+      "fields": [
+        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic-style providers report cache creation tokens" },
+        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style streaming usage reports prompt tokens exclusive of cache buckets; Google does not expose this semantic flag" }
+      ]
+    },
+    {
+      "source": "Anthropic",
+      "target": "Bedrock",
+      "fields": [
+        { "pattern": "usage.prompt_cache_creation_tokens", "reason": "Only Anthropic-style providers report cache creation tokens" },
+        { "pattern": "usage.prompt_cache_creation_5m_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_cache_creation_1h_tokens", "reason": "Only Anthropic-style providers report split cache creation TTL buckets" },
+        { "pattern": "usage.prompt_tokens_exclude_cache", "reason": "Anthropic-style streaming usage reports prompt tokens exclusive of cache buckets; Bedrock Converse does not expose this semantic flag" }
       ]
     },
     {

--- a/crates/lingua/src/providers/bedrock_anthropic/adapter.rs
+++ b/crates/lingua/src/providers/bedrock_anthropic/adapter.rs
@@ -154,6 +154,11 @@ fn usage_from_bedrock_invocation_metrics(payload: &Value) -> Option<UniversalUsa
         completion_tokens: metrics.get("outputTokenCount").and_then(Value::as_i64),
         prompt_cached_tokens: None,
         prompt_cache_creation_tokens: None,
+        prompt_cache_creation_5m_tokens: None,
+        prompt_cache_creation_1h_tokens: None,
+        // Anthropic-style token counting excludes cache tokens (none are
+        // reported here, so this is for semantic consistency only)
+        prompt_tokens_exclude_cache: true,
         completion_reasoning_tokens: None,
     })
 }

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -1371,9 +1371,7 @@ mod tests {
             Some(UniversalUsage {
                 prompt_tokens: Some(1),
                 completion_tokens: Some(2),
-                prompt_cached_tokens: None,
-                prompt_cache_creation_tokens: None,
-                completion_reasoning_tokens: None,
+                ..Default::default()
             }),
         );
 

--- a/crates/lingua/src/providers/google/convert.rs
+++ b/crates/lingua/src/providers/google/convert.rs
@@ -1253,16 +1253,17 @@ impl From<&UsageMetadata> for UniversalUsage {
 
 impl From<&UniversalUsage> for UsageMetadata {
     fn from(usage: &UniversalUsage) -> Self {
+        let prompt = usage.inclusive_prompt_tokens();
         let completion = usage.completion_tokens.unwrap_or(0);
         let reasoning = usage.completion_reasoning_tokens.unwrap_or(0);
 
         Self {
-            prompt_token_count: usage.prompt_tokens,
+            prompt_token_count: prompt,
             // Google's candidatesTokenCount excludes thoughts, so subtract reasoning
             candidates_token_count: Some((completion - reasoning).max(0)),
             cached_content_token_count: usage.prompt_cached_tokens,
             thoughts_token_count: usage.completion_reasoning_tokens,
-            total_token_count: Some(usage.prompt_tokens.unwrap_or(0) + completion),
+            total_token_count: Some(prompt.unwrap_or(0) + completion),
             ..Default::default()
         }
     }
@@ -1294,6 +1295,24 @@ mod tests {
         property_ordering: Option<Vec<String>>,
         #[serde(default)]
         properties: std::collections::HashMap<String, JsonSchemaPropertyView>,
+    }
+
+    #[test]
+    fn test_google_usage_metadata_uses_inclusive_prompt_tokens() {
+        let usage = UniversalUsage {
+            prompt_tokens: Some(10),
+            completion_tokens: Some(5),
+            prompt_cached_tokens: Some(20),
+            prompt_cache_creation_tokens: Some(30),
+            prompt_tokens_exclude_cache: true,
+            ..Default::default()
+        };
+
+        let metadata = UsageMetadata::from(&usage);
+        assert_eq!(metadata.prompt_token_count, Some(60));
+        assert_eq!(metadata.candidates_token_count, Some(5));
+        assert_eq!(metadata.cached_content_token_count, Some(20));
+        assert_eq!(metadata.total_token_count, Some(65));
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/convert.rs
+++ b/crates/lingua/src/providers/google/convert.rs
@@ -1242,6 +1242,10 @@ impl From<&UsageMetadata> for UniversalUsage {
             completion_tokens: Some(candidates + thoughts),
             prompt_cached_tokens: usage.cached_content_token_count,
             prompt_cache_creation_tokens: None,
+            prompt_cache_creation_5m_tokens: None,
+            prompt_cache_creation_1h_tokens: None,
+            // Google's promptTokenCount includes cachedContentTokenCount
+            prompt_tokens_exclude_cache: false,
             completion_reasoning_tokens: usage.thoughts_token_count,
         }
     }

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -63,7 +63,9 @@ pub struct UniversalUsage {
     /// tokens, while OpenAI-style usage reports `prompt_tokens` inclusive of
     /// them. Consumers that want an OpenAI-style inclusive prompt total must
     /// add the cache buckets back when this is set; see
-    /// [`UniversalUsage::inclusive_prompt_tokens`].
+    /// [`UniversalUsage::inclusive_prompt_tokens`]. Consumers that want an
+    /// Anthropic-style exclusive input count must subtract the cache buckets
+    /// when this is not set; see [`UniversalUsage::exclusive_prompt_tokens`].
     pub prompt_tokens_exclude_cache: bool,
 
     /// Reasoning/thinking tokens used in the completion.
@@ -474,17 +476,7 @@ impl UniversalUsage {
         if !self.prompt_tokens_exclude_cache {
             return self.prompt_tokens;
         }
-        let prompt_cache_creation_tokens = self.prompt_cache_creation_tokens.or_else(|| {
-            if self.prompt_cache_creation_5m_tokens.is_none()
-                && self.prompt_cache_creation_1h_tokens.is_none()
-            {
-                return None;
-            }
-            Some(
-                self.prompt_cache_creation_5m_tokens.unwrap_or(0)
-                    + self.prompt_cache_creation_1h_tokens.unwrap_or(0),
-            )
-        });
+        let prompt_cache_creation_tokens = self.prompt_cache_creation_tokens_for_prompt_math();
         if self.prompt_tokens.is_none()
             && self.prompt_cached_tokens.is_none()
             && prompt_cache_creation_tokens.is_none()
@@ -495,6 +487,35 @@ impl UniversalUsage {
             self.prompt_tokens.unwrap_or(0)
                 + self.prompt_cached_tokens.unwrap_or(0)
                 + prompt_cache_creation_tokens.unwrap_or(0),
+        )
+    }
+
+    fn prompt_cache_creation_tokens_for_prompt_math(&self) -> Option<i64> {
+        self.prompt_cache_creation_tokens.or_else(|| {
+            if self.prompt_cache_creation_5m_tokens.is_none()
+                && self.prompt_cache_creation_1h_tokens.is_none()
+            {
+                return None;
+            }
+            Some(
+                self.prompt_cache_creation_5m_tokens.unwrap_or(0)
+                    + self.prompt_cache_creation_1h_tokens.unwrap_or(0),
+            )
+        })
+    }
+
+    pub fn exclusive_prompt_tokens(&self) -> Option<i64> {
+        if self.prompt_tokens_exclude_cache {
+            return self.prompt_tokens;
+        }
+        let prompt_tokens = self.prompt_tokens?;
+        Some(
+            (prompt_tokens
+                - self.prompt_cached_tokens.unwrap_or(0)
+                - self
+                    .prompt_cache_creation_tokens_for_prompt_math()
+                    .unwrap_or(0))
+            .max(0),
         )
     }
 
@@ -570,7 +591,7 @@ impl UniversalUsage {
             | ProviderFormat::BedrockAnthropic
             | ProviderFormat::VertexAnthropic => {
                 let mut map = serde_json::Map::new();
-                if let Some(p) = self.prompt_tokens {
+                if let Some(p) = self.exclusive_prompt_tokens() {
                     map.insert("input_tokens".into(), serde_json::json!(p));
                 }
                 if let Some(c) = self.completion_tokens {
@@ -773,6 +794,24 @@ mod tests {
         assert_eq!(anthropic["output_tokens"], 5);
         assert_eq!(anthropic["cache_read_input_tokens"], 20);
         assert_eq!(anthropic["cache_creation_input_tokens"], 30);
+    }
+
+    #[test]
+    fn test_inclusive_usage_serializes_exclusive_prompt_tokens_for_anthropic_formats() {
+        let usage = UniversalUsage {
+            prompt_tokens: Some(60),
+            completion_tokens: Some(5),
+            prompt_cached_tokens: Some(20),
+            prompt_cache_creation_tokens: Some(10),
+            prompt_tokens_exclude_cache: false,
+            ..Default::default()
+        };
+
+        let anthropic = usage.to_provider_value(ProviderFormat::Anthropic);
+        assert_eq!(anthropic["input_tokens"], 30);
+        assert_eq!(anthropic["output_tokens"], 5);
+        assert_eq!(anthropic["cache_read_input_tokens"], 20);
+        assert_eq!(anthropic["cache_creation_input_tokens"], 10);
     }
 
     #[test]

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -526,20 +526,17 @@ impl UniversalUsage {
                 if self.prompt_cache_creation_5m_tokens.is_some()
                     || self.prompt_cache_creation_1h_tokens.is_some()
                 {
-                    let mut cache_creation = serde_json::Map::new();
-                    if let Some(cache_creation_5m) = self.prompt_cache_creation_5m_tokens {
-                        cache_creation.insert(
-                            "ephemeral_5m_input_tokens".into(),
-                            serde_json::json!(cache_creation_5m),
-                        );
-                    }
-                    if let Some(cache_creation_1h) = self.prompt_cache_creation_1h_tokens {
-                        cache_creation.insert(
-                            "ephemeral_1h_input_tokens".into(),
-                            serde_json::json!(cache_creation_1h),
-                        );
-                    }
-                    map.insert("cache_creation".into(), Value::Object(cache_creation));
+                    map.insert(
+                        "cache_creation".into(),
+                        serde_json::json!({
+                            "ephemeral_5m_input_tokens": self
+                                .prompt_cache_creation_5m_tokens
+                                .unwrap_or(0),
+                            "ephemeral_1h_input_tokens": self
+                                .prompt_cache_creation_1h_tokens
+                                .unwrap_or(0),
+                        }),
+                    );
                 }
 
                 if let Some(cache_read) = self.prompt_cached_tokens {

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -313,6 +313,25 @@ impl UniversalResponse {
     }
 }
 
+#[derive(Default, Deserialize)]
+struct AnthropicUsageView {
+    input_tokens: Option<i64>,
+    output_tokens: Option<i64>,
+    cache_read_input_tokens: Option<i64>,
+    cache_creation_input_tokens: Option<i64>,
+    cache_creation: Option<AnthropicCacheCreationView>,
+}
+
+#[derive(Default, Deserialize)]
+struct AnthropicCacheCreationView {
+    ephemeral_5m_input_tokens: Option<i64>,
+    ephemeral_1h_input_tokens: Option<i64>,
+}
+
+fn anthropic_usage_view(usage: &Value) -> AnthropicUsageView {
+    serde_json::from_value::<AnthropicUsageView>(usage.clone()).unwrap_or_default()
+}
+
 impl UniversalUsage {
     /// Parse usage from provider-specific JSON value.
     ///
@@ -367,25 +386,21 @@ impl UniversalUsage {
             },
             ProviderFormat::Anthropic
             | ProviderFormat::BedrockAnthropic
-            | ProviderFormat::VertexAnthropic => Self {
-                prompt_tokens: usage.get("input_tokens").and_then(Value::as_i64),
-                completion_tokens: usage.get("output_tokens").and_then(Value::as_i64),
-                prompt_cached_tokens: usage.get("cache_read_input_tokens").and_then(Value::as_i64),
-                prompt_cache_creation_tokens: usage
-                    .get("cache_creation_input_tokens")
-                    .and_then(Value::as_i64),
-                prompt_cache_creation_5m_tokens: usage
-                    .get("cache_creation")
-                    .and_then(|c| c.get("ephemeral_5m_input_tokens"))
-                    .and_then(Value::as_i64),
-                prompt_cache_creation_1h_tokens: usage
-                    .get("cache_creation")
-                    .and_then(|c| c.get("ephemeral_1h_input_tokens"))
-                    .and_then(Value::as_i64),
-                // Anthropic's input_tokens excludes cache read/creation tokens
-                prompt_tokens_exclude_cache: true,
-                completion_reasoning_tokens: None, // Anthropic doesn't expose thinking tokens separately
-            },
+            | ProviderFormat::VertexAnthropic => {
+                let usage = anthropic_usage_view(usage);
+                let cache_creation = usage.cache_creation.unwrap_or_default();
+                Self {
+                    prompt_tokens: usage.input_tokens,
+                    completion_tokens: usage.output_tokens,
+                    prompt_cached_tokens: usage.cache_read_input_tokens,
+                    prompt_cache_creation_tokens: usage.cache_creation_input_tokens,
+                    prompt_cache_creation_5m_tokens: cache_creation.ephemeral_5m_input_tokens,
+                    prompt_cache_creation_1h_tokens: cache_creation.ephemeral_1h_input_tokens,
+                    // Anthropic's input_tokens excludes cache read/creation tokens
+                    prompt_tokens_exclude_cache: true,
+                    completion_reasoning_tokens: None, // Anthropic doesn't expose thinking tokens separately
+                }
+            }
             ProviderFormat::Converse => Self {
                 prompt_tokens: usage.get("inputTokens").and_then(Value::as_i64),
                 completion_tokens: usage.get("outputTokens").and_then(Value::as_i64),
@@ -507,6 +522,24 @@ impl UniversalUsage {
                         "cache_creation_input_tokens".into(),
                         serde_json::json!(cache_creation),
                     );
+                }
+                if self.prompt_cache_creation_5m_tokens.is_some()
+                    || self.prompt_cache_creation_1h_tokens.is_some()
+                {
+                    let mut cache_creation = serde_json::Map::new();
+                    if let Some(cache_creation_5m) = self.prompt_cache_creation_5m_tokens {
+                        cache_creation.insert(
+                            "ephemeral_5m_input_tokens".into(),
+                            serde_json::json!(cache_creation_5m),
+                        );
+                    }
+                    if let Some(cache_creation_1h) = self.prompt_cache_creation_1h_tokens {
+                        cache_creation.insert(
+                            "ephemeral_1h_input_tokens".into(),
+                            serde_json::json!(cache_creation_1h),
+                        );
+                    }
+                    map.insert("cache_creation".into(), Value::Object(cache_creation));
                 }
 
                 if let Some(cache_read) = self.prompt_cached_tokens {

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -52,6 +52,20 @@ pub struct UniversalUsage {
     /// Tokens written to cache during this request
     pub prompt_cache_creation_tokens: Option<i64>,
 
+    /// Tokens written to the 5-minute-TTL cache (Anthropic split cache writes)
+    pub prompt_cache_creation_5m_tokens: Option<i64>,
+
+    /// Tokens written to the 1-hour-TTL cache (Anthropic split cache writes)
+    pub prompt_cache_creation_1h_tokens: Option<i64>,
+
+    /// True when `prompt_tokens` excludes the cache read/creation buckets.
+    /// Anthropic-style usage reports `input_tokens` exclusive of cache
+    /// tokens, while OpenAI-style usage reports `prompt_tokens` inclusive of
+    /// them. Consumers that want an OpenAI-style inclusive prompt total must
+    /// add the cache buckets back when this is set; see
+    /// [`UniversalUsage::inclusive_prompt_tokens`].
+    pub prompt_tokens_exclude_cache: bool,
+
     /// Reasoning/thinking tokens used in the completion.
     /// `Some(n)` only when `n > 0`; otherwise `None`.
     pub completion_reasoning_tokens: Option<i64>,
@@ -320,6 +334,10 @@ impl UniversalUsage {
                         .and_then(|d| d.get("cached_tokens"))
                         .and_then(Value::as_i64),
                     prompt_cache_creation_tokens: None, // OpenAI doesn't report cache creation tokens
+                    prompt_cache_creation_5m_tokens: None,
+                    prompt_cache_creation_1h_tokens: None,
+                    // OpenAI's prompt_tokens already includes cached tokens
+                    prompt_tokens_exclude_cache: false,
                     // Treat 0 as None: 0 reasoning tokens means "no reasoning" = semantically None
                     completion_reasoning_tokens: usage
                         .get("completion_tokens_details")
@@ -336,6 +354,10 @@ impl UniversalUsage {
                     .and_then(|d| d.get("cached_tokens"))
                     .and_then(Value::as_i64),
                 prompt_cache_creation_tokens: None,
+                prompt_cache_creation_5m_tokens: None,
+                prompt_cache_creation_1h_tokens: None,
+                // OpenAI's input_tokens already includes cached tokens
+                prompt_tokens_exclude_cache: false,
                 // Treat 0 as None: 0 reasoning tokens means "no reasoning" = semantically None
                 completion_reasoning_tokens: usage
                     .get("output_tokens_details")
@@ -352,6 +374,16 @@ impl UniversalUsage {
                 prompt_cache_creation_tokens: usage
                     .get("cache_creation_input_tokens")
                     .and_then(Value::as_i64),
+                prompt_cache_creation_5m_tokens: usage
+                    .get("cache_creation")
+                    .and_then(|c| c.get("ephemeral_5m_input_tokens"))
+                    .and_then(Value::as_i64),
+                prompt_cache_creation_1h_tokens: usage
+                    .get("cache_creation")
+                    .and_then(|c| c.get("ephemeral_1h_input_tokens"))
+                    .and_then(Value::as_i64),
+                // Anthropic's input_tokens excludes cache read/creation tokens
+                prompt_tokens_exclude_cache: true,
                 completion_reasoning_tokens: None, // Anthropic doesn't expose thinking tokens separately
             },
             ProviderFormat::Converse => Self {
@@ -361,10 +393,36 @@ impl UniversalUsage {
                 prompt_cache_creation_tokens: usage
                     .get("cacheWriteInputTokens")
                     .and_then(Value::as_i64),
+                prompt_cache_creation_5m_tokens: None,
+                prompt_cache_creation_1h_tokens: None,
+                // Converse's inputTokens excludes cache read/write tokens
+                prompt_tokens_exclude_cache: true,
                 completion_reasoning_tokens: None, // Bedrock doesn't expose thinking tokens separately
             },
             ProviderFormat::Google => unreachable!("Google usage is handled via typed From trait"),
         }
+    }
+
+    /// Prompt tokens following the OpenAI convention of including cache
+    /// read/creation tokens. For providers that report prompt tokens
+    /// exclusive of the cache buckets (Anthropic, Converse), the cache
+    /// tokens are added back. Returns `None` when no prompt-side counts are
+    /// present at all.
+    pub fn inclusive_prompt_tokens(&self) -> Option<i64> {
+        if !self.prompt_tokens_exclude_cache {
+            return self.prompt_tokens;
+        }
+        if self.prompt_tokens.is_none()
+            && self.prompt_cached_tokens.is_none()
+            && self.prompt_cache_creation_tokens.is_none()
+        {
+            return None;
+        }
+        Some(
+            self.prompt_tokens.unwrap_or(0)
+                + self.prompt_cached_tokens.unwrap_or(0)
+                + self.prompt_cache_creation_tokens.unwrap_or(0),
+        )
     }
 
     /// Extract usage from a response payload, handling provider-specific key names.

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -315,21 +315,49 @@ impl UniversalResponse {
 
 #[derive(Default, Deserialize)]
 struct AnthropicUsageView {
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
     input_tokens: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
     output_tokens: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
     cache_read_input_tokens: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
     cache_creation_input_tokens: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_optional_cache_creation")]
     cache_creation: Option<AnthropicCacheCreationView>,
 }
 
 #[derive(Default, Deserialize)]
 struct AnthropicCacheCreationView {
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
     ephemeral_5m_input_tokens: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
     ephemeral_1h_input_tokens: Option<i64>,
 }
 
+fn deserialize_optional_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|value| value.as_i64()))
+}
+
+fn deserialize_optional_cache_creation<'de, D>(
+    deserializer: D,
+) -> Result<Option<AnthropicCacheCreationView>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|value| serde_json::from_value(value).ok()))
+}
+
 fn anthropic_usage_view(usage: &Value) -> AnthropicUsageView {
-    serde_json::from_value::<AnthropicUsageView>(usage.clone()).unwrap_or_default()
+    match serde_json::from_value::<AnthropicUsageView>(usage.clone()) {
+        Ok(view) => view,
+        Err(_) => AnthropicUsageView::default(),
+    }
 }
 
 impl UniversalUsage {

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -376,10 +376,7 @@ where
 }
 
 fn anthropic_usage_view(usage: &Value) -> AnthropicUsageView {
-    match serde_json::from_value::<AnthropicUsageView>(usage.clone()) {
-        Ok(view) => view,
-        Err(_) => AnthropicUsageView::default(),
-    }
+    serde_json::from_value::<AnthropicUsageView>(usage.clone()).unwrap_or_default()
 }
 
 impl UniversalUsage {

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -474,16 +474,27 @@ impl UniversalUsage {
         if !self.prompt_tokens_exclude_cache {
             return self.prompt_tokens;
         }
+        let prompt_cache_creation_tokens = self.prompt_cache_creation_tokens.or_else(|| {
+            if self.prompt_cache_creation_5m_tokens.is_none()
+                && self.prompt_cache_creation_1h_tokens.is_none()
+            {
+                return None;
+            }
+            Some(
+                self.prompt_cache_creation_5m_tokens.unwrap_or(0)
+                    + self.prompt_cache_creation_1h_tokens.unwrap_or(0),
+            )
+        });
         if self.prompt_tokens.is_none()
             && self.prompt_cached_tokens.is_none()
-            && self.prompt_cache_creation_tokens.is_none()
+            && prompt_cache_creation_tokens.is_none()
         {
             return None;
         }
         Some(
             self.prompt_tokens.unwrap_or(0)
                 + self.prompt_cached_tokens.unwrap_or(0)
-                + self.prompt_cache_creation_tokens.unwrap_or(0),
+                + prompt_cache_creation_tokens.unwrap_or(0),
         )
     }
 
@@ -730,6 +741,20 @@ mod tests {
         assert_eq!(responses["input_tokens"], 60);
         assert_eq!(responses["output_tokens"], 5);
         assert_eq!(responses["total_tokens"], 65);
+    }
+
+    #[test]
+    fn test_inclusive_prompt_tokens_uses_split_ttl_when_aggregate_missing() {
+        let usage = UniversalUsage {
+            prompt_tokens: Some(10),
+            prompt_cached_tokens: Some(20),
+            prompt_cache_creation_5m_tokens: Some(30),
+            prompt_cache_creation_1h_tokens: Some(40),
+            prompt_tokens_exclude_cache: true,
+            ..Default::default()
+        };
+
+        assert_eq!(usage.inclusive_prompt_tokens(), Some(100));
     }
 
     #[test]

--- a/crates/lingua/src/universal/response.rs
+++ b/crates/lingua/src/universal/response.rs
@@ -335,12 +335,30 @@ struct AnthropicCacheCreationView {
     ephemeral_1h_input_tokens: Option<i64>,
 }
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum OptionalI64View {
+    Integer(i64),
+    Other(serde::de::IgnoredAny),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum OptionalCacheCreationView {
+    CacheCreation(AnthropicCacheCreationView),
+    Other(serde::de::IgnoredAny),
+}
+
 fn deserialize_optional_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let value = Option::<Value>::deserialize(deserializer)?;
-    Ok(value.and_then(|value| value.as_i64()))
+    Ok(
+        match Option::<OptionalI64View>::deserialize(deserializer)? {
+            Some(OptionalI64View::Integer(value)) => Some(value),
+            Some(OptionalI64View::Other(_)) | None => None,
+        },
+    )
 }
 
 fn deserialize_optional_cache_creation<'de, D>(
@@ -349,8 +367,12 @@ fn deserialize_optional_cache_creation<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
-    let value = Option::<Value>::deserialize(deserializer)?;
-    Ok(value.and_then(|value| serde_json::from_value(value).ok()))
+    Ok(
+        match Option::<OptionalCacheCreationView>::deserialize(deserializer)? {
+            Some(OptionalCacheCreationView::CacheCreation(value)) => Some(value),
+            Some(OptionalCacheCreationView::Other(_)) | None => None,
+        },
+    )
 }
 
 fn anthropic_usage_view(usage: &Value) -> AnthropicUsageView {
@@ -481,7 +503,9 @@ impl UniversalUsage {
     ///
     /// Returns a JSON object with provider-specific field names.
     pub fn to_provider_value(&self, provider: ProviderFormat) -> Value {
-        let prompt = self.prompt_tokens.unwrap_or(0);
+        let inclusive_prompt = self.inclusive_prompt_tokens();
+        let prompt = inclusive_prompt.unwrap_or(0);
+        let provider_prompt = self.prompt_tokens.unwrap_or(0);
         let completion = self.completion_tokens.unwrap_or(0);
 
         match provider {
@@ -577,20 +601,20 @@ impl UniversalUsage {
                 Value::Object(map)
             }
             ProviderFormat::Converse => serde_json::json!({
-                "inputTokens": prompt,
+                "inputTokens": provider_prompt,
                 "outputTokens": completion
             }),
             ProviderFormat::Google => {
                 let mut map = serde_json::Map::new();
 
-                if let Some(p) = self.prompt_tokens {
+                if let Some(p) = inclusive_prompt {
                     map.insert("promptTokenCount".into(), serde_json::json!(p));
                 }
                 if let Some(c) = self.completion_tokens {
                     map.insert("candidatesTokenCount".into(), serde_json::json!(c));
                 }
 
-                if self.prompt_tokens.is_some() || self.completion_tokens.is_some() {
+                if inclusive_prompt.is_some() || self.completion_tokens.is_some() {
                     map.insert(
                         "totalTokenCount".into(),
                         serde_json::json!(prompt + completion),
@@ -687,5 +711,78 @@ mod tests {
                 "expected {reason} to map to ContentFilter"
             );
         }
+    }
+
+    #[test]
+    fn test_exclusive_usage_serializes_inclusive_prompt_tokens_for_openai_formats() {
+        let usage = UniversalUsage {
+            prompt_tokens: Some(10),
+            completion_tokens: Some(5),
+            prompt_cached_tokens: Some(20),
+            prompt_cache_creation_tokens: Some(30),
+            prompt_tokens_exclude_cache: true,
+            ..Default::default()
+        };
+
+        let chat = usage.to_provider_value(ProviderFormat::ChatCompletions);
+        assert_eq!(chat["prompt_tokens"], 60);
+        assert_eq!(chat["completion_tokens"], 5);
+        assert_eq!(chat["total_tokens"], 65);
+
+        let responses = usage.to_provider_value(ProviderFormat::Responses);
+        assert_eq!(responses["input_tokens"], 60);
+        assert_eq!(responses["output_tokens"], 5);
+        assert_eq!(responses["total_tokens"], 65);
+    }
+
+    #[test]
+    fn test_exclusive_usage_stays_exclusive_for_anthropic_formats() {
+        let usage = UniversalUsage {
+            prompt_tokens: Some(10),
+            completion_tokens: Some(5),
+            prompt_cached_tokens: Some(20),
+            prompt_cache_creation_tokens: Some(30),
+            prompt_tokens_exclude_cache: true,
+            ..Default::default()
+        };
+
+        let anthropic = usage.to_provider_value(ProviderFormat::Anthropic);
+        assert_eq!(anthropic["input_tokens"], 10);
+        assert_eq!(anthropic["output_tokens"], 5);
+        assert_eq!(anthropic["cache_read_input_tokens"], 20);
+        assert_eq!(anthropic["cache_creation_input_tokens"], 30);
+    }
+
+    #[test]
+    fn test_anthropic_cache_creation_serializes_both_ttl_buckets() {
+        let usage = UniversalUsage {
+            prompt_tokens: Some(10),
+            prompt_cache_creation_5m_tokens: Some(20),
+            prompt_tokens_exclude_cache: true,
+            ..Default::default()
+        };
+
+        let anthropic = usage.to_provider_value(ProviderFormat::Anthropic);
+        assert_eq!(anthropic["cache_creation"]["ephemeral_5m_input_tokens"], 20);
+        assert_eq!(anthropic["cache_creation"]["ephemeral_1h_input_tokens"], 0);
+    }
+
+    #[test]
+    fn test_malformed_anthropic_cache_creation_preserves_token_counts() {
+        let usage = crate::serde_json::json!({
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_read_input_tokens": 20,
+            "cache_creation_input_tokens": 30,
+            "cache_creation": "invalid",
+        });
+
+        let usage = UniversalUsage::from_provider_value(&usage, ProviderFormat::Anthropic);
+        assert_eq!(usage.prompt_tokens, Some(10));
+        assert_eq!(usage.completion_tokens, Some(5));
+        assert_eq!(usage.prompt_cached_tokens, Some(20));
+        assert_eq!(usage.prompt_cache_creation_tokens, Some(30));
+        assert_eq!(usage.prompt_cache_creation_5m_tokens, None);
+        assert_eq!(usage.prompt_cache_creation_1h_tokens, None);
     }
 }

--- a/crates/lingua/src/universal/stream.rs
+++ b/crates/lingua/src/universal/stream.rs
@@ -239,7 +239,7 @@ impl Serialize for UniversalUsage {
         S: serde::Serializer,
     {
         use serde::ser::SerializeStruct;
-        let mut state = serializer.serialize_struct("UniversalUsage", 5)?;
+        let mut state = serializer.serialize_struct("UniversalUsage", 8)?;
         if let Some(prompt) = self.prompt_tokens {
             state.serialize_field("prompt_tokens", &prompt)?;
         }
@@ -251,6 +251,18 @@ impl Serialize for UniversalUsage {
         }
         if let Some(cache_creation) = self.prompt_cache_creation_tokens {
             state.serialize_field("prompt_cache_creation_tokens", &cache_creation)?;
+        }
+        if let Some(cache_creation_5m) = self.prompt_cache_creation_5m_tokens {
+            state.serialize_field("prompt_cache_creation_5m_tokens", &cache_creation_5m)?;
+        }
+        if let Some(cache_creation_1h) = self.prompt_cache_creation_1h_tokens {
+            state.serialize_field("prompt_cache_creation_1h_tokens", &cache_creation_1h)?;
+        }
+        if self.prompt_tokens_exclude_cache {
+            state.serialize_field(
+                "prompt_tokens_exclude_cache",
+                &self.prompt_tokens_exclude_cache,
+            )?;
         }
         if let Some(reasoning) = self.completion_reasoning_tokens {
             state.serialize_field("completion_reasoning_tokens", &reasoning)?;
@@ -270,6 +282,10 @@ impl<'de> Deserialize<'de> for UniversalUsage {
             completion_tokens: Option<i64>,
             prompt_cached_tokens: Option<i64>,
             prompt_cache_creation_tokens: Option<i64>,
+            prompt_cache_creation_5m_tokens: Option<i64>,
+            prompt_cache_creation_1h_tokens: Option<i64>,
+            #[serde(default)]
+            prompt_tokens_exclude_cache: bool,
             completion_reasoning_tokens: Option<i64>,
         }
         let helper = Helper::deserialize(deserializer)?;
@@ -278,6 +294,9 @@ impl<'de> Deserialize<'de> for UniversalUsage {
             completion_tokens: helper.completion_tokens,
             prompt_cached_tokens: helper.prompt_cached_tokens,
             prompt_cache_creation_tokens: helper.prompt_cache_creation_tokens,
+            prompt_cache_creation_5m_tokens: helper.prompt_cache_creation_5m_tokens,
+            prompt_cache_creation_1h_tokens: helper.prompt_cache_creation_1h_tokens,
+            prompt_tokens_exclude_cache: helper.prompt_tokens_exclude_cache,
             completion_reasoning_tokens: helper.completion_reasoning_tokens,
         })
     }

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -7615,7 +7615,7 @@ exports[`anthropic → responses > webSearchToolAdvancedParam > response 1`] = `
   "type": "message",
   "usage": {
     "cache_read_input_tokens": 4224,
-    "input_tokens": 9258,
+    "input_tokens": 5034,
     "output_tokens": 958,
   },
 }


### PR DESCRIPTION
Add support for lingua to take in the TTL cache that Anthropic supports and also convert it to the openAI convention so logging is consistent

I pared back a lot of my changes, added regression tests that targetted codex's errors and ensured things were fixed after my changes