### PR TITLE
Fix google thinking transform

### DIFF
--- a/bindings/typescript/src/generated/ReasoningCanonical.ts
+++ b/bindings/typescript/src/generated/ReasoningCanonical.ts
@@ -6,4 +6,4 @@
  * When converting between providers, both `effort` and `budget_tokens` are always populated
  * (one derived from the other). This field indicates which was the original source.
  */
-export type ReasoningCanonical = "effort" | "budget_tokens" | "google_thinking_budget";
+export type ReasoningCanonical = "effort" | "budget_tokens" | "google_thinking_budget" | "google_include_thoughts";

--- a/bindings/typescript/src/generated/ReasoningCanonical.ts
+++ b/bindings/typescript/src/generated/ReasoningCanonical.ts
@@ -6,4 +6,4 @@
  * When converting between providers, both `effort` and `budget_tokens` are always populated
  * (one derived from the other). This field indicates which was the original source.
  */
-export type ReasoningCanonical = "effort" | "budget_tokens";
+export type ReasoningCanonical = "effort" | "budget_tokens" | "google_thinking_budget";

--- a/bindings/typescript/src/generated/ReasoningConfig.ts
+++ b/bindings/typescript/src/generated/ReasoningConfig.ts
@@ -9,7 +9,8 @@ import type { SummaryMode } from "./SummaryMode";
  * Both `effort` and `budget_tokens` are always populated when reasoning is enabled.
  * The `canonical` field indicates which was the original source of truth:
  * - `Effort`: From OpenAI (effort is canonical, budget_tokens derived)
- * - `BudgetTokens`: From Anthropic/Google (budget_tokens is canonical, effort derived)
+ * - `BudgetTokens`: From Anthropic/Bedrock budget-based thinking (budget_tokens is canonical, effort derived)
+ * - `GoogleThinkingBudget`: From Google `thinkingConfig.thinkingBudget` (preserve Google-native shape on same-provider roundtrip)
  */
 export type ReasoningConfig = { 
 /**

--- a/bindings/typescript/src/generated/ReasoningConfig.ts
+++ b/bindings/typescript/src/generated/ReasoningConfig.ts
@@ -11,6 +11,7 @@ import type { SummaryMode } from "./SummaryMode";
  * - `Effort`: From OpenAI (effort is canonical, budget_tokens derived)
  * - `BudgetTokens`: From Anthropic/Bedrock budget-based thinking (budget_tokens is canonical, effort derived)
  * - `GoogleThinkingBudget`: From Google `thinkingConfig.thinkingBudget` (preserve Google-native shape on same-provider roundtrip)
+ * - `GoogleIncludeThoughts`: From Google `thinkingConfig.includeThoughts` without budget/level (preserve provider default budget)
  */
 export type ReasoningConfig = { 
 /**

--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -197,6 +197,31 @@
   ],
   "perTestCase": [
     {
+      "testCase": "googleThinkingJsonSchemaParam",
+      "source": "Google",
+      "target": "Google",
+      "fields": [
+        { "pattern": "params.reasoning.canonical", "reason": "Google thinkingConfig uses an explicit token budget, but the universal request canonicalization re-derives an effort level on same-provider roundtrip" }
+      ]
+    },
+    {
+      "testCase": "googleThinkingJsonSchemaParam",
+      "source": "Google",
+      "target": "Responses",
+      "fields": [
+        { "pattern": "params.response_format.json_schema.schema.additionalProperties", "reason": "Responses-compatible JSON schema normalization adds additionalProperties when converting Google responseJsonSchema" },
+        { "pattern": "messages.length", "reason": "Responses request format expands Google followup content into separate input items" }
+      ]
+    },
+    {
+      "testCase": "googleThinkingJsonSchemaParam",
+      "source": "Google",
+      "target": "ChatCompletions",
+      "fields": [
+        { "pattern": "params.response_format.json_schema.schema.additionalProperties", "reason": "ChatCompletions-compatible JSON schema normalization adds additionalProperties when converting Google responseJsonSchema" }
+      ]
+    },
+    {
       "testCase": "imageContentParam",
       "source": "*",
       "target": "Anthropic",

--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -199,14 +199,6 @@
     {
       "testCase": "googleThinkingJsonSchemaParam",
       "source": "Google",
-      "target": "Google",
-      "fields": [
-        { "pattern": "params.reasoning.canonical", "reason": "Google thinkingConfig uses an explicit token budget, but the universal request canonicalization re-derives an effort level on same-provider roundtrip" }
-      ]
-    },
-    {
-      "testCase": "googleThinkingJsonSchemaParam",
-      "source": "Google",
       "target": "Responses",
       "fields": [
         { "pattern": "params.response_format.json_schema.schema.additionalProperties", "reason": "Responses-compatible JSON schema normalization adds additionalProperties when converting Google responseJsonSchema" },

--- a/crates/coverage-report/src/responses_expected_differences.json
+++ b/crates/coverage-report/src/responses_expected_differences.json
@@ -79,6 +79,14 @@
   ],
   "perTestCase": [
     {
+      "testCase": "googleThinkingJsonSchemaParam",
+      "source": "Google",
+      "target": "Responses",
+      "fields": [
+        { "pattern": "messages.length", "reason": "Google thought parts become separate Responses reasoning output items" }
+      ]
+    },
+    {
       "testCase": "nMultipleCompletionsParam",
       "source": "ChatCompletions",
       "target": "Anthropic",

--- a/crates/coverage-report/src/runner.rs
+++ b/crates/coverage-report/src/runner.rs
@@ -8,8 +8,8 @@ use lingua::capabilities::ProviderFormat;
 use lingua::processing::adapters::ProviderAdapter;
 use lingua::serde_json::Value;
 use lingua::universal::{
-    UniversalRequest, UniversalResponse, UniversalStreamChunk, UniversalStreamDelta,
-    UniversalToolCallDelta,
+    UniversalRequest, UniversalResponse, UniversalStreamChoice, UniversalStreamChunk,
+    UniversalStreamDelta, UniversalToolCallDelta,
 };
 
 use crate::discovery::{discover_test_cases_filtered, load_payload};
@@ -546,7 +546,11 @@ fn merge_universal_stream_chunks(
             target.usage = chunk.usage;
         }
 
-        for choice in chunk.choices {
+        for mut choice in chunk.choices {
+            if let Some(target_index) = reasoning_split_target_index(&target.choices, &choice) {
+                remap_stream_choice_index(&mut choice, target_index);
+            }
+
             if let Some(existing) = target
                 .choices
                 .iter_mut()
@@ -563,6 +567,66 @@ fn merge_universal_stream_chunks(
     }
 
     merged
+}
+
+fn reasoning_split_target_index(
+    existing_choices: &[UniversalStreamChoice],
+    incoming: &UniversalStreamChoice,
+) -> Option<u32> {
+    if !stream_choice_has_visible_delta(incoming) {
+        return None;
+    }
+
+    existing_choices
+        .iter()
+        .find(|existing| {
+            existing.index + 1 == incoming.index && stream_choice_has_reasoning(existing)
+        })
+        .map(|existing| existing.index)
+}
+
+fn stream_choice_has_reasoning(choice: &UniversalStreamChoice) -> bool {
+    stream_choice_delta(choice).is_some_and(|delta| !delta.reasoning.is_empty())
+}
+
+fn stream_choice_has_visible_delta(choice: &UniversalStreamChoice) -> bool {
+    stream_choice_delta(choice).is_some_and(|delta| {
+        delta
+            .content
+            .as_deref()
+            .is_some_and(|content| !content.is_empty())
+            || !delta.tool_calls.is_empty()
+    })
+}
+
+fn stream_choice_delta(choice: &UniversalStreamChoice) -> Option<UniversalStreamDelta> {
+    choice
+        .delta
+        .clone()
+        .and_then(|value| lingua::serde_json::from_value(value).ok())
+}
+
+fn remap_stream_choice_index(choice: &mut UniversalStreamChoice, target_index: u32) {
+    let source_index = choice.index;
+    if source_index == target_index {
+        return;
+    }
+
+    choice.index = target_index;
+    if let Some(delta_value) = choice.delta.take() {
+        choice.delta =
+            match lingua::serde_json::from_value::<UniversalStreamDelta>(delta_value.clone()) {
+                Ok(mut delta) => {
+                    for tool_call in &mut delta.tool_calls {
+                        if tool_call.index == Some(source_index) {
+                            tool_call.index = Some(target_index);
+                        }
+                    }
+                    lingua::serde_json::to_value(delta).ok()
+                }
+                Err(_) => Some(delta_value),
+            };
+    }
 }
 
 fn merge_stream_delta_values(existing: Option<Value>, incoming: Option<Value>) -> Option<Value> {
@@ -1162,5 +1226,124 @@ fn compare_recursive(
                 diff.changed_fields.push((path.to_string(), before, after));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lingua::serde_json::json;
+
+    fn stream_chunk(
+        index: u32,
+        delta: Option<Value>,
+        finish_reason: Option<&str>,
+    ) -> UniversalStreamChunk {
+        UniversalStreamChunk::new(
+            Some("resp_test".to_string()),
+            Some("gemini-2.5-flash".to_string()),
+            vec![UniversalStreamChoice {
+                index,
+                delta,
+                finish_reason: finish_reason.map(ToString::to_string),
+            }],
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    fn merge_stream_chunks_collapses_responses_reasoning_text_indexes() {
+        let merged = merge_universal_stream_chunks(vec![
+            stream_chunk(
+                0,
+                Some(json!({
+                    "reasoning": [{"content": "thinking"}]
+                })),
+                None,
+            ),
+            stream_chunk(
+                1,
+                Some(json!({
+                    "content": "visible answer"
+                })),
+                None,
+            ),
+            stream_chunk(0, None, Some("stop")),
+        ])
+        .expect("chunks should merge");
+
+        assert_eq!(merged.choices.len(), 1);
+        assert_eq!(merged.choices[0].index, 0);
+        assert_eq!(merged.choices[0].finish_reason.as_deref(), Some("stop"));
+
+        let delta: UniversalStreamDelta =
+            lingua::serde_json::from_value(merged.choices[0].delta.clone().unwrap()).unwrap();
+        assert_eq!(delta.reasoning.len(), 1);
+        assert_eq!(delta.reasoning[0].content.as_deref(), Some("thinking"));
+        assert_eq!(delta.content.as_deref(), Some("visible answer"));
+    }
+
+    #[test]
+    fn merge_stream_chunks_collapses_responses_reasoning_tool_indexes() {
+        let merged = merge_universal_stream_chunks(vec![
+            stream_chunk(
+                0,
+                Some(json!({
+                    "reasoning": [{"content": "thinking"}]
+                })),
+                None,
+            ),
+            stream_chunk(
+                1,
+                Some(json!({
+                    "tool_calls": [{
+                        "index": 1,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup"
+                        }
+                    }]
+                })),
+                None,
+            ),
+            stream_chunk(
+                1,
+                Some(json!({
+                    "tool_calls": [{
+                        "index": 1,
+                        "function": {
+                            "arguments": "{\"q\":\"camera\"}"
+                        }
+                    }]
+                })),
+                None,
+            ),
+        ])
+        .expect("chunks should merge");
+
+        assert_eq!(merged.choices.len(), 1);
+        assert_eq!(merged.choices[0].index, 0);
+
+        let delta: UniversalStreamDelta =
+            lingua::serde_json::from_value(merged.choices[0].delta.clone().unwrap()).unwrap();
+        assert_eq!(delta.reasoning.len(), 1);
+        assert_eq!(delta.tool_calls.len(), 1);
+        assert_eq!(delta.tool_calls[0].index, Some(0));
+        assert_eq!(
+            delta.tool_calls[0]
+                .function
+                .as_ref()
+                .and_then(|function| function.name.as_deref()),
+            Some("lookup")
+        );
+        assert_eq!(
+            delta.tool_calls[0]
+                .function
+                .as_ref()
+                .and_then(|function| function.arguments.as_deref()),
+            Some("{\"q\":\"camera\"}")
+        );
     }
 }

--- a/crates/coverage-report/src/runner.rs
+++ b/crates/coverage-report/src/runner.rs
@@ -9,6 +9,7 @@ use lingua::processing::adapters::ProviderAdapter;
 use lingua::serde_json::Value;
 use lingua::universal::{
     UniversalRequest, UniversalResponse, UniversalStreamChunk, UniversalStreamDelta,
+    UniversalToolCallDelta,
 };
 
 use crate::discovery::{discover_test_cases_filtered, load_payload};
@@ -584,7 +585,7 @@ fn merge_stream_delta_values(existing: Option<Value>, incoming: Option<Value>) -
         }
     }
     if !incoming.tool_calls.is_empty() {
-        merged.tool_calls.extend(incoming.tool_calls);
+        merge_tool_call_deltas(&mut merged.tool_calls, incoming.tool_calls);
     }
     if !incoming.reasoning.is_empty() {
         merged.reasoning.extend(incoming.reasoning);
@@ -594,6 +595,52 @@ fn merge_stream_delta_values(existing: Option<Value>, incoming: Option<Value>) -
     }
 
     lingua::serde_json::to_value(merged).ok()
+}
+
+fn merge_tool_call_deltas(
+    existing: &mut Vec<UniversalToolCallDelta>,
+    incoming: Vec<UniversalToolCallDelta>,
+) {
+    for incoming_tool_call in incoming {
+        let Some(index) = incoming_tool_call.index else {
+            existing.push(incoming_tool_call);
+            continue;
+        };
+
+        if let Some(existing_tool_call) = existing
+            .iter_mut()
+            .find(|tool_call| tool_call.index == Some(index))
+        {
+            if incoming_tool_call.id.is_some() {
+                existing_tool_call.id = incoming_tool_call.id;
+            }
+            if incoming_tool_call.call_type.is_some() {
+                existing_tool_call.call_type = incoming_tool_call.call_type;
+            }
+            match (
+                &mut existing_tool_call.function,
+                incoming_tool_call.function,
+            ) {
+                (Some(existing_function), Some(incoming_function)) => {
+                    if incoming_function.name.is_some() {
+                        existing_function.name = incoming_function.name;
+                    }
+                    if let Some(arguments) = incoming_function.arguments {
+                        match &mut existing_function.arguments {
+                            Some(existing_arguments) => existing_arguments.push_str(&arguments),
+                            None => existing_function.arguments = Some(arguments),
+                        }
+                    }
+                }
+                (None, Some(incoming_function)) => {
+                    existing_tool_call.function = Some(incoming_function);
+                }
+                _ => {}
+            }
+        } else {
+            existing.push(incoming_tool_call);
+        }
+    }
 }
 
 /// Run all cross-transformation tests and collect results

--- a/crates/coverage-report/src/runner.rs
+++ b/crates/coverage-report/src/runner.rs
@@ -7,7 +7,9 @@ use std::collections::HashMap;
 use lingua::capabilities::ProviderFormat;
 use lingua::processing::adapters::ProviderAdapter;
 use lingua::serde_json::Value;
-use lingua::universal::{UniversalRequest, UniversalResponse, UniversalStreamChunk};
+use lingua::universal::{
+    UniversalRequest, UniversalResponse, UniversalStreamChunk, UniversalStreamDelta,
+};
 
 use crate::discovery::{discover_test_cases_filtered, load_payload};
 use crate::expected::TestCategory;
@@ -452,17 +454,26 @@ fn test_single_stream_event(
                 }
             };
 
-            match target_adapter.stream_to_universal(transformed) {
-                Ok(u) => u,
-                Err(e) => {
-                    return TransformResult {
-                        level: ValidationLevel::Fail,
-                        error: Some(format!("Conversion from universal format failed: {}", e)),
-                        diff: None,
-                        limitation_reason: None,
-                    };
+            let transformed_events = transformed
+                .as_array()
+                .map(|events| events.to_vec())
+                .unwrap_or_else(|| vec![transformed]);
+            let mut target_chunks = Vec::new();
+            for transformed_event in transformed_events {
+                match target_adapter.stream_to_universal(transformed_event) {
+                    Ok(Some(chunk)) => target_chunks.push(chunk),
+                    Ok(None) => {}
+                    Err(e) => {
+                        return TransformResult {
+                            level: ValidationLevel::Fail,
+                            error: Some(format!("Conversion from universal format failed: {}", e)),
+                            diff: None,
+                            limitation_reason: None,
+                        };
+                    }
                 }
             }
+            merge_universal_stream_chunks(target_chunks)
         }
         None => {
             // Keep-alive event with no universal representation - pass through
@@ -503,6 +514,86 @@ fn test_single_stream_event(
             diff_to_transform_result(roundtrip_result)
         }
     }
+}
+
+fn merge_universal_stream_chunks(
+    chunks: Vec<UniversalStreamChunk>,
+) -> Option<UniversalStreamChunk> {
+    let mut merged: Option<UniversalStreamChunk> = None;
+
+    for chunk in chunks {
+        let target = merged.get_or_insert_with(|| {
+            UniversalStreamChunk::new(
+                chunk.id.clone(),
+                chunk.model.clone(),
+                Vec::new(),
+                chunk.created,
+                chunk.usage.clone(),
+            )
+        });
+
+        if target.id.is_none() {
+            target.id = chunk.id;
+        }
+        if target.model.is_none() {
+            target.model = chunk.model;
+        }
+        if target.created.is_none() {
+            target.created = chunk.created;
+        }
+        if target.usage.is_none() {
+            target.usage = chunk.usage;
+        }
+
+        for choice in chunk.choices {
+            if let Some(existing) = target
+                .choices
+                .iter_mut()
+                .find(|existing| existing.index == choice.index)
+            {
+                existing.delta = merge_stream_delta_values(existing.delta.take(), choice.delta);
+                if choice.finish_reason.is_some() {
+                    existing.finish_reason = choice.finish_reason;
+                }
+            } else {
+                target.choices.push(choice);
+            }
+        }
+    }
+
+    merged
+}
+
+fn merge_stream_delta_values(existing: Option<Value>, incoming: Option<Value>) -> Option<Value> {
+    let Some(incoming) = incoming else {
+        return existing;
+    };
+
+    let mut merged = existing
+        .and_then(|value| lingua::serde_json::from_value::<UniversalStreamDelta>(value).ok())
+        .unwrap_or_default();
+    let incoming = lingua::serde_json::from_value::<UniversalStreamDelta>(incoming).ok()?;
+
+    if incoming.role.is_some() {
+        merged.role = incoming.role;
+    }
+    if let Some(content) = incoming.content {
+        match &mut merged.content {
+            Some(existing_content) => existing_content.push_str(&content),
+            None => merged.content = Some(content),
+        }
+    }
+    if !incoming.tool_calls.is_empty() {
+        merged.tool_calls.extend(incoming.tool_calls);
+    }
+    if !incoming.reasoning.is_empty() {
+        merged.reasoning.extend(incoming.reasoning);
+    }
+    if incoming.reasoning_signature.is_some() {
+        merged.reasoning_signature = incoming.reasoning_signature;
+    }
+
+    lingua::serde_json::to_value(merged).ok()
 }
 
 /// Run all cross-transformation tests and collect results

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -51,6 +51,18 @@ impl StreamOutputChunk {
     }
 }
 
+struct SessionChunkState<'a> {
+    anthropic_message_started: bool,
+    responses_message_started: bool,
+    responses_output_index_states: &'a mut BTreeMap<u32, ResponsesOutputIndexState>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ResponsesOutputIndexState {
+    text_output_index: Option<u32>,
+    tool_output_index_offset: u32,
+}
+
 /// Stateful stream transformation session.
 ///
 /// This wraps the stateless `transform_stream_chunk` API with target-provider
@@ -77,7 +89,7 @@ pub struct StreamTransformSession {
     anthropic_next_content_block_index: u32,
     anthropic_content_block_index_map: BTreeMap<(AnthropicContentBlockKind, u32), u32>,
     responses_message_started: bool,
-    responses_output_index_offsets: BTreeMap<u32, u32>,
+    responses_output_index_states: BTreeMap<u32, ResponsesOutputIndexState>,
     responses_tool_call_indexes: BTreeMap<u32, u32>,
     next_responses_tool_call_index: u32,
     bedrock_tool_call_indexes: BTreeMap<u32, u32>,
@@ -105,7 +117,7 @@ impl StreamTransformSession {
             anthropic_next_content_block_index: 0,
             anthropic_content_block_index_map: BTreeMap::new(),
             responses_message_started: false,
-            responses_output_index_offsets: BTreeMap::new(),
+            responses_output_index_states: BTreeMap::new(),
             responses_tool_call_indexes: BTreeMap::new(),
             next_responses_tool_call_index: 0,
             bedrock_tool_call_indexes: BTreeMap::new(),
@@ -139,9 +151,11 @@ impl StreamTransformSession {
             self.target_format,
             step.universal.as_ref(),
             step.source_is_native_stream,
-            self.anthropic_message_started,
-            self.responses_message_started,
-            &mut self.responses_output_index_offsets,
+            SessionChunkState {
+                anthropic_message_started: self.anthropic_message_started,
+                responses_message_started: self.responses_message_started,
+                responses_output_index_states: &mut self.responses_output_index_states,
+            },
         )?;
         self.process_chunks(chunks)
     }
@@ -914,9 +928,7 @@ fn build_session_chunks(
     target_format: ProviderFormat,
     universal: Option<&UniversalStreamChunk>,
     source_is_native_stream: bool,
-    anthropic_message_started: bool,
-    responses_message_started: bool,
-    responses_output_index_offsets: &mut BTreeMap<u32, u32>,
+    state: SessionChunkState<'_>,
 ) -> Result<Vec<StreamOutputChunk>, TransformError> {
     let mut chunks = expand_transform_result(result)?;
     if target_format == ProviderFormat::Anthropic {
@@ -925,7 +937,7 @@ fn build_session_chunks(
             source_format,
             universal,
             source_is_native_stream,
-            anthropic_message_started,
+            state.anthropic_message_started,
         );
     }
     if target_format == ProviderFormat::Responses {
@@ -933,8 +945,8 @@ fn build_session_chunks(
         return expand_responses_session_chunks(
             chunks,
             universal,
-            responses_message_started,
-            responses_output_index_offsets,
+            state.responses_message_started,
+            state.responses_output_index_states,
         );
         #[cfg(not(feature = "openai"))]
         return Ok(std::mem::take(&mut chunks));
@@ -946,43 +958,71 @@ fn expand_responses_session_chunks(
     chunks: Vec<StreamOutputChunk>,
     universal: Option<&UniversalStreamChunk>,
     responses_message_started: bool,
-    responses_output_index_offsets: &mut BTreeMap<u32, u32>,
+    responses_output_index_states: &mut BTreeMap<u32, ResponsesOutputIndexState>,
 ) -> Result<Vec<StreamOutputChunk>, TransformError> {
     let Some(universal) = universal else {
         return Ok(chunks);
     };
 
-    let (choice_index, has_reasoning, has_finish) = universal
+    let (choice_index, has_reasoning, has_content, has_finish) = universal
         .choices
         .first()
         .map(|choice| {
-            let has_reasoning = choice.delta_view().is_some_and(|delta| {
-                delta.reasoning.iter().any(|r| {
-                    r.content
+            let (has_reasoning, has_content) = choice
+                .delta_view()
+                .map(|delta| {
+                    let has_reasoning = delta.reasoning.iter().any(|r| {
+                        r.content
+                            .as_deref()
+                            .is_some_and(|content| !content.is_empty())
+                    });
+                    let has_content = delta
+                        .content
                         .as_deref()
-                        .is_some_and(|content| !content.is_empty())
+                        .is_some_and(|content| !content.is_empty());
+                    (has_reasoning, has_content)
                 })
-            });
-            (choice.index, has_reasoning, choice.finish_reason.is_some())
+                .unwrap_or((false, false));
+            (
+                choice.index,
+                has_reasoning,
+                has_content,
+                choice.finish_reason.is_some(),
+            )
         })
-        .unwrap_or((0, false, false));
-    let output_index_offset = responses_output_index_offsets
+        .unwrap_or((0, false, false, false));
+    let output_index_state = responses_output_index_states
         .get(&choice_index)
         .copied()
-        .unwrap_or(0);
+        .unwrap_or_default();
 
     let mut events = responses_stream_events_from_universal_with_output_index_offset(
         universal,
-        output_index_offset,
+        output_index_state.text_output_index,
+        output_index_state.tool_output_index_offset,
     );
+    let mut next_output_index_state = output_index_state;
     if has_reasoning {
-        responses_output_index_offsets
-            .entry(choice_index)
-            .and_modify(|offset| *offset = (*offset).max(1))
-            .or_insert(1);
+        next_output_index_state.tool_output_index_offset = next_output_index_state
+            .tool_output_index_offset
+            .max(choice_index + 1);
+    }
+    if has_content {
+        let text_output_index = *next_output_index_state
+            .text_output_index
+            .get_or_insert_with(|| {
+                choice_index.max(next_output_index_state.tool_output_index_offset)
+            });
+        next_output_index_state.tool_output_index_offset = next_output_index_state
+            .tool_output_index_offset
+            .max(text_output_index + 1);
     }
     if has_finish {
-        responses_output_index_offsets.remove(&choice_index);
+        responses_output_index_states.remove(&choice_index);
+    } else if next_output_index_state.text_output_index.is_some()
+        || next_output_index_state.tool_output_index_offset > 0
+    {
+        responses_output_index_states.insert(choice_index, next_output_index_state);
     }
     let has_metadata =
         universal.model.is_some() || universal.id.is_some() || universal.usage.is_some();
@@ -2697,6 +2737,87 @@ mod tests {
         let text_delta: OutputTextDelta = crate::serde_json::from_slice(&second[0].data).unwrap();
         assert_eq!(text_delta.output_index, 1);
         assert_eq!(text_delta.delta, "{\"answer\":\"visible json\"}");
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "openai"))]
+    fn test_stream_session_google_text_then_tool_uses_next_responses_output_index() {
+        #[derive(Deserialize)]
+        struct OutputEvent {
+            output_index: u32,
+        }
+
+        let mut session = StreamTransformSession::new(ProviderFormat::Responses);
+        let thought_and_text = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "text": "thinking first",
+                            "thought": true
+                        },
+                        {
+                            "text": "{\"answer\":\"visible json\"}"
+                        }
+                    ]
+                }
+            }]
+        }));
+        let tool_call = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "functionCall": {
+                            "name": "lookup_creator",
+                            "args": {
+                                "query": "microphone comparison"
+                            }
+                        }
+                    }]
+                },
+                "finishReason": "STOP"
+            }]
+        }));
+
+        let first = session.push(thought_and_text).unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("response.created"),
+                Some("response.reasoning_summary_text.delta"),
+                Some("response.output_text.delta")
+            ]
+        );
+        let text_delta: OutputEvent = crate::serde_json::from_slice(&first[2].data).unwrap();
+        assert_eq!(text_delta.output_index, 1);
+
+        let second = session.push(tool_call).unwrap();
+        assert_eq!(
+            second
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("response.output_item.added"),
+                Some("response.function_call_arguments.delta"),
+                Some("response.completed")
+            ]
+        );
+        let tool_start: OutputEvent = crate::serde_json::from_slice(&second[0].data).unwrap();
+        let tool_args: OutputEvent = crate::serde_json::from_slice(&second[1].data).unwrap();
+        assert_eq!(tool_start.output_index, 2);
+        assert_eq!(tool_args.output_index, 2);
     }
 
     #[test]

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -352,6 +352,37 @@ impl StreamTransformSession {
                 }
             }
         }
+        if self.anthropic_open_content_block_index.is_none()
+            && self.anthropic_message_started
+            && !is_content_block_start
+        {
+            if let (Some(delta_index), Some(delta_kind)) =
+                (content_block_delta_index, content_block_delta_kind)
+            {
+                if delta_kind.can_synthesize_start() {
+                    let target_index = self
+                        .anthropic_content_block_index_map
+                        .get(&(delta_kind, delta_index))
+                        .copied()
+                        .unwrap_or_else(|| {
+                            let index = delta_index.max(self.anthropic_next_content_block_index);
+                            self.anthropic_content_block_index_map
+                                .insert((delta_kind, delta_index), index);
+                            self.anthropic_next_content_block_index = index + 1;
+                            index
+                        });
+                    if target_index != delta_index {
+                        chunk = with_anthropic_content_block_delta_index(chunk, target_index);
+                    }
+                    self.anthropic_open_content_block_index = Some(target_index);
+                    self.anthropic_open_content_block_kind = Some(delta_kind);
+                    prefix.push(anthropic_content_block_start_chunk(
+                        target_index,
+                        delta_kind,
+                    ));
+                }
+            }
+        }
         // This closes blocks before explicit block starts and terminal message
         // deltas. Content-block deltas, including synthesized kind switches
         // above, must stay inside their open block until the delta is emitted.
@@ -607,26 +638,16 @@ fn anthropic_content_block_start_chunk(
     index: u32,
     kind: AnthropicContentBlockKind,
 ) -> StreamOutputChunk {
-    let content_block = match kind {
-        AnthropicContentBlockKind::Text => crate::serde_json::json!({
-            "type": "text",
-            "text": ""
-        }),
-        AnthropicContentBlockKind::Thinking => crate::serde_json::json!({
-            "type": "thinking",
-            "thinking": ""
-        }),
+    let data = match kind {
+        AnthropicContentBlockKind::Text => Bytes::from(format!(
+            r#"{{"type":"content_block_start","index":{index},"content_block":{{"type":"text","text":""}}}}"#
+        )),
+        AnthropicContentBlockKind::Thinking => Bytes::from(format!(
+            r#"{{"type":"content_block_start","index":{index},"content_block":{{"type":"thinking","thinking":""}}}}"#
+        )),
         AnthropicContentBlockKind::ToolUse => unreachable!("tool_use starts need provider IDs"),
     };
-    StreamOutputChunk::with_event(
-        serialize_stream_value(&crate::serde_json::json!({
-            "type": "content_block_start",
-            "index": index,
-            "content_block": content_block
-        }))
-        .unwrap_or_else(|_| Bytes::new()),
-        "content_block_start".to_string(),
-    )
+    StreamOutputChunk::with_event(data, "content_block_start".to_string())
 }
 
 fn with_anthropic_content_block_delta_index(
@@ -1017,13 +1038,6 @@ fn expand_anthropic_session_chunks(
         if let Some(message_start) = chunks.first() {
             out.push(message_start.clone());
         }
-
-        out.push(StreamOutputChunk::with_event(
-            Bytes::from_static(
-                br#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
-            ),
-            "content_block_start".to_string(),
-        ));
         return out;
     }
 
@@ -1571,9 +1585,8 @@ mod tests {
         }));
 
         let out = session.push(openai_chunk).unwrap();
-        assert_eq!(out.len(), 2);
+        assert_eq!(out.len(), 1);
         assert_eq!(out[0].event_type.as_deref(), Some("message_start"));
-        assert_eq!(out[1].event_type.as_deref(), Some("content_block_start"));
     }
 
     #[test]
@@ -1682,7 +1695,7 @@ mod tests {
                 .iter()
                 .map(|chunk| chunk.event_type.as_deref())
                 .collect::<Vec<_>>(),
-            vec![Some("message_start"), Some("content_block_start")]
+            vec![Some("message_start")]
         );
 
         let second = session.push(in_progress).unwrap();
@@ -1694,10 +1707,10 @@ mod tests {
                 .iter()
                 .map(|chunk| chunk.event_type.as_deref())
                 .collect::<Vec<_>>(),
-            vec![Some("content_block_stop"), Some("content_block_start")]
+            vec![Some("content_block_start")]
         );
 
-        let tool_block: Value = crate::serde_json::from_slice(&third[1].data).unwrap();
+        let tool_block: Value = crate::serde_json::from_slice(&third[0].data).unwrap();
         assert_eq!(
             tool_block
                 .get("content_block")
@@ -1732,6 +1745,150 @@ mod tests {
                 .and_then(Value::as_str),
             Some("tool_use")
         );
+    }
+
+    #[test]
+    #[cfg(all(feature = "openai", feature = "anthropic"))]
+    fn test_stream_session_responses_reasoning_after_metadata_starts_thinking_block() {
+        #[derive(Deserialize)]
+        struct ThinkingDeltaEvent {
+            index: u32,
+            delta: ThinkingDelta,
+        }
+
+        #[derive(Deserialize)]
+        struct ThinkingDelta {
+            thinking: String,
+        }
+
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+
+        let created = to_bytes(&json!({
+            "type": "response.created",
+            "response": {
+                "id": "resp_123",
+                "model": "gpt-5.5-2026-04-23",
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0
+                }
+            }
+        }));
+        let reasoning = to_bytes(&json!({
+            "type": "response.reasoning_summary_text.delta",
+            "output_index": 0,
+            "summary_index": 0,
+            "delta": "thinking after metadata"
+        }));
+
+        let first = session.push(created).unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("message_start")]
+        );
+
+        let second = session.push(reasoning).unwrap();
+        assert_eq!(
+            second
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_start"), Some("content_block_delta")]
+        );
+
+        let thinking_start: AnthropicContentBlockStartEventView =
+            crate::serde_json::from_slice(&second[0].data).unwrap();
+        assert_eq!(
+            thinking_start.block_kind(),
+            Some(AnthropicContentBlockKind::Thinking)
+        );
+        assert_eq!(thinking_start.index, 0);
+
+        let thinking_delta: ThinkingDeltaEvent =
+            crate::serde_json::from_slice(&second[1].data).unwrap();
+        assert_eq!(thinking_delta.index, 0);
+        assert_eq!(thinking_delta.delta.thinking, "thinking after metadata");
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "anthropic"))]
+    fn test_stream_session_google_thought_after_metadata_starts_thinking_block() {
+        #[derive(Deserialize)]
+        struct ThinkingDeltaEvent {
+            index: u32,
+            delta: ThinkingDelta,
+        }
+
+        #[derive(Deserialize)]
+        struct ThinkingDelta {
+            thinking: String,
+        }
+
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+
+        let metadata = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": []
+                }
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 1,
+                "totalTokenCount": 1
+            }
+        }));
+        let thought = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "text": "thinking after metadata",
+                        "thought": true
+                    }]
+                }
+            }]
+        }));
+
+        let first = session.push(metadata).unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("message_start")]
+        );
+
+        let second = session.push(thought).unwrap();
+        assert_eq!(
+            second
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_start"), Some("content_block_delta")]
+        );
+
+        let thinking_start: AnthropicContentBlockStartEventView =
+            crate::serde_json::from_slice(&second[0].data).unwrap();
+        assert_eq!(
+            thinking_start.block_kind(),
+            Some(AnthropicContentBlockKind::Thinking)
+        );
+        assert_eq!(thinking_start.index, 0);
+
+        let thinking_delta: ThinkingDeltaEvent =
+            crate::serde_json::from_slice(&second[1].data).unwrap();
+        assert_eq!(thinking_delta.index, 0);
+        assert_eq!(thinking_delta.delta.thinking, "thinking after metadata");
     }
 
     #[test]

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -853,6 +853,24 @@ fn expand_anthropic_session_chunks(
             .unwrap_or_else(|_| Bytes::new()),
             "content_block_delta".to_string(),
         ));
+        if let Some(signature) = delta_view
+            .as_ref()
+            .and_then(|d| d.reasoning_signature.as_deref())
+            .filter(|signature| !signature.is_empty())
+        {
+            out.push(StreamOutputChunk::with_event(
+                serialize_stream_value(&crate::serde_json::json!({
+                    "type": "content_block_delta",
+                    "index": choice.map(|c| c.index).unwrap_or(0),
+                    "delta": {
+                        "type": "signature_delta",
+                        "signature": signature
+                    }
+                }))
+                .unwrap_or_else(|_| Bytes::new()),
+                "content_block_delta".to_string(),
+            ));
+        }
         if let Some(content) = content {
             out.push(StreamOutputChunk::with_event(
                 serialize_stream_value(&crate::serde_json::json!({
@@ -1690,6 +1708,17 @@ mod tests {
     #[test]
     #[cfg(all(feature = "google", feature = "anthropic"))]
     fn test_stream_session_google_mixed_thought_and_tool_call_preserves_tool_use() {
+        #[derive(Deserialize)]
+        struct SignatureDeltaEvent {
+            index: u32,
+            delta: SignatureDelta,
+        }
+
+        #[derive(Deserialize)]
+        struct SignatureDelta {
+            signature: String,
+        }
+
         let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
         let mixed_tool = to_bytes(&json!({
             "responseId": "response_123",
@@ -1701,7 +1730,8 @@ mod tests {
                     "parts": [
                         {
                             "text": "thinking before the tool",
-                            "thought": true
+                            "thought": true,
+                            "thoughtSignature": "sig_abc123"
                         },
                         {
                             "functionCall": {
@@ -1725,14 +1755,20 @@ mod tests {
                 Some("message_start"),
                 Some("content_block_start"),
                 Some("content_block_delta"),
+                Some("content_block_delta"),
                 Some("content_block_stop"),
                 Some("content_block_start"),
                 Some("content_block_delta")
             ]
         );
 
+        let signature_delta: SignatureDeltaEvent =
+            crate::serde_json::from_slice(&out[3].data).unwrap();
+        assert_eq!(signature_delta.index, 0);
+        assert_eq!(signature_delta.delta.signature, "sig_abc123");
+
         let tool_start: AnthropicContentBlockStartEventView =
-            crate::serde_json::from_slice(&out[4].data).unwrap();
+            crate::serde_json::from_slice(&out[5].data).unwrap();
         assert_eq!(tool_start.index, 1);
         assert_eq!(
             tool_start.block_kind(),
@@ -1740,7 +1776,7 @@ mod tests {
         );
 
         let tool_delta: AnthropicContentBlockDeltaEventView =
-            crate::serde_json::from_slice(&out[5].data).unwrap();
+            crate::serde_json::from_slice(&out[6].data).unwrap();
         assert_eq!(tool_delta.index, 1);
         assert_eq!(
             tool_delta.block_kind(),

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -568,6 +568,15 @@ fn expand_anthropic_session_chunks(
     let has_tool_calls = delta_view
         .as_ref()
         .is_some_and(|d| !d.tool_calls.is_empty());
+    let reasoning_text = delta_view.as_ref().and_then(|d| {
+        let text = d
+            .reasoning
+            .iter()
+            .filter_map(|r| r.content.as_deref())
+            .collect::<String>();
+        (!text.is_empty()).then_some(text)
+    });
+    let has_reasoning = reasoning_text.is_some();
     let is_initial_tool_call = delta_view
         .as_ref()
         .and_then(|d| d.tool_calls.first())
@@ -582,6 +591,7 @@ fn expand_anthropic_session_chunks(
     let is_initial_metadata = has_metadata
         && !has_finish
         && !has_tool_calls
+        && !has_reasoning
         && !universal.choices.is_empty()
         && delta_view
             .as_ref()
@@ -593,42 +603,37 @@ fn expand_anthropic_session_chunks(
         return out;
     }
 
+    if let Some(thinking) = reasoning_text {
+        if !anthropic_message_started {
+            out.push(StreamOutputChunk::with_event(
+                anthropic_message_start_bytes(universal),
+                "message_start".to_string(),
+            ));
+            out.push(StreamOutputChunk::with_event(
+                Bytes::from_static(
+                    br#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#,
+                ),
+                "content_block_start".to_string(),
+            ));
+        }
+        out.push(StreamOutputChunk::with_event(
+            serialize_stream_value(&crate::serde_json::json!({
+                "type": "content_block_delta",
+                "index": choice.map(|c| c.index).unwrap_or(0),
+                "delta": {
+                    "type": "thinking_delta",
+                    "thinking": thinking
+                }
+            }))
+            .unwrap_or_else(|_| Bytes::new()),
+            "content_block_delta".to_string(),
+        ));
+        return out;
+    }
+
     if is_initial_metadata && !anthropic_message_started {
         if let Some(message_start) = chunks.first() {
             out.push(message_start.clone());
-        }
-
-        if let Some(choice) = choice {
-            if let Some(delta_view) = delta_view.as_ref() {
-                if !delta_view.reasoning.is_empty() {
-                    let thinking = delta_view
-                        .reasoning
-                        .iter()
-                        .filter_map(|r| r.content.as_deref())
-                        .collect::<String>();
-                    if !thinking.is_empty() {
-                        out.push(StreamOutputChunk::with_event(
-                            Bytes::from_static(
-                                br#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#,
-                            ),
-                            "content_block_start".to_string(),
-                        ));
-                        out.push(StreamOutputChunk::with_event(
-                            serialize_stream_value(&crate::serde_json::json!({
-                                "type": "content_block_delta",
-                                "index": choice.index,
-                                "delta": {
-                                    "type": "thinking_delta",
-                                    "thinking": thinking
-                                }
-                            }))
-                            .unwrap_or_else(|_| Bytes::new()),
-                            "content_block_delta".to_string(),
-                        ));
-                        return out;
-                    }
-                }
-            }
         }
 
         out.push(StreamOutputChunk::with_event(
@@ -1179,6 +1184,90 @@ mod tests {
                 .and_then(Value::as_str),
             Some("end_turn")
         );
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "anthropic"))]
+    fn test_stream_session_google_thought_only_chunks_are_anthropic_thinking_deltas() {
+        #[derive(Deserialize)]
+        struct ThinkingDeltaEvent {
+            delta: ThinkingDelta,
+        }
+
+        #[derive(Deserialize)]
+        struct ThinkingDelta {
+            thinking: String,
+        }
+
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+        let first_thought = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "text": "thinking before visible text",
+                        "thought": true
+                    }]
+                }
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 1,
+                "thoughtsTokenCount": 2,
+                "totalTokenCount": 3
+            }
+        }));
+        let later_thought = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "text": "later thinking",
+                        "thought": true
+                    }]
+                }
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 1,
+                "thoughtsTokenCount": 4,
+                "totalTokenCount": 5
+            }
+        }));
+
+        let first = session.push(first_thought).unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("message_start"),
+                Some("content_block_start"),
+                Some("content_block_delta")
+            ]
+        );
+
+        let first_delta: ThinkingDeltaEvent =
+            crate::serde_json::from_slice(&first[2].data).unwrap();
+        assert_eq!(first_delta.delta.thinking, "thinking before visible text");
+
+        let second = session.push(later_thought).unwrap();
+        assert_eq!(
+            second
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_delta")]
+        );
+
+        let second_delta: ThinkingDeltaEvent =
+            crate::serde_json::from_slice(&second[0].data).unwrap();
+        assert_eq!(second_delta.delta.thinking, "later thinking");
     }
 
     #[test]

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -68,6 +68,7 @@ pub struct StreamTransformSession {
     // new block or the terminal message delta. Some source providers do not have
     // an equivalent event, so the session synthesizes `content_block_stop`.
     anthropic_open_content_block_index: Option<u32>,
+    anthropic_open_content_block_kind: Option<AnthropicContentBlockKind>,
     bedrock_tool_call_indexes: BTreeMap<u32, u32>,
     next_bedrock_tool_call_index: u32,
 }
@@ -89,6 +90,7 @@ impl StreamTransformSession {
             anthropic_message_started: false,
             anthropic_tool_use_started: false,
             anthropic_open_content_block_index: None,
+            anthropic_open_content_block_kind: None,
             bedrock_tool_call_indexes: BTreeMap::new(),
             next_bedrock_tool_call_index: 0,
         }
@@ -260,6 +262,14 @@ impl StreamTransformSession {
         let is_content_block_stop = chunk.event_type.as_deref() == Some("content_block_stop");
         let content_block_start = parse_anthropic_content_block_start_event(&chunk)?;
         let content_block_start_index = content_block_start.as_ref().map(|event| event.index);
+        let content_block_start_kind = content_block_start
+            .as_ref()
+            .and_then(AnthropicContentBlockStartEventView::block_kind);
+        let content_block_delta = parse_anthropic_content_block_delta_event(&chunk)?;
+        let content_block_delta_kind = content_block_delta
+            .as_ref()
+            .and_then(AnthropicContentBlockDeltaEventView::block_kind);
+        let content_block_delta_index = content_block_delta.as_ref().map(|event| event.index);
         let is_tool_use_start = content_block_start
             .as_ref()
             .is_some_and(AnthropicContentBlockStartEventView::is_tool_use_start);
@@ -274,19 +284,36 @@ impl StreamTransformSession {
             self.anthropic_message_started = true;
             self.anthropic_tool_use_started = false;
             self.anthropic_open_content_block_index = None;
+            self.anthropic_open_content_block_kind = None;
+        }
+        if let (Some(open_index), Some(open_kind), Some(delta_index), Some(delta_kind)) = (
+            self.anthropic_open_content_block_index,
+            self.anthropic_open_content_block_kind,
+            content_block_delta_index,
+            content_block_delta_kind,
+        ) {
+            if open_kind != delta_kind && delta_kind.can_synthesize_start() {
+                self.anthropic_open_content_block_index = Some(delta_index);
+                self.anthropic_open_content_block_kind = Some(delta_kind);
+                prefix.push(anthropic_content_block_stop_chunk(open_index));
+                prefix.push(anthropic_content_block_start_chunk(delta_index, delta_kind));
+            }
         }
         if (is_content_block_start || is_delta || is_stop)
             && self.anthropic_open_content_block_index.is_some()
         {
             if let Some(index) = self.anthropic_open_content_block_index.take() {
                 prefix.push(anthropic_content_block_stop_chunk(index));
+                self.anthropic_open_content_block_kind = None;
             }
         }
         if is_content_block_start {
             self.anthropic_open_content_block_index = content_block_start_index;
+            self.anthropic_open_content_block_kind = content_block_start_kind;
         }
         if is_content_block_stop {
             self.anthropic_open_content_block_index = None;
+            self.anthropic_open_content_block_kind = None;
         }
         if is_tool_use_start {
             self.anthropic_tool_use_started = true;
@@ -305,6 +332,7 @@ impl StreamTransformSession {
                 self.anthropic_message_started = false;
                 self.anthropic_tool_use_started = false;
                 self.anthropic_open_content_block_index = None;
+                self.anthropic_open_content_block_kind = None;
                 out.push(stop);
             }
             return Ok(out);
@@ -324,6 +352,7 @@ impl StreamTransformSession {
             self.anthropic_message_started = false;
             self.anthropic_tool_use_started = false;
             self.anthropic_open_content_block_index = None;
+            self.anthropic_open_content_block_kind = None;
         }
 
         let mut out = prefix;
@@ -341,6 +370,7 @@ impl StreamTransformSession {
             self.anthropic_message_started = false;
             self.anthropic_tool_use_started = false;
             self.anthropic_open_content_block_index = None;
+            self.anthropic_open_content_block_kind = None;
             out.push(stop);
         }
         out
@@ -362,12 +392,74 @@ impl AnthropicContentBlockStartEventView {
             .and_then(|block| block.block_type.as_deref())
             == Some("tool_use")
     }
+
+    fn block_kind(&self) -> Option<AnthropicContentBlockKind> {
+        self.content_block
+            .as_ref()
+            .and_then(|block| block.block_type.as_deref())
+            .and_then(AnthropicContentBlockKind::from_content_block_type)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicContentBlockDeltaEventView {
+    #[serde(rename = "type")]
+    _event_type: AnthropicStreamEventTypeView,
+    index: u32,
+    delta: Option<AnthropicContentBlockDeltaView>,
+}
+
+impl AnthropicContentBlockDeltaEventView {
+    fn block_kind(&self) -> Option<AnthropicContentBlockKind> {
+        self.delta
+            .as_ref()
+            .and_then(|delta| delta.delta_type.as_deref())
+            .and_then(AnthropicContentBlockKind::from_delta_type)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicContentBlockDeltaView {
+    #[serde(rename = "type")]
+    delta_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnthropicContentBlockKind {
+    Text,
+    Thinking,
+    ToolUse,
+}
+
+impl AnthropicContentBlockKind {
+    fn from_content_block_type(block_type: &str) -> Option<Self> {
+        match block_type {
+            "text" => Some(Self::Text),
+            "thinking" => Some(Self::Thinking),
+            "tool_use" => Some(Self::ToolUse),
+            _ => None,
+        }
+    }
+
+    fn from_delta_type(delta_type: &str) -> Option<Self> {
+        match delta_type {
+            "text_delta" => Some(Self::Text),
+            "thinking_delta" | "signature_delta" => Some(Self::Thinking),
+            "input_json_delta" => Some(Self::ToolUse),
+            _ => None,
+        }
+    }
+
+    fn can_synthesize_start(self) -> bool {
+        matches!(self, Self::Text | Self::Thinking)
+    }
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum AnthropicStreamEventTypeView {
     ContentBlockStart,
+    ContentBlockDelta,
 }
 
 #[derive(Debug, Deserialize)]
@@ -393,6 +485,23 @@ fn parse_anthropic_content_block_start_event(
         })
 }
 
+fn parse_anthropic_content_block_delta_event(
+    chunk: &StreamOutputChunk,
+) -> Result<Option<AnthropicContentBlockDeltaEventView>, TransformError> {
+    if chunk.event_type.as_deref() != Some("content_block_delta") {
+        return Ok(None);
+    }
+
+    crate::serde_json::from_slice::<AnthropicContentBlockDeltaEventView>(&chunk.data)
+        .map(Some)
+        .map_err(|e| {
+            TransformError::DeserializationFailed(format!(
+                "Anthropic content_block_delta event: {}",
+                e
+            ))
+        })
+}
+
 fn anthropic_content_block_stop_chunk(index: u32) -> StreamOutputChunk {
     StreamOutputChunk::with_event(
         serialize_stream_value(&crate::serde_json::json!({
@@ -401,6 +510,32 @@ fn anthropic_content_block_stop_chunk(index: u32) -> StreamOutputChunk {
         }))
         .unwrap_or_else(|_| Bytes::new()),
         "content_block_stop".to_string(),
+    )
+}
+
+fn anthropic_content_block_start_chunk(
+    index: u32,
+    kind: AnthropicContentBlockKind,
+) -> StreamOutputChunk {
+    let content_block = match kind {
+        AnthropicContentBlockKind::Text => crate::serde_json::json!({
+            "type": "text",
+            "text": ""
+        }),
+        AnthropicContentBlockKind::Thinking => crate::serde_json::json!({
+            "type": "thinking",
+            "thinking": ""
+        }),
+        AnthropicContentBlockKind::ToolUse => unreachable!("tool_use starts need provider IDs"),
+    };
+    StreamOutputChunk::with_event(
+        serialize_stream_value(&crate::serde_json::json!({
+            "type": "content_block_start",
+            "index": index,
+            "content_block": content_block
+        }))
+        .unwrap_or_else(|_| Bytes::new()),
+        "content_block_start".to_string(),
     )
 }
 
@@ -1238,6 +1373,19 @@ mod tests {
                 "totalTokenCount": 5
             }
         }));
+        let visible_text = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "text": "The visible answer."
+                    }]
+                }
+            }]
+        }));
 
         let first = session.push(first_thought).unwrap();
         assert_eq!(
@@ -1268,6 +1416,26 @@ mod tests {
         let second_delta: ThinkingDeltaEvent =
             crate::serde_json::from_slice(&second[0].data).unwrap();
         assert_eq!(second_delta.delta.thinking, "later thinking");
+
+        let third = session.push(visible_text).unwrap();
+        assert_eq!(
+            third
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("content_block_stop"),
+                Some("content_block_start"),
+                Some("content_block_delta")
+            ]
+        );
+
+        let text_start: AnthropicContentBlockStartEventView =
+            crate::serde_json::from_slice(&third[1].data).unwrap();
+        assert_eq!(
+            text_start.block_kind(),
+            Some(AnthropicContentBlockKind::Text)
+        );
     }
 
     #[test]

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -9,7 +9,8 @@ use crate::processing::transform::{
 };
 #[cfg(feature = "openai")]
 use crate::providers::openai::responses_adapter::{
-    responses_created_stream_event_from_universal, responses_stream_events_from_universal,
+    responses_created_stream_event_from_universal,
+    responses_stream_events_from_universal_with_output_index_offset,
 };
 use crate::serde_json::Value;
 use crate::universal::UniversalStreamChunk;
@@ -76,6 +77,7 @@ pub struct StreamTransformSession {
     anthropic_next_content_block_index: u32,
     anthropic_content_block_index_map: BTreeMap<(AnthropicContentBlockKind, u32), u32>,
     responses_message_started: bool,
+    responses_output_index_offsets: BTreeMap<u32, u32>,
     responses_tool_call_indexes: BTreeMap<u32, u32>,
     next_responses_tool_call_index: u32,
     bedrock_tool_call_indexes: BTreeMap<u32, u32>,
@@ -103,6 +105,7 @@ impl StreamTransformSession {
             anthropic_next_content_block_index: 0,
             anthropic_content_block_index_map: BTreeMap::new(),
             responses_message_started: false,
+            responses_output_index_offsets: BTreeMap::new(),
             responses_tool_call_indexes: BTreeMap::new(),
             next_responses_tool_call_index: 0,
             bedrock_tool_call_indexes: BTreeMap::new(),
@@ -138,6 +141,7 @@ impl StreamTransformSession {
             step.source_is_native_stream,
             self.anthropic_message_started,
             self.responses_message_started,
+            &mut self.responses_output_index_offsets,
         )?;
         self.process_chunks(chunks)
     }
@@ -912,6 +916,7 @@ fn build_session_chunks(
     source_is_native_stream: bool,
     anthropic_message_started: bool,
     responses_message_started: bool,
+    responses_output_index_offsets: &mut BTreeMap<u32, u32>,
 ) -> Result<Vec<StreamOutputChunk>, TransformError> {
     let mut chunks = expand_transform_result(result)?;
     if target_format == ProviderFormat::Anthropic {
@@ -925,7 +930,12 @@ fn build_session_chunks(
     }
     if target_format == ProviderFormat::Responses {
         #[cfg(feature = "openai")]
-        return expand_responses_session_chunks(chunks, universal, responses_message_started);
+        return expand_responses_session_chunks(
+            chunks,
+            universal,
+            responses_message_started,
+            responses_output_index_offsets,
+        );
         #[cfg(not(feature = "openai"))]
         return Ok(std::mem::take(&mut chunks));
     }
@@ -936,12 +946,44 @@ fn expand_responses_session_chunks(
     chunks: Vec<StreamOutputChunk>,
     universal: Option<&UniversalStreamChunk>,
     responses_message_started: bool,
+    responses_output_index_offsets: &mut BTreeMap<u32, u32>,
 ) -> Result<Vec<StreamOutputChunk>, TransformError> {
     let Some(universal) = universal else {
         return Ok(chunks);
     };
 
-    let mut events = responses_stream_events_from_universal(universal);
+    let (choice_index, has_reasoning, has_finish) = universal
+        .choices
+        .first()
+        .map(|choice| {
+            let has_reasoning = choice.delta_view().is_some_and(|delta| {
+                delta.reasoning.iter().any(|r| {
+                    r.content
+                        .as_deref()
+                        .is_some_and(|content| !content.is_empty())
+                })
+            });
+            (choice.index, has_reasoning, choice.finish_reason.is_some())
+        })
+        .unwrap_or((0, false, false));
+    let output_index_offset = responses_output_index_offsets
+        .get(&choice_index)
+        .copied()
+        .unwrap_or(0);
+
+    let mut events = responses_stream_events_from_universal_with_output_index_offset(
+        universal,
+        output_index_offset,
+    );
+    if has_reasoning {
+        responses_output_index_offsets
+            .entry(choice_index)
+            .and_modify(|offset| *offset = (*offset).max(1))
+            .or_insert(1);
+    }
+    if has_finish {
+        responses_output_index_offsets.remove(&choice_index);
+    }
     let has_metadata =
         universal.model.is_some() || universal.id.is_some() || universal.usage.is_some();
     if has_metadata
@@ -2529,6 +2571,11 @@ mod tests {
     #[test]
     #[cfg(all(feature = "google", feature = "openai"))]
     fn test_stream_session_google_response_metadata_created_once_for_responses() {
+        #[derive(Deserialize)]
+        struct ReasoningDelta {
+            output_index: u32,
+        }
+
         let mut session = StreamTransformSession::new(ProviderFormat::Responses);
         let first_thought = to_bytes(&json!({
             "responseId": "response_123",
@@ -2579,6 +2626,77 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![Some("response.reasoning_summary_text.delta")]
         );
+        let second_reasoning: ReasoningDelta =
+            crate::serde_json::from_slice(&second[0].data).unwrap();
+        assert_eq!(second_reasoning.output_index, 0);
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "openai"))]
+    fn test_stream_session_google_split_thought_then_text_offsets_responses_text_index() {
+        #[derive(Deserialize)]
+        struct OutputTextDelta {
+            output_index: u32,
+            delta: String,
+        }
+
+        let mut session = StreamTransformSession::new(ProviderFormat::Responses);
+        let thought = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "text": "thinking first",
+                        "thought": true
+                    }]
+                }
+            }]
+        }));
+        let visible_text = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "text": "{\"answer\":\"visible json\"}"
+                    }]
+                },
+                "finishReason": "STOP"
+            }]
+        }));
+
+        let first = session.push(thought).unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("response.created"),
+                Some("response.reasoning_summary_text.delta")
+            ]
+        );
+
+        let second = session.push(visible_text).unwrap();
+        assert_eq!(
+            second
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("response.output_text.delta"),
+                Some("response.completed")
+            ]
+        );
+
+        let text_delta: OutputTextDelta = crate::serde_json::from_slice(&second[0].data).unwrap();
+        assert_eq!(text_delta.output_index, 1);
+        assert_eq!(text_delta.delta, "{\"answer\":\"visible json\"}");
     }
 
     #[test]

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -296,16 +296,33 @@ impl StreamTransformSession {
         }
         let mut chunk = chunk;
         let source_content_block_start_index = content_block_start_index;
-        if let (Some(open_index), Some(open_kind), Some(start_kind)) = (
-            self.anthropic_open_content_block_index,
-            self.anthropic_open_content_block_kind,
-            content_block_start_kind,
-        ) {
-            if open_kind != start_kind {
-                let new_index = self.anthropic_next_content_block_index.max(open_index + 1);
-                self.anthropic_next_content_block_index = new_index + 1;
-                chunk = with_anthropic_content_block_start_index(chunk, new_index);
-                content_block_start_index = Some(new_index);
+        if let (Some(source_index), Some(start_kind)) =
+            (source_content_block_start_index, content_block_start_kind)
+        {
+            if let Some(mapped_index) = self
+                .anthropic_content_block_index_map
+                .get(&(start_kind, source_index))
+                .copied()
+            {
+                if mapped_index != source_index {
+                    chunk = with_anthropic_content_block_start_index(chunk, mapped_index);
+                    content_block_start_index = Some(mapped_index);
+                }
+            } else {
+                let open_index = self.anthropic_open_content_block_index;
+                let needs_fresh_index = source_index < self.anthropic_next_content_block_index
+                    || open_index == Some(source_index)
+                    || self
+                        .anthropic_open_content_block_kind
+                        .is_some_and(|open_kind| open_kind != start_kind);
+                if needs_fresh_index {
+                    let new_index = self
+                        .anthropic_next_content_block_index
+                        .max(open_index.map(|index| index + 1).unwrap_or(0));
+                    self.anthropic_next_content_block_index = new_index + 1;
+                    chunk = with_anthropic_content_block_start_index(chunk, new_index);
+                    content_block_start_index = Some(new_index);
+                }
             }
         }
         if let (Some(open_index), Some(open_kind), Some(delta_index), Some(delta_kind)) = (
@@ -1324,6 +1341,134 @@ mod tests {
             arguments_delta.block_kind(),
             Some(AnthropicContentBlockKind::ToolUse)
         );
+    }
+
+    #[test]
+    #[cfg(feature = "anthropic")]
+    fn test_stream_session_allocates_unique_same_kind_tool_start_after_remap() {
+        #[derive(Deserialize)]
+        struct ContentBlockStopEvent {
+            index: u32,
+        }
+
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+
+        let thinking_start = StreamOutputChunk::with_event(
+            to_bytes(&json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "thinking",
+                    "thinking": ""
+                }
+            })),
+            "content_block_start".to_string(),
+        );
+        let first_tool_start = StreamOutputChunk::with_event(
+            to_bytes(&json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "lookup",
+                    "input": {}
+                }
+            })),
+            "content_block_start".to_string(),
+        );
+        let second_tool_start = StreamOutputChunk::with_event(
+            to_bytes(&json!({
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_2",
+                    "name": "lookup",
+                    "input": {}
+                }
+            })),
+            "content_block_start".to_string(),
+        );
+        let first_tool_arguments = StreamOutputChunk::with_event(
+            to_bytes(&json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": "{\"first\":true}"
+                }
+            })),
+            "content_block_delta".to_string(),
+        );
+        let second_tool_arguments = StreamOutputChunk::with_event(
+            to_bytes(&json!({
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": "{\"second\":true}"
+                }
+            })),
+            "content_block_delta".to_string(),
+        );
+
+        let thinking = session.process_chunks(vec![thinking_start]).unwrap();
+        assert_eq!(
+            thinking
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_start")]
+        );
+
+        let first_tool = session.process_chunks(vec![first_tool_start]).unwrap();
+        assert_eq!(
+            first_tool
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_stop"), Some("content_block_start")]
+        );
+        let thinking_stop: ContentBlockStopEvent =
+            crate::serde_json::from_slice(&first_tool[0].data).unwrap();
+        assert_eq!(thinking_stop.index, 0);
+        let first_start: AnthropicContentBlockStartEventView =
+            crate::serde_json::from_slice(&first_tool[1].data).unwrap();
+        assert_eq!(first_start.index, 1);
+        assert_eq!(
+            first_start.block_kind(),
+            Some(AnthropicContentBlockKind::ToolUse)
+        );
+
+        let second_tool = session.process_chunks(vec![second_tool_start]).unwrap();
+        assert_eq!(
+            second_tool
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_stop"), Some("content_block_start")]
+        );
+        let first_tool_stop: ContentBlockStopEvent =
+            crate::serde_json::from_slice(&second_tool[0].data).unwrap();
+        assert_eq!(first_tool_stop.index, 1);
+        let second_start: AnthropicContentBlockStartEventView =
+            crate::serde_json::from_slice(&second_tool[1].data).unwrap();
+        assert_eq!(second_start.index, 2);
+        assert_eq!(
+            second_start.block_kind(),
+            Some(AnthropicContentBlockKind::ToolUse)
+        );
+
+        let first_arguments = session.process_chunks(vec![first_tool_arguments]).unwrap();
+        let first_delta: AnthropicContentBlockDeltaEventView =
+            crate::serde_json::from_slice(&first_arguments[0].data).unwrap();
+        assert_eq!(first_delta.index, 1);
+
+        let second_arguments = session.process_chunks(vec![second_tool_arguments]).unwrap();
+        let second_delta: AnthropicContentBlockDeltaEventView =
+            crate::serde_json::from_slice(&second_arguments[0].data).unwrap();
+        assert_eq!(second_delta.index, 2);
     }
 
     #[test]

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use crate::capabilities::ProviderFormat;
@@ -8,7 +9,6 @@ use crate::processing::transform::{
 };
 use crate::serde_json::Value;
 use crate::universal::UniversalStreamChunk;
-use serde::Deserialize;
 
 static EMPTY_JSON: Bytes = Bytes::from_static(b"{}");
 static SSE_DATA_PREFIX: &[u8] = b"data: ";
@@ -69,6 +69,7 @@ pub struct StreamTransformSession {
     // an equivalent event, so the session synthesizes `content_block_stop`.
     anthropic_open_content_block_index: Option<u32>,
     anthropic_open_content_block_kind: Option<AnthropicContentBlockKind>,
+    anthropic_next_content_block_index: u32,
     bedrock_tool_call_indexes: BTreeMap<u32, u32>,
     next_bedrock_tool_call_index: u32,
 }
@@ -91,6 +92,7 @@ impl StreamTransformSession {
             anthropic_tool_use_started: false,
             anthropic_open_content_block_index: None,
             anthropic_open_content_block_kind: None,
+            anthropic_next_content_block_index: 0,
             bedrock_tool_call_indexes: BTreeMap::new(),
             next_bedrock_tool_call_index: 0,
         }
@@ -285,7 +287,9 @@ impl StreamTransformSession {
             self.anthropic_tool_use_started = false;
             self.anthropic_open_content_block_index = None;
             self.anthropic_open_content_block_kind = None;
+            self.anthropic_next_content_block_index = 0;
         }
+        let mut chunk = chunk;
         if let (Some(open_index), Some(open_kind), Some(delta_index), Some(delta_kind)) = (
             self.anthropic_open_content_block_index,
             self.anthropic_open_content_block_kind,
@@ -293,10 +297,15 @@ impl StreamTransformSession {
             content_block_delta_kind,
         ) {
             if open_kind != delta_kind && delta_kind.can_synthesize_start() {
-                self.anthropic_open_content_block_index = Some(delta_index);
+                let new_index = self.anthropic_next_content_block_index.max(open_index + 1);
+                self.anthropic_next_content_block_index = new_index + 1;
+                chunk = with_anthropic_content_block_delta_index(chunk, new_index);
+                self.anthropic_open_content_block_index = Some(new_index);
                 self.anthropic_open_content_block_kind = Some(delta_kind);
                 prefix.push(anthropic_content_block_stop_chunk(open_index));
-                prefix.push(anthropic_content_block_start_chunk(delta_index, delta_kind));
+                prefix.push(anthropic_content_block_start_chunk(new_index, delta_kind));
+            } else if open_kind == delta_kind && delta_index != open_index {
+                chunk = with_anthropic_content_block_delta_index(chunk, open_index);
             }
         }
         if (is_content_block_start || is_delta || is_stop)
@@ -310,6 +319,10 @@ impl StreamTransformSession {
         if is_content_block_start {
             self.anthropic_open_content_block_index = content_block_start_index;
             self.anthropic_open_content_block_kind = content_block_start_kind;
+            if let Some(index) = content_block_start_index {
+                self.anthropic_next_content_block_index =
+                    self.anthropic_next_content_block_index.max(index + 1);
+            }
         }
         if is_content_block_stop {
             self.anthropic_open_content_block_index = None;
@@ -333,6 +346,7 @@ impl StreamTransformSession {
                 self.anthropic_tool_use_started = false;
                 self.anthropic_open_content_block_index = None;
                 self.anthropic_open_content_block_kind = None;
+                self.anthropic_next_content_block_index = 0;
                 out.push(stop);
             }
             return Ok(out);
@@ -353,6 +367,7 @@ impl StreamTransformSession {
             self.anthropic_tool_use_started = false;
             self.anthropic_open_content_block_index = None;
             self.anthropic_open_content_block_kind = None;
+            self.anthropic_next_content_block_index = 0;
         }
 
         let mut out = prefix;
@@ -371,6 +386,7 @@ impl StreamTransformSession {
             self.anthropic_tool_use_started = false;
             self.anthropic_open_content_block_index = None;
             self.anthropic_open_content_block_kind = None;
+            self.anthropic_next_content_block_index = 0;
             out.push(stop);
         }
         out
@@ -422,6 +438,14 @@ impl AnthropicContentBlockDeltaEventView {
 struct AnthropicContentBlockDeltaView {
     #[serde(rename = "type")]
     delta_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AnthropicContentBlockDeltaEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    index: u32,
+    delta: Value,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -537,6 +561,25 @@ fn anthropic_content_block_start_chunk(
         .unwrap_or_else(|_| Bytes::new()),
         "content_block_start".to_string(),
     )
+}
+
+fn with_anthropic_content_block_delta_index(
+    chunk: StreamOutputChunk,
+    index: u32,
+) -> StreamOutputChunk {
+    let Ok(mut event) =
+        crate::serde_json::from_slice::<AnthropicContentBlockDeltaEvent>(&chunk.data)
+    else {
+        return chunk;
+    };
+    event.index = index;
+    let Ok(data) = crate::serde_json::to_vec(&event).map(Bytes::from) else {
+        return chunk;
+    };
+    StreamOutputChunk {
+        data,
+        event_type: chunk.event_type,
+    }
 }
 
 fn with_anthropic_tool_use_stop_reason(chunk: StreamOutputChunk) -> StreamOutputChunk {
@@ -739,6 +782,10 @@ fn expand_anthropic_session_chunks(
     }
 
     if let Some(thinking) = reasoning_text {
+        let content = delta_view
+            .as_ref()
+            .and_then(|d| d.content.as_deref())
+            .filter(|s| !s.is_empty());
         if !anthropic_message_started {
             out.push(StreamOutputChunk::with_event(
                 anthropic_message_start_bytes(universal),
@@ -763,6 +810,27 @@ fn expand_anthropic_session_chunks(
             .unwrap_or_else(|_| Bytes::new()),
             "content_block_delta".to_string(),
         ));
+        if let Some(content) = content {
+            out.push(StreamOutputChunk::with_event(
+                serialize_stream_value(&crate::serde_json::json!({
+                    "type": "content_block_delta",
+                    "index": choice.map(|c| c.index).unwrap_or(0),
+                    "delta": {
+                        "type": "text_delta",
+                        "text": content
+                    }
+                }))
+                .unwrap_or_else(|_| Bytes::new()),
+                "content_block_delta".to_string(),
+            ));
+        }
+        if has_finish {
+            out.append(&mut chunks);
+            out.push(StreamOutputChunk::with_event(
+                Bytes::from_static(br#"{"type":"message_stop"}"#),
+                "message_stop".to_string(),
+            ));
+        }
         return out;
     }
 
@@ -1334,6 +1402,17 @@ mod tests {
             thinking: String,
         }
 
+        #[derive(Deserialize)]
+        struct TextDeltaEvent {
+            index: u32,
+            delta: TextDelta,
+        }
+
+        #[derive(Deserialize)]
+        struct TextDelta {
+            text: String,
+        }
+
         let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
         let first_thought = to_bytes(&json!({
             "responseId": "response_123",
@@ -1435,6 +1514,91 @@ mod tests {
         assert_eq!(
             text_start.block_kind(),
             Some(AnthropicContentBlockKind::Text)
+        );
+        assert_eq!(text_start.index, 1);
+
+        let text_delta: TextDeltaEvent = crate::serde_json::from_slice(&third[2].data).unwrap();
+        assert_eq!(text_delta.index, 1);
+        assert_eq!(text_delta.delta.text, "The visible answer.");
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "anthropic"))]
+    fn test_stream_session_google_mixed_thought_and_text_chunk_preserves_both_blocks() {
+        #[derive(Deserialize)]
+        struct TextDeltaEvent {
+            index: u32,
+            delta: TextDelta,
+        }
+
+        #[derive(Deserialize)]
+        struct TextDelta {
+            text: String,
+        }
+
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+        let mixed_final = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "text": "thinking in the same candidate",
+                            "thought": true
+                        },
+                        {
+                            "text": "{\"answer\":\"visible json\"}"
+                        }
+                    ]
+                },
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 1,
+                "candidatesTokenCount": 4,
+                "thoughtsTokenCount": 2,
+                "totalTokenCount": 7
+            }
+        }));
+
+        let out = session.push(mixed_final).unwrap();
+        assert_eq!(
+            out.iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("message_start"),
+                Some("content_block_start"),
+                Some("content_block_delta"),
+                Some("content_block_stop"),
+                Some("content_block_start"),
+                Some("content_block_delta"),
+                Some("content_block_stop")
+            ]
+        );
+
+        let text_start: AnthropicContentBlockStartEventView =
+            crate::serde_json::from_slice(&out[4].data).unwrap();
+        assert_eq!(text_start.index, 1);
+        assert_eq!(
+            text_start.block_kind(),
+            Some(AnthropicContentBlockKind::Text)
+        );
+
+        let text_delta: TextDeltaEvent = crate::serde_json::from_slice(&out[5].data).unwrap();
+        assert_eq!(text_delta.index, 1);
+        assert_eq!(text_delta.delta.text, "{\"answer\":\"visible json\"}");
+
+        let final_chunks = session.finish();
+        assert_eq!(
+            final_chunks
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("message_delta"), Some("message_stop")]
         );
     }
 

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -263,7 +263,7 @@ impl StreamTransformSession {
         let is_content_block_start = chunk.event_type.as_deref() == Some("content_block_start");
         let is_content_block_stop = chunk.event_type.as_deref() == Some("content_block_stop");
         let content_block_start = parse_anthropic_content_block_start_event(&chunk)?;
-        let content_block_start_index = content_block_start.as_ref().map(|event| event.index);
+        let mut content_block_start_index = content_block_start.as_ref().map(|event| event.index);
         let content_block_start_kind = content_block_start
             .as_ref()
             .and_then(AnthropicContentBlockStartEventView::block_kind);
@@ -290,6 +290,22 @@ impl StreamTransformSession {
             self.anthropic_next_content_block_index = 0;
         }
         let mut chunk = chunk;
+        if let (Some(open_index), Some(open_kind), Some(start_index), Some(start_kind)) = (
+            self.anthropic_open_content_block_index,
+            self.anthropic_open_content_block_kind,
+            content_block_start_index,
+            content_block_start_kind,
+        ) {
+            if open_kind != start_kind {
+                let new_index = self.anthropic_next_content_block_index.max(open_index + 1);
+                self.anthropic_next_content_block_index = new_index + 1;
+                chunk = with_anthropic_content_block_start_index(chunk, new_index);
+                content_block_start_index = Some(new_index);
+            } else if start_index != open_index {
+                chunk = with_anthropic_content_block_start_index(chunk, open_index);
+                content_block_start_index = Some(open_index);
+            }
+        }
         if let (Some(open_index), Some(open_kind), Some(delta_index), Some(delta_kind)) = (
             self.anthropic_open_content_block_index,
             self.anthropic_open_content_block_kind,
@@ -399,6 +415,14 @@ struct AnthropicContentBlockStartEventView {
     _event_type: AnthropicStreamEventTypeView,
     index: u32,
     content_block: Option<AnthropicContentBlockView>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AnthropicContentBlockStartEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    index: u32,
+    content_block: Value,
 }
 
 impl AnthropicContentBlockStartEventView {
@@ -569,6 +593,25 @@ fn with_anthropic_content_block_delta_index(
 ) -> StreamOutputChunk {
     let Ok(mut event) =
         crate::serde_json::from_slice::<AnthropicContentBlockDeltaEvent>(&chunk.data)
+    else {
+        return chunk;
+    };
+    event.index = index;
+    let Ok(data) = crate::serde_json::to_vec(&event).map(Bytes::from) else {
+        return chunk;
+    };
+    StreamOutputChunk {
+        data,
+        event_type: chunk.event_type,
+    }
+}
+
+fn with_anthropic_content_block_start_index(
+    chunk: StreamOutputChunk,
+    index: u32,
+) -> StreamOutputChunk {
+    let Ok(mut event) =
+        crate::serde_json::from_slice::<AnthropicContentBlockStartEvent>(&chunk.data)
     else {
         return chunk;
     };
@@ -823,6 +866,48 @@ fn expand_anthropic_session_chunks(
                 .unwrap_or_else(|_| Bytes::new()),
                 "content_block_delta".to_string(),
             ));
+        }
+        if let Some(delta_view) = delta_view.as_ref() {
+            for tool_call in &delta_view.tool_calls {
+                let tool_index = tool_call
+                    .index
+                    .unwrap_or(choice.map(|c| c.index).unwrap_or(0));
+                let function = tool_call.function.clone().unwrap_or_default();
+                let tool_name = function.name.unwrap_or_default();
+                let tool_id = tool_call.id.clone().unwrap_or_default();
+                if !tool_name.is_empty() || !tool_id.is_empty() {
+                    out.push(StreamOutputChunk::with_event(
+                        serialize_stream_value(&crate::serde_json::json!({
+                            "type": "content_block_start",
+                            "index": tool_index,
+                            "content_block": {
+                                "type": "tool_use",
+                                "id": tool_id,
+                                "name": tool_name,
+                                "input": {}
+                            }
+                        }))
+                        .unwrap_or_else(|_| Bytes::new()),
+                        "content_block_start".to_string(),
+                    ));
+                }
+                if let Some(arguments) =
+                    function.arguments.filter(|arguments| !arguments.is_empty())
+                {
+                    out.push(StreamOutputChunk::with_event(
+                        serialize_stream_value(&crate::serde_json::json!({
+                            "type": "content_block_delta",
+                            "index": tool_index,
+                            "delta": {
+                                "type": "input_json_delta",
+                                "partial_json": arguments
+                            }
+                        }))
+                        .unwrap_or_else(|_| Bytes::new()),
+                        "content_block_delta".to_string(),
+                    ));
+                }
+            }
         }
         if has_finish {
             out.append(&mut chunks);
@@ -1599,6 +1684,67 @@ mod tests {
                 .map(|chunk| chunk.event_type.as_deref())
                 .collect::<Vec<_>>(),
             vec![Some("message_delta"), Some("message_stop")]
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "anthropic"))]
+    fn test_stream_session_google_mixed_thought_and_tool_call_preserves_tool_use() {
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+        let mixed_tool = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "text": "thinking before the tool",
+                            "thought": true
+                        },
+                        {
+                            "functionCall": {
+                                "name": "lookup_creator",
+                                "args": {
+                                    "query": "microphone comparison"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }]
+        }));
+
+        let out = session.push(mixed_tool).unwrap();
+        assert_eq!(
+            out.iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("message_start"),
+                Some("content_block_start"),
+                Some("content_block_delta"),
+                Some("content_block_stop"),
+                Some("content_block_start"),
+                Some("content_block_delta")
+            ]
+        );
+
+        let tool_start: AnthropicContentBlockStartEventView =
+            crate::serde_json::from_slice(&out[4].data).unwrap();
+        assert_eq!(tool_start.index, 1);
+        assert_eq!(
+            tool_start.block_kind(),
+            Some(AnthropicContentBlockKind::ToolUse)
+        );
+
+        let tool_delta: AnthropicContentBlockDeltaEventView =
+            crate::serde_json::from_slice(&out[5].data).unwrap();
+        assert_eq!(tool_delta.index, 1);
+        assert_eq!(
+            tool_delta.block_kind(),
+            Some(AnthropicContentBlockKind::ToolUse)
         );
     }
 

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -985,6 +985,7 @@ fn expand_anthropic_session_chunks(
     }
 
     if has_reasoning {
+        let reasoning_index = choice.map(|c| c.index).unwrap_or(0);
         let content = delta_view
             .as_ref()
             .and_then(|d| d.content.as_deref())
@@ -995,9 +996,9 @@ fn expand_anthropic_session_chunks(
                 "message_start".to_string(),
             ));
             out.push(StreamOutputChunk::with_event(
-                Bytes::from_static(
-                    br#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#,
-                ),
+                Bytes::from(format!(
+                    r#"{{"type":"content_block_start","index":{reasoning_index},"content_block":{{"type":"thinking","thinking":""}}}}"#
+                )),
                 "content_block_start".to_string(),
             ));
         }
@@ -1005,7 +1006,7 @@ fn expand_anthropic_session_chunks(
             out.push(StreamOutputChunk::with_event(
                 serialize_stream_value(&crate::serde_json::json!({
                     "type": "content_block_delta",
-                    "index": choice.map(|c| c.index).unwrap_or(0),
+                    "index": reasoning_index,
                     "delta": {
                         "type": "thinking_delta",
                         "thinking": thinking
@@ -1019,7 +1020,7 @@ fn expand_anthropic_session_chunks(
             out.push(StreamOutputChunk::with_event(
                 serialize_stream_value(&crate::serde_json::json!({
                     "type": "content_block_delta",
-                    "index": choice.map(|c| c.index).unwrap_or(0),
+                    "index": reasoning_index,
                     "delta": {
                         "type": "signature_delta",
                         "signature": signature
@@ -1033,7 +1034,7 @@ fn expand_anthropic_session_chunks(
             out.push(StreamOutputChunk::with_event(
                 serialize_stream_value(&crate::serde_json::json!({
                     "type": "content_block_delta",
-                    "index": choice.map(|c| c.index).unwrap_or(0),
+                    "index": reasoning_index,
                     "delta": {
                         "type": "text_delta",
                         "text": content
@@ -1045,9 +1046,7 @@ fn expand_anthropic_session_chunks(
         }
         if let Some(delta_view) = delta_view.as_ref() {
             for tool_call in &delta_view.tool_calls {
-                let tool_index = tool_call
-                    .index
-                    .unwrap_or(choice.map(|c| c.index).unwrap_or(0));
+                let tool_index = tool_call.index.unwrap_or(reasoning_index);
                 let function = tool_call.function.clone().unwrap_or_default();
                 let tool_name = function.name.unwrap_or_default();
                 let tool_id = tool_call.id.clone().unwrap_or_default();
@@ -2157,6 +2156,62 @@ mod tests {
         let text_delta: TextDeltaEvent = crate::serde_json::from_slice(&third[3].data).unwrap();
         assert_eq!(text_delta.index, 1);
         assert_eq!(text_delta.delta.text, "The visible answer.");
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "anthropic"))]
+    fn test_stream_session_google_nonzero_candidate_thinking_starts_matching_block() {
+        #[derive(Deserialize)]
+        struct ThinkingDeltaEvent {
+            index: u32,
+            delta: ThinkingDelta,
+        }
+
+        #[derive(Deserialize)]
+        struct ThinkingDelta {
+            thinking: String,
+        }
+
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+        let thought = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 1,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "text": "candidate one thinking",
+                        "thought": true
+                    }]
+                }
+            }]
+        }));
+
+        let out = session.push(thought).unwrap();
+        assert_eq!(
+            out.iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("message_start"),
+                Some("content_block_start"),
+                Some("content_block_delta")
+            ]
+        );
+
+        let thinking_start: AnthropicContentBlockStartEventView =
+            crate::serde_json::from_slice(&out[1].data).unwrap();
+        assert_eq!(
+            thinking_start.block_kind(),
+            Some(AnthropicContentBlockKind::Thinking)
+        );
+        assert_eq!(thinking_start.index, 1);
+
+        let thinking_delta: ThinkingDeltaEvent =
+            crate::serde_json::from_slice(&out[2].data).unwrap();
+        assert_eq!(thinking_delta.index, 1);
+        assert_eq!(thinking_delta.delta.thinking, "candidate one thinking");
     }
 
     #[test]

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -76,6 +76,8 @@ pub struct StreamTransformSession {
     anthropic_next_content_block_index: u32,
     anthropic_content_block_index_map: BTreeMap<(AnthropicContentBlockKind, u32), u32>,
     responses_message_started: bool,
+    responses_tool_call_indexes: BTreeMap<u32, u32>,
+    next_responses_tool_call_index: u32,
     bedrock_tool_call_indexes: BTreeMap<u32, u32>,
     next_bedrock_tool_call_index: u32,
 }
@@ -101,6 +103,8 @@ impl StreamTransformSession {
             anthropic_next_content_block_index: 0,
             anthropic_content_block_index_map: BTreeMap::new(),
             responses_message_started: false,
+            responses_tool_call_indexes: BTreeMap::new(),
+            next_responses_tool_call_index: 0,
             bedrock_tool_call_indexes: BTreeMap::new(),
             next_bedrock_tool_call_index: 0,
         }
@@ -124,7 +128,7 @@ impl StreamTransformSession {
             }]);
         }
 
-        let result = self.normalize_bedrock_to_openai_stream_result(&step)?;
+        let result = self.normalize_source_stream_result(&step)?;
 
         let chunks = build_session_chunks(
             result,
@@ -138,17 +142,31 @@ impl StreamTransformSession {
         self.process_chunks(chunks)
     }
 
+    fn normalize_source_stream_result(
+        &mut self,
+        step: &crate::processing::transform::StreamTransformStep,
+    ) -> Result<TransformResult, TransformError> {
+        if step.source_format == ProviderFormat::Converse
+            && self.target_format == ProviderFormat::ChatCompletions
+            && step.source_is_native_stream
+        {
+            return self.normalize_bedrock_to_openai_stream_result(step);
+        }
+
+        if step.source_format == ProviderFormat::Responses
+            && self.target_format != ProviderFormat::Responses
+            && step.source_is_native_stream
+        {
+            return self.normalize_responses_tool_call_indexes_stream_result(step);
+        }
+
+        Ok(step.result.clone())
+    }
+
     fn normalize_bedrock_to_openai_stream_result(
         &mut self,
         step: &crate::processing::transform::StreamTransformStep,
     ) -> Result<TransformResult, TransformError> {
-        if step.source_format != ProviderFormat::Converse
-            || self.target_format != ProviderFormat::ChatCompletions
-            || !step.source_is_native_stream
-        {
-            return Ok(step.result.clone());
-        }
-
         let Some(mut universal) = step.universal.clone() else {
             return Ok(step.result.clone());
         };
@@ -174,6 +192,71 @@ impl StreamTransformSession {
             source_format: step.source_format,
             actual_target_format: self.target_format,
         })
+    }
+
+    fn normalize_responses_tool_call_indexes_stream_result(
+        &mut self,
+        step: &crate::processing::transform::StreamTransformStep,
+    ) -> Result<TransformResult, TransformError> {
+        let Some(mut universal) = step.universal.clone() else {
+            return Ok(step.result.clone());
+        };
+
+        self.remap_responses_tool_call_indexes(&mut universal);
+
+        let should_reset = universal
+            .choices
+            .iter()
+            .any(|choice| choice.finish_reason.is_some());
+
+        let target_adapter = adapter_for_format(self.target_format)
+            .ok_or(TransformError::UnsupportedTargetFormat(self.target_format))?;
+        let bytes = serialize_stream_value(&target_adapter.stream_from_universal(&universal)?)?;
+
+        if should_reset {
+            self.responses_tool_call_indexes.clear();
+            self.next_responses_tool_call_index = 0;
+        }
+
+        Ok(TransformResult::Transformed {
+            bytes,
+            source_format: step.source_format,
+            actual_target_format: self.target_format,
+        })
+    }
+
+    fn remap_responses_tool_call_indexes(&mut self, universal: &mut UniversalStreamChunk) {
+        for choice in &mut universal.choices {
+            let Some(mut delta) = choice.delta_view() else {
+                continue;
+            };
+
+            if delta.tool_calls.is_empty() {
+                continue;
+            }
+
+            for tool_call in &mut delta.tool_calls {
+                let Some(responses_output_index) = tool_call.index else {
+                    continue;
+                };
+                let tool_index = match self
+                    .responses_tool_call_indexes
+                    .get(&responses_output_index)
+                {
+                    Some(index) => *index,
+                    None => {
+                        let index = self.next_responses_tool_call_index;
+                        self.next_responses_tool_call_index += 1;
+                        self.responses_tool_call_indexes
+                            .insert(responses_output_index, index);
+                        index
+                    }
+                };
+                tool_call.index = Some(tool_index);
+            }
+
+            choice.delta = Some(Value::from(delta));
+        }
     }
 
     fn remap_bedrock_tool_call_indexes(&mut self, universal: &mut UniversalStreamChunk) {
@@ -2583,6 +2666,61 @@ mod tests {
         let mut session = StreamTransformSession::new(ProviderFormat::ChatCompletions);
         let out = session.finish_sse();
         assert_eq!(out, vec![Bytes::from_static(b"data: [DONE]\n\n")]);
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
+    fn test_stream_session_maps_responses_output_item_indexes_to_tool_call_indexes() {
+        let mut session = StreamTransformSession::new(ProviderFormat::ChatCompletions);
+
+        let reasoning = to_bytes(&json!({
+            "type": "response.reasoning_summary_text.delta",
+            "output_index": 0,
+            "summary_index": 0,
+            "delta": "thinking before tool"
+        }));
+        let reasoning_out = session.push(reasoning).unwrap();
+        assert_eq!(reasoning_out.len(), 1);
+        let reasoning_chunk: Value = crate::serde_json::from_slice(&reasoning_out[0].data).unwrap();
+        assert_eq!(
+            reasoning_chunk["choices"][0]["index"],
+            json!(0),
+            "reasoning output item should remain one assistant choice"
+        );
+
+        let tool_start = to_bytes(&json!({
+            "type": "response.output_item.added",
+            "output_index": 1,
+            "item": {
+                "type": "function_call",
+                "status": "in_progress",
+                "call_id": "call_lookup",
+                "name": "lookup_creator",
+                "arguments": ""
+            }
+        }));
+        let start_out = session.push(tool_start).unwrap();
+        assert_eq!(start_out.len(), 1);
+        let start_chunk: Value = crate::serde_json::from_slice(&start_out[0].data).unwrap();
+        assert_eq!(start_chunk["choices"][0]["index"], json!(0));
+        assert_eq!(
+            start_chunk["choices"][0]["delta"]["tool_calls"][0]["index"],
+            json!(0)
+        );
+
+        let tool_args = to_bytes(&json!({
+            "type": "response.function_call_arguments.delta",
+            "output_index": 1,
+            "delta": "{\"query\":\"microphone comparison\"}"
+        }));
+        let args_out = session.push(tool_args).unwrap();
+        assert_eq!(args_out.len(), 1);
+        let args_chunk: Value = crate::serde_json::from_slice(&args_out[0].data).unwrap();
+        assert_eq!(args_chunk["choices"][0]["index"], json!(0));
+        assert_eq!(
+            args_chunk["choices"][0]["delta"]["tool_calls"][0]["index"],
+            json!(0)
+        );
     }
 
     #[test]

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -259,7 +259,7 @@ impl StreamTransformSession {
         // Enforce Anthropic event ordering after provider adapters have produced
         // Anthropic-shaped chunks: one message_start, balanced content blocks,
         // tool_use stop reasons, and merged finish/usage message_delta events.
-        let is_delta = chunk.event_type.as_deref() == Some("message_delta");
+        let is_message_delta = chunk.event_type.as_deref() == Some("message_delta");
         let is_stop = chunk.event_type.as_deref() == Some("message_stop");
         let is_start = chunk.event_type.as_deref() == Some("message_start");
         let is_content_block_start = chunk.event_type.as_deref() == Some("content_block_start");
@@ -277,7 +277,7 @@ impl StreamTransformSession {
         let is_tool_use_start = content_block_start
             .as_ref()
             .is_some_and(AnthropicContentBlockStartEventView::is_tool_use_start);
-        let chunk = if is_delta && self.anthropic_tool_use_started {
+        let chunk = if is_message_delta && self.anthropic_tool_use_started {
             with_anthropic_tool_use_stop_reason(chunk)
         } else {
             chunk
@@ -322,7 +322,10 @@ impl StreamTransformSession {
                 chunk = with_anthropic_content_block_delta_index(chunk, open_index);
             }
         }
-        if (is_content_block_start || is_delta || is_stop)
+        // This closes blocks before explicit block starts and terminal message
+        // deltas. Content-block deltas, including synthesized kind switches
+        // above, must stay inside their open block until the delta is emitted.
+        if (is_content_block_start || is_message_delta || is_stop)
             && self.anthropic_open_content_block_index.is_some()
         {
             if let Some(index) = self.anthropic_open_content_block_index.take() {
@@ -346,7 +349,7 @@ impl StreamTransformSession {
             self.anthropic_tool_use_started = true;
         }
 
-        if is_delta && self.buffered_delta.is_some() {
+        if is_message_delta && self.buffered_delta.is_some() {
             let merged = merge_delta_usage(
                 self.buffered_delta
                     .take()
@@ -366,7 +369,7 @@ impl StreamTransformSession {
             return Ok(out);
         }
 
-        if is_delta {
+        if is_message_delta {
             self.buffered_delta = Some(chunk);
             return Ok(prefix);
         }
@@ -1725,6 +1728,11 @@ mod tests {
     #[cfg(all(feature = "google", feature = "anthropic"))]
     fn test_stream_session_google_mixed_thought_and_text_chunk_preserves_both_blocks() {
         #[derive(Deserialize)]
+        struct ContentBlockStopEvent {
+            index: u32,
+        }
+
+        #[derive(Deserialize)]
         struct TextDeltaEvent {
             index: u32,
             delta: TextDelta,
@@ -1790,6 +1798,9 @@ mod tests {
         let text_delta: TextDeltaEvent = crate::serde_json::from_slice(&out[5].data).unwrap();
         assert_eq!(text_delta.index, 1);
         assert_eq!(text_delta.delta.text, "{\"answer\":\"visible json\"}");
+
+        let text_stop: ContentBlockStopEvent = crate::serde_json::from_slice(&out[6].data).unwrap();
+        assert_eq!(text_stop.index, 1);
 
         let final_chunks = session.finish();
         assert_eq!(

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -7,6 +7,8 @@ use crate::processing::adapters::adapter_for_format;
 use crate::processing::transform::{
     serialize_stream_value, transform_stream_chunk_step, TransformError, TransformResult,
 };
+#[cfg(feature = "openai")]
+use crate::providers::openai::responses_adapter::responses_stream_events_from_universal;
 use crate::serde_json::Value;
 use crate::universal::UniversalStreamChunk;
 
@@ -290,10 +292,9 @@ impl StreamTransformSession {
             self.anthropic_next_content_block_index = 0;
         }
         let mut chunk = chunk;
-        if let (Some(open_index), Some(open_kind), Some(start_index), Some(start_kind)) = (
+        if let (Some(open_index), Some(open_kind), Some(start_kind)) = (
             self.anthropic_open_content_block_index,
             self.anthropic_open_content_block_kind,
-            content_block_start_index,
             content_block_start_kind,
         ) {
             if open_kind != start_kind {
@@ -301,9 +302,6 @@ impl StreamTransformSession {
                 self.anthropic_next_content_block_index = new_index + 1;
                 chunk = with_anthropic_content_block_start_index(chunk, new_index);
                 content_block_start_index = Some(new_index);
-            } else if start_index != open_index {
-                chunk = with_anthropic_content_block_start_index(chunk, open_index);
-                content_block_start_index = Some(open_index);
             }
         }
         if let (Some(open_index), Some(open_kind), Some(delta_index), Some(delta_kind)) = (
@@ -759,7 +757,39 @@ fn build_session_chunks(
             anthropic_message_started,
         ));
     }
+    if target_format == ProviderFormat::Responses {
+        #[cfg(feature = "openai")]
+        return expand_responses_session_chunks(chunks, universal);
+        #[cfg(not(feature = "openai"))]
+        return Ok(std::mem::take(&mut chunks));
+    }
     Ok(std::mem::take(&mut chunks))
+}
+
+fn expand_responses_session_chunks(
+    chunks: Vec<StreamOutputChunk>,
+    universal: Option<&UniversalStreamChunk>,
+) -> Result<Vec<StreamOutputChunk>, TransformError> {
+    let Some(universal) = universal else {
+        return Ok(chunks);
+    };
+
+    let out = responses_stream_events_from_universal(universal)
+        .into_iter()
+        .map(|event| {
+            let event_type = extract_event_type(&event);
+            Ok(StreamOutputChunk {
+                data: serialize_stream_value(&event)?,
+                event_type,
+            })
+        })
+        .collect::<Result<Vec<_>, TransformError>>()?;
+
+    if out.is_empty() {
+        Ok(chunks)
+    } else {
+        Ok(out)
+    }
 }
 
 fn expand_anthropic_session_chunks(
@@ -1171,6 +1201,72 @@ mod tests {
         assert!(matches!(err, TransformError::DeserializationFailed(_)));
         assert!(err.to_string().contains("Anthropic content_block_start"));
         assert!(err.to_string().contains("missing field `index`"));
+    }
+
+    #[test]
+    #[cfg(feature = "anthropic")]
+    fn test_stream_session_preserves_new_same_kind_anthropic_block_index() {
+        #[derive(Deserialize)]
+        struct ContentBlockStopEvent {
+            index: u32,
+        }
+
+        let mut session = StreamTransformSession::new(ProviderFormat::Anthropic);
+
+        let first_tool_start = StreamOutputChunk::with_event(
+            to_bytes(&json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "lookup",
+                    "input": {}
+                }
+            })),
+            "content_block_start".to_string(),
+        );
+        let second_tool_start = StreamOutputChunk::with_event(
+            to_bytes(&json!({
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_2",
+                    "name": "lookup",
+                    "input": {}
+                }
+            })),
+            "content_block_start".to_string(),
+        );
+
+        let first = session.process_chunks(vec![first_tool_start]).unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_start")]
+        );
+
+        let second = session.process_chunks(vec![second_tool_start]).unwrap();
+        assert_eq!(
+            second
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_stop"), Some("content_block_start")]
+        );
+
+        let stop: ContentBlockStopEvent = crate::serde_json::from_slice(&second[0].data)
+            .expect("content_block_stop should parse");
+        assert_eq!(stop.index, 0);
+
+        let start: AnthropicContentBlockStartEventView =
+            crate::serde_json::from_slice(&second[1].data)
+                .expect("content_block_start should parse");
+        assert_eq!(start.index, 1);
+        assert_eq!(start.block_kind(), Some(AnthropicContentBlockKind::ToolUse));
     }
 
     #[test]
@@ -1781,6 +1877,92 @@ mod tests {
         assert_eq!(
             tool_delta.block_kind(),
             Some(AnthropicContentBlockKind::ToolUse)
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "openai"))]
+    fn test_stream_session_google_mixed_thought_and_text_expands_to_responses_events() {
+        let mut session = StreamTransformSession::new(ProviderFormat::Responses);
+        let mixed_final = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "text": "thinking in the same candidate",
+                            "thought": true
+                        },
+                        {
+                            "text": "{\"answer\":\"visible json\"}"
+                        }
+                    ]
+                },
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 1,
+                "candidatesTokenCount": 4,
+                "thoughtsTokenCount": 2,
+                "totalTokenCount": 7
+            }
+        }));
+
+        let out = session.push(mixed_final).unwrap();
+        assert_eq!(
+            out.iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("response.reasoning_summary_text.delta"),
+                Some("response.output_text.delta"),
+                Some("response.completed")
+            ]
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "openai"))]
+    fn test_stream_session_google_mixed_thought_and_tool_expands_to_responses_events() {
+        let mut session = StreamTransformSession::new(ProviderFormat::Responses);
+        let mixed_tool = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "text": "thinking before the tool",
+                            "thought": true
+                        },
+                        {
+                            "functionCall": {
+                                "name": "lookup_creator",
+                                "args": {
+                                    "query": "microphone comparison"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }]
+        }));
+
+        let out = session.push(mixed_tool).unwrap();
+        assert_eq!(
+            out.iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("response.reasoning_summary_text.delta"),
+                Some("response.output_item.added"),
+                Some("response.function_call_arguments.delta")
+            ]
         );
     }
 

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -72,6 +72,7 @@ pub struct StreamTransformSession {
     anthropic_open_content_block_index: Option<u32>,
     anthropic_open_content_block_kind: Option<AnthropicContentBlockKind>,
     anthropic_next_content_block_index: u32,
+    anthropic_content_block_index_map: BTreeMap<(AnthropicContentBlockKind, u32), u32>,
     bedrock_tool_call_indexes: BTreeMap<u32, u32>,
     next_bedrock_tool_call_index: u32,
 }
@@ -95,6 +96,7 @@ impl StreamTransformSession {
             anthropic_open_content_block_index: None,
             anthropic_open_content_block_kind: None,
             anthropic_next_content_block_index: 0,
+            anthropic_content_block_index_map: BTreeMap::new(),
             bedrock_tool_call_indexes: BTreeMap::new(),
             next_bedrock_tool_call_index: 0,
         }
@@ -290,8 +292,10 @@ impl StreamTransformSession {
             self.anthropic_open_content_block_index = None;
             self.anthropic_open_content_block_kind = None;
             self.anthropic_next_content_block_index = 0;
+            self.anthropic_content_block_index_map.clear();
         }
         let mut chunk = chunk;
+        let source_content_block_start_index = content_block_start_index;
         if let (Some(open_index), Some(open_kind), Some(start_kind)) = (
             self.anthropic_open_content_block_index,
             self.anthropic_open_content_block_kind,
@@ -316,10 +320,19 @@ impl StreamTransformSession {
                 chunk = with_anthropic_content_block_delta_index(chunk, new_index);
                 self.anthropic_open_content_block_index = Some(new_index);
                 self.anthropic_open_content_block_kind = Some(delta_kind);
+                self.anthropic_content_block_index_map
+                    .insert((delta_kind, delta_index), new_index);
                 prefix.push(anthropic_content_block_stop_chunk(open_index));
                 prefix.push(anthropic_content_block_start_chunk(new_index, delta_kind));
-            } else if open_kind == delta_kind && delta_index != open_index {
-                chunk = with_anthropic_content_block_delta_index(chunk, open_index);
+            } else if open_kind == delta_kind {
+                if let Some(mapped_index) = self
+                    .anthropic_content_block_index_map
+                    .get(&(delta_kind, delta_index))
+                    .copied()
+                    .filter(|mapped_index| *mapped_index != delta_index)
+                {
+                    chunk = with_anthropic_content_block_delta_index(chunk, mapped_index);
+                }
             }
         }
         // This closes blocks before explicit block starts and terminal message
@@ -336,6 +349,14 @@ impl StreamTransformSession {
         if is_content_block_start {
             self.anthropic_open_content_block_index = content_block_start_index;
             self.anthropic_open_content_block_kind = content_block_start_kind;
+            if let (Some(source_index), Some(target_index), Some(kind)) = (
+                source_content_block_start_index,
+                content_block_start_index,
+                content_block_start_kind,
+            ) {
+                self.anthropic_content_block_index_map
+                    .insert((kind, source_index), target_index);
+            }
             if let Some(index) = content_block_start_index {
                 self.anthropic_next_content_block_index =
                     self.anthropic_next_content_block_index.max(index + 1);
@@ -364,6 +385,7 @@ impl StreamTransformSession {
                 self.anthropic_open_content_block_index = None;
                 self.anthropic_open_content_block_kind = None;
                 self.anthropic_next_content_block_index = 0;
+                self.anthropic_content_block_index_map.clear();
                 out.push(stop);
             }
             return Ok(out);
@@ -385,6 +407,7 @@ impl StreamTransformSession {
             self.anthropic_open_content_block_index = None;
             self.anthropic_open_content_block_kind = None;
             self.anthropic_next_content_block_index = 0;
+            self.anthropic_content_block_index_map.clear();
         }
 
         let mut out = prefix;
@@ -404,6 +427,7 @@ impl StreamTransformSession {
             self.anthropic_open_content_block_index = None;
             self.anthropic_open_content_block_kind = None;
             self.anthropic_next_content_block_index = 0;
+            self.anthropic_content_block_index_map.clear();
             out.push(stop);
         }
         out
@@ -473,7 +497,7 @@ struct AnthropicContentBlockDeltaEvent {
     delta: Value,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum AnthropicContentBlockKind {
     Text,
     Thinking,
@@ -1242,6 +1266,17 @@ mod tests {
             })),
             "content_block_start".to_string(),
         );
+        let first_tool_arguments = StreamOutputChunk::with_event(
+            to_bytes(&json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": "{\"first\":true}"
+                }
+            })),
+            "content_block_delta".to_string(),
+        );
 
         let first = session.process_chunks(vec![first_tool_start]).unwrap();
         assert_eq!(
@@ -1270,6 +1305,23 @@ mod tests {
                 .expect("content_block_start should parse");
         assert_eq!(start.index, 1);
         assert_eq!(start.block_kind(), Some(AnthropicContentBlockKind::ToolUse));
+
+        let arguments = session.process_chunks(vec![first_tool_arguments]).unwrap();
+        assert_eq!(
+            arguments
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("content_block_delta")]
+        );
+        let arguments_delta: AnthropicContentBlockDeltaEventView =
+            crate::serde_json::from_slice(&arguments[0].data)
+                .expect("content_block_delta should parse");
+        assert_eq!(arguments_delta.index, 0);
+        assert_eq!(
+            arguments_delta.block_kind(),
+            Some(AnthropicContentBlockKind::ToolUse)
+        );
     }
 
     #[test]

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -854,7 +854,11 @@ fn expand_anthropic_session_chunks(
             .collect::<String>();
         (!text.is_empty()).then_some(text)
     });
-    let has_reasoning = reasoning_text.is_some();
+    let reasoning_signature = delta_view
+        .as_ref()
+        .and_then(|d| d.reasoning_signature.as_deref())
+        .filter(|signature| !signature.is_empty());
+    let has_reasoning = reasoning_text.is_some() || reasoning_signature.is_some();
     let is_initial_tool_call = delta_view
         .as_ref()
         .and_then(|d| d.tool_calls.first())
@@ -881,7 +885,7 @@ fn expand_anthropic_session_chunks(
         return out;
     }
 
-    if let Some(thinking) = reasoning_text {
+    if has_reasoning {
         let content = delta_view
             .as_ref()
             .and_then(|d| d.content.as_deref())
@@ -898,23 +902,21 @@ fn expand_anthropic_session_chunks(
                 "content_block_start".to_string(),
             ));
         }
-        out.push(StreamOutputChunk::with_event(
-            serialize_stream_value(&crate::serde_json::json!({
-                "type": "content_block_delta",
-                "index": choice.map(|c| c.index).unwrap_or(0),
-                "delta": {
-                    "type": "thinking_delta",
-                    "thinking": thinking
-                }
-            }))
-            .unwrap_or_else(|_| Bytes::new()),
-            "content_block_delta".to_string(),
-        ));
-        if let Some(signature) = delta_view
-            .as_ref()
-            .and_then(|d| d.reasoning_signature.as_deref())
-            .filter(|signature| !signature.is_empty())
-        {
+        if let Some(thinking) = reasoning_text {
+            out.push(StreamOutputChunk::with_event(
+                serialize_stream_value(&crate::serde_json::json!({
+                    "type": "content_block_delta",
+                    "index": choice.map(|c| c.index).unwrap_or(0),
+                    "delta": {
+                        "type": "thinking_delta",
+                        "thinking": thinking
+                    }
+                }))
+                .unwrap_or_else(|_| Bytes::new()),
+                "content_block_delta".to_string(),
+            ));
+        }
+        if let Some(signature) = reasoning_signature {
             out.push(StreamOutputChunk::with_event(
                 serialize_stream_value(&crate::serde_json::json!({
                     "type": "content_block_delta",
@@ -1657,6 +1659,17 @@ mod tests {
         }
 
         #[derive(Deserialize)]
+        struct SignatureDeltaEvent {
+            index: u32,
+            delta: SignatureDelta,
+        }
+
+        #[derive(Deserialize)]
+        struct SignatureDelta {
+            signature: String,
+        }
+
+        #[derive(Deserialize)]
         struct TextDeltaEvent {
             index: u32,
             delta: TextDelta,
@@ -1714,7 +1727,8 @@ mod tests {
                 "content": {
                     "role": "model",
                     "parts": [{
-                        "text": "The visible answer."
+                        "text": "The visible answer.",
+                        "thoughtSignature": "sig_on_text_part"
                     }]
                 }
             }]
@@ -1757,21 +1771,27 @@ mod tests {
                 .map(|chunk| chunk.event_type.as_deref())
                 .collect::<Vec<_>>(),
             vec![
+                Some("content_block_delta"),
                 Some("content_block_stop"),
                 Some("content_block_start"),
                 Some("content_block_delta")
             ]
         );
 
+        let signature_delta: SignatureDeltaEvent =
+            crate::serde_json::from_slice(&third[0].data).unwrap();
+        assert_eq!(signature_delta.index, 0);
+        assert_eq!(signature_delta.delta.signature, "sig_on_text_part");
+
         let text_start: AnthropicContentBlockStartEventView =
-            crate::serde_json::from_slice(&third[1].data).unwrap();
+            crate::serde_json::from_slice(&third[2].data).unwrap();
         assert_eq!(
             text_start.block_kind(),
             Some(AnthropicContentBlockKind::Text)
         );
         assert_eq!(text_start.index, 1);
 
-        let text_delta: TextDeltaEvent = crate::serde_json::from_slice(&third[2].data).unwrap();
+        let text_delta: TextDeltaEvent = crate::serde_json::from_slice(&third[3].data).unwrap();
         assert_eq!(text_delta.index, 1);
         assert_eq!(text_delta.delta.text, "The visible answer.");
     }

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -10,7 +10,7 @@ use crate::processing::transform::{
 #[cfg(feature = "openai")]
 use crate::providers::openai::responses_adapter::responses_stream_events_from_universal;
 use crate::serde_json::Value;
-use crate::universal::UniversalStreamChunk;
+use crate::universal::{UniversalStreamChunk, PLACEHOLDER_ID, PLACEHOLDER_MODEL};
 
 static EMPTY_JSON: Bytes = Bytes::from_static(b"{}");
 static SSE_DATA_PREFIX: &[u8] = b"data: ";
@@ -73,6 +73,7 @@ pub struct StreamTransformSession {
     anthropic_open_content_block_kind: Option<AnthropicContentBlockKind>,
     anthropic_next_content_block_index: u32,
     anthropic_content_block_index_map: BTreeMap<(AnthropicContentBlockKind, u32), u32>,
+    responses_message_started: bool,
     bedrock_tool_call_indexes: BTreeMap<u32, u32>,
     next_bedrock_tool_call_index: u32,
 }
@@ -97,6 +98,7 @@ impl StreamTransformSession {
             anthropic_open_content_block_kind: None,
             anthropic_next_content_block_index: 0,
             anthropic_content_block_index_map: BTreeMap::new(),
+            responses_message_started: false,
             bedrock_tool_call_indexes: BTreeMap::new(),
             next_bedrock_tool_call_index: 0,
         }
@@ -129,6 +131,7 @@ impl StreamTransformSession {
             step.universal.as_ref(),
             step.source_is_native_stream,
             self.anthropic_message_started,
+            self.responses_message_started,
         )?;
         self.process_chunks(chunks)
     }
@@ -239,6 +242,19 @@ impl StreamTransformSession {
         &mut self,
         chunks: Vec<StreamOutputChunk>,
     ) -> Result<Vec<StreamOutputChunk>, TransformError> {
+        if self.target_format == ProviderFormat::Responses {
+            for chunk in &chunks {
+                match chunk.event_type.as_deref() {
+                    Some("response.created") => self.responses_message_started = true,
+                    Some("response.completed") | Some("response.incomplete") => {
+                        self.responses_message_started = false;
+                    }
+                    _ => {}
+                }
+            }
+            return Ok(chunks);
+        }
+
         // Anthropic currently needs stateful post-processing after universal -> provider
         // conversion: some inputs expand into multiple SSE events, and finish/usage data
         // may arrive as adjacent chunks that must be merged before emission. The adapter
@@ -811,6 +827,7 @@ fn build_session_chunks(
     universal: Option<&UniversalStreamChunk>,
     source_is_native_stream: bool,
     anthropic_message_started: bool,
+    responses_message_started: bool,
 ) -> Result<Vec<StreamOutputChunk>, TransformError> {
     let mut chunks = expand_transform_result(result)?;
     if target_format == ProviderFormat::Anthropic {
@@ -824,7 +841,7 @@ fn build_session_chunks(
     }
     if target_format == ProviderFormat::Responses {
         #[cfg(feature = "openai")]
-        return expand_responses_session_chunks(chunks, universal);
+        return expand_responses_session_chunks(chunks, universal, responses_message_started);
         #[cfg(not(feature = "openai"))]
         return Ok(std::mem::take(&mut chunks));
     }
@@ -834,12 +851,28 @@ fn build_session_chunks(
 fn expand_responses_session_chunks(
     chunks: Vec<StreamOutputChunk>,
     universal: Option<&UniversalStreamChunk>,
+    responses_message_started: bool,
 ) -> Result<Vec<StreamOutputChunk>, TransformError> {
     let Some(universal) = universal else {
         return Ok(chunks);
     };
 
-    let out = responses_stream_events_from_universal(universal)
+    let mut events = responses_stream_events_from_universal(universal);
+    let has_metadata =
+        universal.model.is_some() || universal.id.is_some() || universal.usage.is_some();
+    if has_metadata
+        && !responses_message_started
+        && !events.is_empty()
+        && events
+            .first()
+            .and_then(|event| event.get("type"))
+            .and_then(Value::as_str)
+            != Some("response.created")
+    {
+        events.insert(0, responses_created_stream_event(universal));
+    }
+
+    let out = events
         .into_iter()
         .map(|event| {
             let event_type = extract_event_type(&event);
@@ -855,6 +888,34 @@ fn expand_responses_session_chunks(
     } else {
         Ok(out)
     }
+}
+
+fn responses_created_stream_event(chunk: &UniversalStreamChunk) -> Value {
+    let id = chunk
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("resp_{}", PLACEHOLDER_ID));
+    let mut response = crate::serde_json::json!({
+        "id": id,
+        "object": "response",
+        "model": chunk.model.as_deref().unwrap_or(PLACEHOLDER_MODEL),
+        "status": "in_progress",
+        "output": []
+    });
+
+    if let Some(usage) = &chunk.usage {
+        if let Some(obj) = response.as_object_mut() {
+            obj.insert(
+                "usage".into(),
+                usage.to_provider_value(ProviderFormat::Responses),
+            );
+        }
+    }
+
+    crate::serde_json::json!({
+        "type": "response.created",
+        "response": response
+    })
 }
 
 fn expand_anthropic_session_chunks(
@@ -2302,10 +2363,20 @@ mod tests {
                 .map(|chunk| chunk.event_type.as_deref())
                 .collect::<Vec<_>>(),
             vec![
+                Some("response.created"),
                 Some("response.reasoning_summary_text.delta"),
                 Some("response.output_text.delta"),
                 Some("response.completed")
             ]
+        );
+
+        let created: Value = crate::serde_json::from_slice(&out[0].data).unwrap();
+        assert_eq!(
+            created
+                .get("response")
+                .and_then(|response| response.get("id"))
+                .and_then(Value::as_str),
+            Some("response_123")
         );
     }
 
@@ -2344,10 +2415,66 @@ mod tests {
                 .map(|chunk| chunk.event_type.as_deref())
                 .collect::<Vec<_>>(),
             vec![
+                Some("response.created"),
                 Some("response.reasoning_summary_text.delta"),
                 Some("response.output_item.added"),
                 Some("response.function_call_arguments.delta")
             ]
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "google", feature = "openai"))]
+    fn test_stream_session_google_response_metadata_created_once_for_responses() {
+        let mut session = StreamTransformSession::new(ProviderFormat::Responses);
+        let first_thought = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "text": "first thought",
+                        "thought": true
+                    }]
+                }
+            }]
+        }));
+        let second_thought = to_bytes(&json!({
+            "responseId": "response_123",
+            "modelVersion": "gemini-2.5-flash",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "text": "second thought",
+                        "thought": true
+                    }]
+                }
+            }]
+        }));
+
+        let first = session.push(first_thought).unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("response.created"),
+                Some("response.reasoning_summary_text.delta")
+            ]
+        );
+
+        let second = session.push(second_thought).unwrap();
+        assert_eq!(
+            second
+                .iter()
+                .map(|chunk| chunk.event_type.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("response.reasoning_summary_text.delta")]
         );
     }
 

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -8,9 +8,11 @@ use crate::processing::transform::{
     serialize_stream_value, transform_stream_chunk_step, TransformError, TransformResult,
 };
 #[cfg(feature = "openai")]
-use crate::providers::openai::responses_adapter::responses_stream_events_from_universal;
+use crate::providers::openai::responses_adapter::{
+    responses_created_stream_event_from_universal, responses_stream_events_from_universal,
+};
 use crate::serde_json::Value;
-use crate::universal::{UniversalStreamChunk, PLACEHOLDER_ID, PLACEHOLDER_MODEL};
+use crate::universal::UniversalStreamChunk;
 
 static EMPTY_JSON: Bytes = Bytes::from_static(b"{}");
 static SSE_DATA_PREFIX: &[u8] = b"data: ";
@@ -355,7 +357,7 @@ impl StreamTransformSession {
                 self.anthropic_open_content_block_kind = Some(delta_kind);
                 self.anthropic_content_block_index_map
                     .insert((delta_kind, delta_index), new_index);
-                prefix.push(anthropic_content_block_stop_chunk(open_index));
+                prefix.push(anthropic_content_block_stop_chunk(open_index)?);
                 prefix.push(anthropic_content_block_start_chunk(new_index, delta_kind));
             } else if open_kind == delta_kind {
                 if let Some(mapped_index) = self
@@ -406,7 +408,7 @@ impl StreamTransformSession {
             && self.anthropic_open_content_block_index.is_some()
         {
             if let Some(index) = self.anthropic_open_content_block_index.take() {
-                prefix.push(anthropic_content_block_stop_chunk(index));
+                prefix.push(anthropic_content_block_stop_chunk(index)?);
                 self.anthropic_open_content_block_kind = None;
             }
         }
@@ -639,15 +641,14 @@ fn parse_anthropic_content_block_delta_event(
         })
 }
 
-fn anthropic_content_block_stop_chunk(index: u32) -> StreamOutputChunk {
-    StreamOutputChunk::with_event(
+fn anthropic_content_block_stop_chunk(index: u32) -> Result<StreamOutputChunk, TransformError> {
+    Ok(StreamOutputChunk::with_event(
         serialize_stream_value(&crate::serde_json::json!({
             "type": "content_block_stop",
             "index": index
-        }))
-        .unwrap_or_else(|_| Bytes::new()),
+        }))?,
         "content_block_stop".to_string(),
-    )
+    ))
 }
 
 fn anthropic_content_block_start_chunk(
@@ -831,13 +832,13 @@ fn build_session_chunks(
 ) -> Result<Vec<StreamOutputChunk>, TransformError> {
     let mut chunks = expand_transform_result(result)?;
     if target_format == ProviderFormat::Anthropic {
-        return Ok(expand_anthropic_session_chunks(
+        return expand_anthropic_session_chunks(
             chunks,
             source_format,
             universal,
             source_is_native_stream,
             anthropic_message_started,
-        ));
+        );
     }
     if target_format == ProviderFormat::Responses {
         #[cfg(feature = "openai")]
@@ -869,7 +870,7 @@ fn expand_responses_session_chunks(
             .and_then(Value::as_str)
             != Some("response.created")
     {
-        events.insert(0, responses_created_stream_event(universal));
+        events.insert(0, responses_created_stream_event_from_universal(universal));
     }
 
     let out = events
@@ -890,47 +891,19 @@ fn expand_responses_session_chunks(
     }
 }
 
-fn responses_created_stream_event(chunk: &UniversalStreamChunk) -> Value {
-    let id = chunk
-        .id
-        .clone()
-        .unwrap_or_else(|| format!("resp_{}", PLACEHOLDER_ID));
-    let mut response = crate::serde_json::json!({
-        "id": id,
-        "object": "response",
-        "model": chunk.model.as_deref().unwrap_or(PLACEHOLDER_MODEL),
-        "status": "in_progress",
-        "output": []
-    });
-
-    if let Some(usage) = &chunk.usage {
-        if let Some(obj) = response.as_object_mut() {
-            obj.insert(
-                "usage".into(),
-                usage.to_provider_value(ProviderFormat::Responses),
-            );
-        }
-    }
-
-    crate::serde_json::json!({
-        "type": "response.created",
-        "response": response
-    })
-}
-
 fn expand_anthropic_session_chunks(
     mut chunks: Vec<StreamOutputChunk>,
     source_format: ProviderFormat,
     universal: Option<&UniversalStreamChunk>,
     source_is_native_stream: bool,
     anthropic_message_started: bool,
-) -> Vec<StreamOutputChunk> {
+) -> Result<Vec<StreamOutputChunk>, TransformError> {
     if source_format == ProviderFormat::Anthropic && source_is_native_stream {
-        return chunks;
+        return Ok(chunks);
     }
 
     let Some(universal) = universal else {
-        return chunks;
+        return Ok(chunks);
     };
 
     let has_finish = universal
@@ -981,7 +954,7 @@ fn expand_anthropic_session_chunks(
     let mut out = Vec::new();
 
     if is_initial_metadata && anthropic_message_started {
-        return out;
+        return Ok(out);
     }
 
     if has_reasoning {
@@ -992,7 +965,7 @@ fn expand_anthropic_session_chunks(
             .filter(|s| !s.is_empty());
         if !anthropic_message_started {
             out.push(StreamOutputChunk::with_event(
-                anthropic_message_start_bytes(universal),
+                anthropic_message_start_bytes(universal)?,
                 "message_start".to_string(),
             ));
             out.push(StreamOutputChunk::with_event(
@@ -1011,8 +984,7 @@ fn expand_anthropic_session_chunks(
                         "type": "thinking_delta",
                         "thinking": thinking
                     }
-                }))
-                .unwrap_or_else(|_| Bytes::new()),
+                }))?,
                 "content_block_delta".to_string(),
             ));
         }
@@ -1025,8 +997,7 @@ fn expand_anthropic_session_chunks(
                         "type": "signature_delta",
                         "signature": signature
                     }
-                }))
-                .unwrap_or_else(|_| Bytes::new()),
+                }))?,
                 "content_block_delta".to_string(),
             ));
         }
@@ -1039,8 +1010,7 @@ fn expand_anthropic_session_chunks(
                         "type": "text_delta",
                         "text": content
                     }
-                }))
-                .unwrap_or_else(|_| Bytes::new()),
+                }))?,
                 "content_block_delta".to_string(),
             ));
         }
@@ -1061,8 +1031,7 @@ fn expand_anthropic_session_chunks(
                                 "name": tool_name,
                                 "input": {}
                             }
-                        }))
-                        .unwrap_or_else(|_| Bytes::new()),
+                        }))?,
                         "content_block_start".to_string(),
                     ));
                 }
@@ -1077,8 +1046,7 @@ fn expand_anthropic_session_chunks(
                                 "type": "input_json_delta",
                                 "partial_json": arguments
                             }
-                        }))
-                        .unwrap_or_else(|_| Bytes::new()),
+                        }))?,
                         "content_block_delta".to_string(),
                     ));
                 }
@@ -1091,14 +1059,14 @@ fn expand_anthropic_session_chunks(
                 "message_stop".to_string(),
             ));
         }
-        return out;
+        return Ok(out);
     }
 
     if is_initial_metadata && !anthropic_message_started {
         if let Some(message_start) = chunks.first() {
             out.push(message_start.clone());
         }
-        return out;
+        return Ok(out);
     }
 
     if has_finish {
@@ -1111,7 +1079,7 @@ fn expand_anthropic_session_chunks(
 
         if needs_message_start {
             out.push(StreamOutputChunk::with_event(
-                anthropic_message_start_bytes(universal),
+                anthropic_message_start_bytes(universal)?,
                 "message_start".to_string(),
             ));
             if content.is_some() {
@@ -1133,8 +1101,7 @@ fn expand_anthropic_session_chunks(
                         "type": "text_delta",
                         "text": content
                     }
-                }))
-                .unwrap_or_else(|_| Bytes::new()),
+                }))?,
                 "content_block_delta".to_string(),
             ));
             if needs_message_start {
@@ -1142,8 +1109,7 @@ fn expand_anthropic_session_chunks(
                     serialize_stream_value(&crate::serde_json::json!({
                         "type": "content_block_stop",
                         "index": choice.map(|c| c.index).unwrap_or(0),
-                    }))
-                    .unwrap_or_else(|_| Bytes::new()),
+                    }))?,
                     "content_block_stop".to_string(),
                 ));
             }
@@ -1153,22 +1119,22 @@ fn expand_anthropic_session_chunks(
             Bytes::from_static(br#"{"type":"message_stop"}"#),
             "message_stop".to_string(),
         ));
-        return out;
+        return Ok(out);
     }
 
     if has_metadata && has_tool_calls && is_initial_tool_call && !anthropic_message_started {
         out.push(StreamOutputChunk::with_event(
-            anthropic_message_start_bytes(universal),
+            anthropic_message_start_bytes(universal)?,
             "message_start".to_string(),
         ));
         out.append(&mut chunks);
-        return out;
+        return Ok(out);
     }
 
-    chunks
+    Ok(chunks)
 }
 
-fn anthropic_message_start_bytes(chunk: &UniversalStreamChunk) -> Bytes {
+fn anthropic_message_start_bytes(chunk: &UniversalStreamChunk) -> Result<Bytes, TransformError> {
     serialize_stream_value(&crate::serde_json::json!({
         "type": "message_start",
         "message": {
@@ -1191,7 +1157,6 @@ fn anthropic_message_start_bytes(chunk: &UniversalStreamChunk) -> Bytes {
             }
         }
     }))
-    .unwrap_or_else(|_| Bytes::new())
 }
 
 fn merge_delta_usage(

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -1056,6 +1056,11 @@ impl ProviderAdapter for AnthropicAdapter {
             .first()
             .and_then(|c| c.delta_view())
             .is_some_and(|d| !d.tool_calls.is_empty());
+        let has_reasoning = chunk
+            .choices
+            .first()
+            .and_then(|c| c.delta_view())
+            .is_some_and(|d| !d.reasoning.is_empty());
 
         // Detect initial metadata (model/id/usage present, no content yet).
         // Exclude chunks with tool_calls — those are handled separately.
@@ -1064,6 +1069,7 @@ impl ProviderAdapter for AnthropicAdapter {
         let is_initial_metadata = has_metadata
             && !has_finish
             && !has_tool_calls
+            && !has_reasoning
             && !chunk.choices.is_empty()
             && chunk
                 .choices

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -95,11 +95,16 @@ impl ProviderAdapter for GoogleAdapter {
                     let budget_tokens = tc.thinking_budget;
                     let effort = budget_tokens
                         .map(|b| crate::universal::reasoning::budget_to_effort(b, max_tokens));
+                    let canonical = if tc.thinking_budget.is_some() {
+                        Some(crate::universal::ReasoningCanonical::GoogleThinkingBudget)
+                    } else {
+                        Some(crate::universal::ReasoningCanonical::GoogleIncludeThoughts)
+                    };
                     crate::universal::ReasoningConfig {
                         enabled: Some(!is_disabled),
                         effort,
                         budget_tokens,
-                        canonical: Some(crate::universal::ReasoningCanonical::GoogleThinkingBudget),
+                        canonical,
                         ..Default::default()
                     }
                 }
@@ -294,12 +299,21 @@ impl ProviderAdapter for GoogleAdapter {
                         if r.canonical
                             == Some(crate::universal::ReasoningCanonical::GoogleThinkingBudget)
                         {
-                            let budget = r
-                                .budget_tokens
-                                .unwrap_or(crate::universal::reasoning::MIN_THINKING_BUDGET);
+                            if let Some(budget) = r.budget_tokens {
+                                return Some(ThinkingConfig {
+                                    include_thoughts: Some(true),
+                                    thinking_budget: Some(budget),
+                                    thinking_level: None,
+                                });
+                            }
+                        }
+
+                        if r.canonical
+                            == Some(crate::universal::ReasoningCanonical::GoogleIncludeThoughts)
+                        {
                             return Some(ThinkingConfig {
                                 include_thoughts: Some(true),
-                                thinking_budget: Some(budget),
+                                thinking_budget: None,
                                 thinking_level: None,
                             });
                         }
@@ -317,6 +331,16 @@ impl ProviderAdapter for GoogleAdapter {
                         })
                     }
                     GoogleThinkingStyle::ThinkingBudget | GoogleThinkingStyle::None => {
+                        if r.canonical
+                            == Some(crate::universal::ReasoningCanonical::GoogleIncludeThoughts)
+                        {
+                            return Some(ThinkingConfig {
+                                include_thoughts: Some(true),
+                                thinking_budget: None,
+                                thinking_level: None,
+                            });
+                        }
+
                         // Gemini 2.5: use thinkingBudget (budget-based)
                         let budget = r
                             .budget_tokens
@@ -973,6 +997,44 @@ mod tests {
 
         assert_eq!(thinking_config.thinking_budget, Some(1024));
         assert_eq!(thinking_config.include_thoughts, Some(true));
+        assert_eq!(thinking_config.thinking_level, None);
+    }
+
+    #[test]
+    fn test_google_same_provider_preserves_include_thoughts_without_budget_for_gemini_3() {
+        let adapter = GoogleAdapter;
+        let payload = json!({
+            "model": "gemini-3.5-flash",
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "Return JSON."}]
+            }],
+            "generationConfig": {
+                "maxOutputTokens": 2048,
+                "thinkingConfig": {
+                    "includeThoughts": true
+                }
+            }
+        });
+
+        let universal = adapter.request_to_universal(payload).unwrap();
+        let reasoning = universal.params.reasoning.as_ref().unwrap();
+        assert_eq!(
+            reasoning.canonical,
+            Some(crate::universal::ReasoningCanonical::GoogleIncludeThoughts)
+        );
+        assert_eq!(reasoning.budget_tokens, None);
+
+        let reconstructed = adapter.request_from_universal(&universal).unwrap();
+        let reconstructed: GenerateContentRequest =
+            serde_json::from_value(reconstructed).expect("request should deserialize");
+        let thinking_config = reconstructed
+            .generation_config
+            .and_then(|config| config.thinking_config)
+            .expect("thinkingConfig should be present");
+
+        assert_eq!(thinking_config.include_thoughts, Some(true));
+        assert_eq!(thinking_config.thinking_budget, None);
         assert_eq!(thinking_config.thinking_level, None);
     }
 

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -11,6 +11,9 @@ Google's API has some unique characteristics:
 use crate::capabilities::ProviderFormat;
 use crate::processing::adapters::ProviderAdapter;
 use crate::processing::transform::TransformError;
+use crate::providers::google::capabilities::{
+    effort_to_thinking_level, thinking_level_to_effort, GoogleCapabilities, GoogleThinkingStyle,
+};
 use crate::providers::google::convert::SYNTHETIC_CALL_ID_PREFIX;
 use crate::providers::google::detect::try_parse_google;
 use crate::providers::google::generated::{
@@ -18,22 +21,36 @@ use crate::providers::google::generated::{
     ThinkingLevel, Tool as GoogleTool, ToolConfig, UsageMetadata,
 };
 use crate::providers::google::params::GoogleParams;
-use crate::providers::google::GoogleCapabilities;
 use crate::serde_json::{self, Map, Value};
 use crate::universal::convert::TryFromLLM;
 use crate::universal::message::{AssistantContent, AssistantContentPart, Message};
+use crate::universal::reasoning::{budget_to_effort, effort_to_budget, MIN_THINKING_BUDGET};
 use crate::universal::request::ToolChoiceConfig;
 use crate::universal::tools::UniversalTool;
 use crate::universal::ToolContentPart;
 use crate::universal::{
-    extract_system_messages, flatten_consecutive_messages, FinishReason, TokenBudget,
-    UniversalParams, UniversalReasoningDelta, UniversalRequest, UniversalResponse,
-    UniversalStreamChoice, UniversalStreamChunk, UniversalStreamDelta, UniversalToolCallDelta,
-    UniversalToolFunctionDelta, UniversalUsage, UserContent,
+    extract_system_messages, flatten_consecutive_messages, FinishReason, ReasoningCanonical,
+    ReasoningConfig, TokenBudget, UniversalParams, UniversalReasoningDelta, UniversalRequest,
+    UniversalResponse, UniversalStreamChoice, UniversalStreamChunk, UniversalStreamDelta,
+    UniversalToolCallDelta, UniversalToolFunctionDelta, UniversalUsage, UserContent,
 };
+use serde::Serialize;
 
 /// Adapter for Google AI GenerateContent API.
 pub struct GoogleAdapter;
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GoogleStreamPart {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thought: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thought_signature: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    function_call: Option<Map<String, Value>>,
+}
 
 impl ProviderAdapter for GoogleAdapter {
     fn format(&self) -> ProviderFormat {
@@ -68,59 +85,55 @@ impl ProviderAdapter for GoogleAdapter {
             .map_err(|e| TransformError::ToUniversalFailed(e.to_string()))?;
 
         // Extract params from generationConfig (now typed in params struct)
-        let (temperature, top_p, top_k, max_tokens, stop, reasoning) = if let Some(config) =
-            &typed_params.generation_config
-        {
-            let max_tokens = config.max_output_tokens;
-            // Convert Google's thinkingConfig to ReasoningConfig
-            // thinkingLevel: Gemini 3 (effort-based)
-            // thinkingBudget: Gemini 2.5 (budget-based), 0 means disabled
-            let reasoning = config.thinking_config.as_ref().map(|tc| {
-                use crate::providers::google::capabilities::thinking_level_to_effort;
-
-                if let Some(ref level) = tc.thinking_level {
-                    // Gemini 3 style: thinkingLevel is canonical (effort-based)
-                    let effort = thinking_level_to_effort(level);
-                    let budget = crate::universal::reasoning::effort_to_budget(effort, max_tokens);
-                    crate::universal::ReasoningConfig {
-                        enabled: Some(true),
-                        effort: Some(effort),
-                        budget_tokens: Some(budget),
-                        canonical: Some(crate::universal::ReasoningCanonical::Effort),
-                        ..Default::default()
-                    }
-                } else {
-                    // Gemini 2.5 style: thinkingBudget is canonical (budget-based)
-                    let is_disabled = tc.thinking_budget == Some(0);
-                    let budget_tokens = tc.thinking_budget;
-                    let effort = budget_tokens
-                        .map(|b| crate::universal::reasoning::budget_to_effort(b, max_tokens));
-                    let canonical = if tc.thinking_budget.is_some() {
-                        Some(crate::universal::ReasoningCanonical::GoogleThinkingBudget)
+        let (temperature, top_p, top_k, max_tokens, stop, reasoning) =
+            if let Some(config) = &typed_params.generation_config {
+                let max_tokens = config.max_output_tokens;
+                // Convert Google's thinkingConfig to ReasoningConfig
+                // thinkingLevel: Gemini 3 (effort-based)
+                // thinkingBudget: Gemini 2.5 (budget-based), 0 means disabled
+                let reasoning = config.thinking_config.as_ref().map(|tc| {
+                    if let Some(ref level) = tc.thinking_level {
+                        // Gemini 3 style: thinkingLevel is canonical (effort-based)
+                        let effort = thinking_level_to_effort(level);
+                        let budget = effort_to_budget(effort, max_tokens);
+                        ReasoningConfig {
+                            enabled: Some(true),
+                            effort: Some(effort),
+                            budget_tokens: Some(budget),
+                            canonical: Some(ReasoningCanonical::Effort),
+                            ..Default::default()
+                        }
                     } else {
-                        Some(crate::universal::ReasoningCanonical::GoogleIncludeThoughts)
-                    };
-                    crate::universal::ReasoningConfig {
-                        enabled: Some(!is_disabled),
-                        effort,
-                        budget_tokens,
-                        canonical,
-                        ..Default::default()
+                        // Gemini 2.5 style: thinkingBudget is canonical (budget-based)
+                        let is_disabled = tc.thinking_budget == Some(0);
+                        let budget_tokens = tc.thinking_budget;
+                        let effort = budget_tokens.map(|b| budget_to_effort(b, max_tokens));
+                        let canonical = if tc.thinking_budget.is_some() {
+                            Some(ReasoningCanonical::GoogleThinkingBudget)
+                        } else {
+                            Some(ReasoningCanonical::GoogleIncludeThoughts)
+                        };
+                        ReasoningConfig {
+                            enabled: Some(!is_disabled),
+                            effort,
+                            budget_tokens,
+                            canonical,
+                            ..Default::default()
+                        }
                     }
-                }
-            });
-            let stop = config.stop_sequences.clone().filter(|s| !s.is_empty());
-            (
-                config.temperature,
-                config.top_p,
-                config.top_k,
-                max_tokens,
-                stop,
-                reasoning,
-            )
-        } else {
-            (None, None, None, None, None, None)
-        };
+                });
+                let stop = config.stop_sequences.clone().filter(|s| !s.is_empty());
+                (
+                    config.temperature,
+                    config.top_p,
+                    config.top_k,
+                    max_tokens,
+                    stop,
+                    reasoning,
+                )
+            } else {
+                (None, None, None, None, None, None)
+            };
 
         // Convert tools using typed conversions
         let tools = typed_params
@@ -284,10 +297,6 @@ impl ProviderAdapter for GoogleAdapter {
             // Convert ReasoningConfig to Google's thinkingConfig
             // Use capabilities to determine whether to use thinkingLevel (Gemini 3) or thinkingBudget (Gemini 2.5)
             let thinking_config = req.params.reasoning.as_ref().and_then(|r| {
-                use crate::providers::google::capabilities::{
-                    effort_to_thinking_level, GoogleCapabilities, GoogleThinkingStyle,
-                };
-
                 if r.is_effectively_disabled() {
                     return None;
                 }
@@ -296,9 +305,7 @@ impl ProviderAdapter for GoogleAdapter {
 
                 match caps.thinking_style {
                     GoogleThinkingStyle::ThinkingLevelBased => {
-                        if r.canonical
-                            == Some(crate::universal::ReasoningCanonical::GoogleThinkingBudget)
-                        {
+                        if r.canonical == Some(ReasoningCanonical::GoogleThinkingBudget) {
                             if let Some(budget) = r.budget_tokens {
                                 return Some(ThinkingConfig {
                                     include_thoughts: Some(true),
@@ -308,9 +315,7 @@ impl ProviderAdapter for GoogleAdapter {
                             }
                         }
 
-                        if r.canonical
-                            == Some(crate::universal::ReasoningCanonical::GoogleIncludeThoughts)
-                        {
+                        if r.canonical == Some(ReasoningCanonical::GoogleIncludeThoughts) {
                             return Some(ThinkingConfig {
                                 include_thoughts: Some(true),
                                 thinking_budget: None,
@@ -331,9 +336,7 @@ impl ProviderAdapter for GoogleAdapter {
                         })
                     }
                     GoogleThinkingStyle::ThinkingBudget | GoogleThinkingStyle::None => {
-                        if r.canonical
-                            == Some(crate::universal::ReasoningCanonical::GoogleIncludeThoughts)
-                        {
+                        if r.canonical == Some(ReasoningCanonical::GoogleIncludeThoughts) {
                             return Some(ThinkingConfig {
                                 include_thoughts: Some(true),
                                 thinking_budget: None,
@@ -342,9 +345,7 @@ impl ProviderAdapter for GoogleAdapter {
                         }
 
                         // Gemini 2.5: use thinkingBudget (budget-based)
-                        let budget = r
-                            .budget_tokens
-                            .unwrap_or(crate::universal::reasoning::MIN_THINKING_BUDGET);
+                        let budget = r.budget_tokens.unwrap_or(MIN_THINKING_BUDGET);
                         Some(ThinkingConfig {
                             include_thoughts: Some(true),
                             thinking_budget: Some(budget),
@@ -669,7 +670,7 @@ impl ProviderAdapter for GoogleAdapter {
                 let delta = c.delta_view();
 
                 // Build parts array from text and tool_calls
-                let mut parts: Vec<Value> = Vec::new();
+                let mut parts: Vec<GoogleStreamPart> = Vec::new();
 
                 let text = delta
                     .as_ref()
@@ -705,68 +706,68 @@ impl ProviderAdapter for GoogleAdapter {
                         });
 
                     for (index, text) in reasoning_texts.iter().enumerate() {
-                        let mut thought_part = serde_json::Map::new();
-                        thought_part.insert("text".into(), Value::String((*text).to_string()));
-                        thought_part.insert("thought".into(), Value::Bool(true));
+                        let mut thought_part = GoogleStreamPart {
+                            text: Some((*text).to_string()),
+                            thought: Some(true),
+                            ..Default::default()
+                        };
                         if index == reasoning_texts.len() - 1 {
                             if let Some(signature) = thought_reasoning_signature {
-                                thought_part.insert(
-                                    "thoughtSignature".into(),
-                                    Value::String(signature.to_string()),
-                                );
+                                thought_part.thought_signature = Some(signature.to_string());
                             }
                         }
-                        parts.push(Value::Object(thought_part));
+                        parts.push(thought_part);
                     }
                 }
 
                 // Add text part if present, carrying thoughtSignature when there are no tool calls
                 if !text.is_empty() || text_reasoning_signature.is_some() {
-                    let mut text_part = serde_json::Map::new();
-                    text_part.insert("text".into(), Value::String(text.to_string()));
+                    let mut text_part = GoogleStreamPart {
+                        text: Some(text.to_string()),
+                        ..Default::default()
+                    };
                     if let Some(signature) = text_reasoning_signature {
-                        text_part.insert(
-                            "thoughtSignature".into(),
-                            Value::String(signature.to_string()),
-                        );
+                        text_part.thought_signature = Some(signature.to_string());
                     }
-                    parts.push(Value::Object(text_part));
+                    parts.push(text_part);
                 }
 
                 // Add functionCall parts from tool_calls
                 if let Some(ref d) = delta {
                     for tc in &d.tool_calls {
                         if let Some(ref func) = tc.function {
-                            let mut fc_map = serde_json::Map::new();
+                            let mut function_call = Map::new();
                             if let Some(ref name) = func.name {
-                                fc_map.insert("name".into(), Value::String(name.clone()));
+                                function_call.insert("name".into(), Value::String(name.clone()));
                             }
                             if let Some(ref id) = tc.id {
-                                fc_map.insert("id".into(), Value::String(id.clone()));
+                                function_call.insert("id".into(), Value::String(id.clone()));
                             }
                             if let Some(ref args) = func.arguments {
                                 if args.is_empty() {
-                                    fc_map.insert("args".into(), serde_json::json!({}));
+                                    function_call.insert("args".into(), serde_json::json!({}));
                                 } else if let Ok(args_val) = serde_json::from_str::<Value>(args) {
-                                    fc_map.insert("args".into(), args_val);
+                                    function_call.insert("args".into(), args_val);
                                 }
                             }
-                            let mut part_map = serde_json::Map::new();
-                            part_map.insert("functionCall".into(), Value::Object(fc_map));
+                            let mut part = GoogleStreamPart {
+                                function_call: Some(function_call),
+                                ..Default::default()
+                            };
                             if let Some(ref signature) = d.reasoning_signature {
-                                part_map.insert(
-                                    "thoughtSignature".into(),
-                                    Value::String(signature.clone()),
-                                );
+                                part.thought_signature = Some(signature.clone());
                             }
-                            parts.push(Value::Object(part_map));
+                            parts.push(part);
                         }
                     }
                 }
 
                 // Ensure at least one empty text part if no parts
                 if parts.is_empty() {
-                    parts.push(serde_json::json!({"text": ""}));
+                    parts.push(GoogleStreamPart {
+                        text: Some(String::new()),
+                        ..Default::default()
+                    });
                 }
 
                 let finish_reason = c.finish_reason.as_ref().map(|r| {
@@ -788,9 +789,9 @@ impl ProviderAdapter for GoogleAdapter {
                     candidate_map.insert("finishReason".into(), Value::String(reason.to_string()));
                 }
 
-                Value::Object(candidate_map)
+                Ok(Value::Object(candidate_map))
             })
-            .collect();
+            .collect::<Result<Vec<_>, TransformError>>()?;
 
         if chunk.is_keep_alive() || candidates.is_empty() {
             candidates.push(serde_json::json!({
@@ -919,6 +920,7 @@ mod tests {
     use crate::providers::google::GenerateContentRequest;
     use crate::serde_json::json;
     use crate::universal::request::ToolChoiceMode;
+    use crate::universal::ReasoningEffort;
 
     #[test]
     fn test_google_detect_request() {
@@ -983,7 +985,7 @@ mod tests {
         let reasoning = universal.params.reasoning.as_ref().unwrap();
         assert_eq!(
             reasoning.canonical,
-            Some(crate::universal::ReasoningCanonical::GoogleThinkingBudget)
+            Some(ReasoningCanonical::GoogleThinkingBudget)
         );
         assert_eq!(reasoning.budget_tokens, Some(1024));
 
@@ -1021,7 +1023,7 @@ mod tests {
         let reasoning = universal.params.reasoning.as_ref().unwrap();
         assert_eq!(
             reasoning.canonical,
-            Some(crate::universal::ReasoningCanonical::GoogleIncludeThoughts)
+            Some(ReasoningCanonical::GoogleIncludeThoughts)
         );
         assert_eq!(reasoning.budget_tokens, None);
 
@@ -1047,11 +1049,11 @@ mod tests {
                 content: UserContent::String("Return JSON.".to_string()),
             }],
             params: UniversalParams {
-                reasoning: Some(crate::universal::ReasoningConfig {
+                reasoning: Some(ReasoningConfig {
                     enabled: Some(true),
-                    effort: Some(crate::universal::ReasoningEffort::Medium),
+                    effort: Some(ReasoningEffort::Medium),
                     budget_tokens: Some(1024),
-                    canonical: Some(crate::universal::ReasoningCanonical::BudgetTokens),
+                    canonical: Some(ReasoningCanonical::BudgetTokens),
                     ..Default::default()
                 }),
                 token_budget: Some(TokenBudget::OutputTokens(2048)),

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -99,7 +99,7 @@ impl ProviderAdapter for GoogleAdapter {
                         enabled: Some(!is_disabled),
                         effort,
                         budget_tokens,
-                        canonical: Some(crate::universal::ReasoningCanonical::BudgetTokens),
+                        canonical: Some(crate::universal::ReasoningCanonical::GoogleThinkingBudget),
                         ..Default::default()
                     }
                 }
@@ -291,7 +291,9 @@ impl ProviderAdapter for GoogleAdapter {
 
                 match caps.thinking_style {
                     GoogleThinkingStyle::ThinkingLevelBased => {
-                        if r.canonical == Some(crate::universal::ReasoningCanonical::BudgetTokens) {
+                        if r.canonical
+                            == Some(crate::universal::ReasoningCanonical::GoogleThinkingBudget)
+                        {
                             let budget = r
                                 .budget_tokens
                                 .unwrap_or(crate::universal::reasoning::MIN_THINKING_BUDGET);
@@ -303,7 +305,7 @@ impl ProviderAdapter for GoogleAdapter {
                         }
 
                         // Gemini 3: use thinkingLevel (effort-based) unless the source was
-                        // explicitly budget-based and must roundtrip through Google unchanged.
+                        // Google's native thinkingBudget and must roundtrip unchanged.
                         let level = r
                             .effort
                             .map(effort_to_thinking_level)
@@ -957,7 +959,7 @@ mod tests {
         let reasoning = universal.params.reasoning.as_ref().unwrap();
         assert_eq!(
             reasoning.canonical,
-            Some(crate::universal::ReasoningCanonical::BudgetTokens)
+            Some(crate::universal::ReasoningCanonical::GoogleThinkingBudget)
         );
         assert_eq!(reasoning.budget_tokens, Some(1024));
 
@@ -972,6 +974,40 @@ mod tests {
         assert_eq!(thinking_config.thinking_budget, Some(1024));
         assert_eq!(thinking_config.include_thoughts, Some(true));
         assert_eq!(thinking_config.thinking_level, None);
+    }
+
+    #[test]
+    fn test_google_gemini_3_uses_thinking_level_for_generic_budget_canonical_reasoning() {
+        let adapter = GoogleAdapter;
+        let req = UniversalRequest {
+            model: Some("gemini-3.5-flash".to_string()),
+            messages: vec![Message::User {
+                content: UserContent::String("Return JSON.".to_string()),
+            }],
+            params: UniversalParams {
+                reasoning: Some(crate::universal::ReasoningConfig {
+                    enabled: Some(true),
+                    effort: Some(crate::universal::ReasoningEffort::Medium),
+                    budget_tokens: Some(1024),
+                    canonical: Some(crate::universal::ReasoningCanonical::BudgetTokens),
+                    ..Default::default()
+                }),
+                token_budget: Some(TokenBudget::OutputTokens(2048)),
+                ..Default::default()
+            },
+        };
+
+        let payload = adapter.request_from_universal(&req).unwrap();
+        let typed: GenerateContentRequest =
+            serde_json::from_value(payload).expect("request should deserialize");
+        let thinking_config = typed
+            .generation_config
+            .and_then(|config| config.thinking_config)
+            .expect("thinkingConfig should be present");
+
+        assert_eq!(thinking_config.thinking_budget, None);
+        assert_eq!(thinking_config.include_thoughts, Some(true));
+        assert_eq!(thinking_config.thinking_level, Some(ThinkingLevel::Medium));
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -291,7 +291,19 @@ impl ProviderAdapter for GoogleAdapter {
 
                 match caps.thinking_style {
                     GoogleThinkingStyle::ThinkingLevelBased => {
-                        // Gemini 3: use thinkingLevel (effort-based)
+                        if r.canonical == Some(crate::universal::ReasoningCanonical::BudgetTokens) {
+                            let budget = r
+                                .budget_tokens
+                                .unwrap_or(crate::universal::reasoning::MIN_THINKING_BUDGET);
+                            return Some(ThinkingConfig {
+                                include_thoughts: Some(true),
+                                thinking_budget: Some(budget),
+                                thinking_level: None,
+                            });
+                        }
+
+                        // Gemini 3: use thinkingLevel (effort-based) unless the source was
+                        // explicitly budget-based and must roundtrip through Google unchanged.
                         let level = r
                             .effort
                             .map(effort_to_thinking_level)
@@ -921,6 +933,45 @@ mod tests {
             serde_json::from_value(reconstructed).expect("request should deserialize");
         assert!(reconstructed.contents.is_some());
         assert!(reconstructed.generation_config.is_some());
+    }
+
+    #[test]
+    fn test_google_same_provider_preserves_budget_based_thinking_config_for_gemini_3() {
+        let adapter = GoogleAdapter;
+        let payload = json!({
+            "model": "gemini-3.5-flash",
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "Return JSON."}]
+            }],
+            "generationConfig": {
+                "maxOutputTokens": 2048,
+                "thinkingConfig": {
+                    "thinkingBudget": 1024,
+                    "includeThoughts": true
+                }
+            }
+        });
+
+        let universal = adapter.request_to_universal(payload).unwrap();
+        let reasoning = universal.params.reasoning.as_ref().unwrap();
+        assert_eq!(
+            reasoning.canonical,
+            Some(crate::universal::ReasoningCanonical::BudgetTokens)
+        );
+        assert_eq!(reasoning.budget_tokens, Some(1024));
+
+        let reconstructed = adapter.request_from_universal(&universal).unwrap();
+        let reconstructed: GenerateContentRequest =
+            serde_json::from_value(reconstructed).expect("request should deserialize");
+        let thinking_config = reconstructed
+            .generation_config
+            .and_then(|config| config.thinking_config)
+            .expect("thinkingConfig should be present");
+
+        assert_eq!(thinking_config.thinking_budget, Some(1024));
+        assert_eq!(thinking_config.include_thoughts, Some(true));
+        assert_eq!(thinking_config.thinking_level, None);
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -642,6 +642,17 @@ impl ProviderAdapter for GoogleAdapter {
                     .and_then(|d| d.reasoning_signature.as_deref())
                     .filter(|_| delta.as_ref().is_none_or(|d| d.tool_calls.is_empty()));
 
+                if let Some(ref d) = delta {
+                    for reasoning in &d.reasoning {
+                        if let Some(text) = reasoning.content.as_deref().filter(|s| !s.is_empty()) {
+                            parts.push(serde_json::json!({
+                                "text": text,
+                                "thought": true
+                            }));
+                        }
+                    }
+                }
+
                 // Add text part if present, carrying thoughtSignature when there are no tool calls
                 if !text.is_empty() || text_reasoning_signature.is_some() {
                     let mut text_part = serde_json::Map::new();
@@ -1338,6 +1349,64 @@ mod tests {
         assert_eq!(
             delta.reasoning_signature.as_deref(),
             Some("thought_signature_123")
+        );
+    }
+
+    #[test]
+    fn test_google_stream_from_universal_emits_reasoning_as_thought_part() {
+        let adapter = GoogleAdapter;
+        let chunk = UniversalStreamChunk::new(
+            Some("response_json_thinking".to_string()),
+            Some("gemini-2.5-flash".to_string()),
+            vec![UniversalStreamChoice {
+                index: 0,
+                delta: Some(Value::from(UniversalStreamDelta {
+                    role: Some("assistant".to_string()),
+                    content: None,
+                    tool_calls: vec![],
+                    reasoning: vec![UniversalReasoningDelta {
+                        content: Some("thinking before visible text".to_string()),
+                    }],
+                    reasoning_signature: None,
+                })),
+                finish_reason: None,
+            }],
+            None,
+            None,
+        );
+
+        let payload = adapter.stream_from_universal(&chunk).unwrap();
+        let typed: GenerateContentResponse =
+            serde_json::from_value(payload).expect("stream chunk should deserialize");
+        let candidates = typed
+            .candidates
+            .as_ref()
+            .expect("candidate should be present");
+        let parts = candidates[0]
+            .content
+            .as_ref()
+            .and_then(|content| content.parts.as_ref())
+            .expect("parts should be present");
+
+        assert_eq!(parts.len(), 1);
+        assert_eq!(
+            parts[0].text.as_deref(),
+            Some("thinking before visible text")
+        );
+        assert_eq!(parts[0].thought, Some(true));
+
+        let roundtripped = adapter
+            .stream_to_universal(serde_json::to_value(&typed).unwrap())
+            .unwrap()
+            .expect("stream chunk should be present");
+        let delta = roundtripped.choices[0]
+            .delta_view()
+            .expect("delta should be present");
+        assert_eq!(delta.content.as_deref(), Some(""));
+        assert_eq!(delta.reasoning.len(), 1);
+        assert_eq!(
+            delta.reasoning[0].content.as_deref(),
+            Some("thinking before visible text")
         );
     }
 

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -637,19 +637,48 @@ impl ProviderAdapter for GoogleAdapter {
                     .as_ref()
                     .and_then(|d| d.content.as_deref())
                     .unwrap_or("");
+                let has_function_call_part = delta.as_ref().is_some_and(|d| {
+                    d.tool_calls
+                        .iter()
+                        .any(|tool_call| tool_call.function.is_some())
+                });
                 let text_reasoning_signature = delta
                     .as_ref()
                     .and_then(|d| d.reasoning_signature.as_deref())
-                    .filter(|_| delta.as_ref().is_none_or(|d| d.tool_calls.is_empty()));
+                    .filter(|_| {
+                        delta.as_ref().is_none_or(|d| {
+                            !has_function_call_part && (!text.is_empty() || d.reasoning.is_empty())
+                        })
+                    });
 
                 if let Some(ref d) = delta {
-                    for reasoning in &d.reasoning {
-                        if let Some(text) = reasoning.content.as_deref().filter(|s| !s.is_empty()) {
-                            parts.push(serde_json::json!({
-                                "text": text,
-                                "thought": true
-                            }));
+                    let reasoning_texts: Vec<&str> = d
+                        .reasoning
+                        .iter()
+                        .filter_map(|reasoning| {
+                            reasoning.content.as_deref().filter(|s| !s.is_empty())
+                        })
+                        .collect();
+                    let thought_reasoning_signature =
+                        d.reasoning_signature.as_deref().filter(|_| {
+                            !reasoning_texts.is_empty()
+                                && text.is_empty()
+                                && !has_function_call_part
+                        });
+
+                    for (index, text) in reasoning_texts.iter().enumerate() {
+                        let mut thought_part = serde_json::Map::new();
+                        thought_part.insert("text".into(), Value::String((*text).to_string()));
+                        thought_part.insert("thought".into(), Value::Bool(true));
+                        if index == reasoning_texts.len() - 1 {
+                            if let Some(signature) = thought_reasoning_signature {
+                                thought_part.insert(
+                                    "thoughtSignature".into(),
+                                    Value::String(signature.to_string()),
+                                );
+                            }
                         }
+                        parts.push(Value::Object(thought_part));
                     }
                 }
 
@@ -1407,6 +1436,71 @@ mod tests {
         assert_eq!(
             delta.reasoning[0].content.as_deref(),
             Some("thinking before visible text")
+        );
+    }
+
+    #[test]
+    fn test_google_stream_from_universal_attaches_signature_to_reasoning_only_thought_part() {
+        let adapter = GoogleAdapter;
+        let chunk = UniversalStreamChunk::new(
+            Some("response_json_thinking".to_string()),
+            Some("gemini-2.5-flash".to_string()),
+            vec![UniversalStreamChoice {
+                index: 0,
+                delta: Some(Value::from(UniversalStreamDelta {
+                    role: Some("assistant".to_string()),
+                    content: None,
+                    tool_calls: vec![],
+                    reasoning: vec![UniversalReasoningDelta {
+                        content: Some("signed thinking without visible text".to_string()),
+                    }],
+                    reasoning_signature: Some("thought_signature_456".to_string()),
+                })),
+                finish_reason: None,
+            }],
+            None,
+            None,
+        );
+
+        let payload = adapter.stream_from_universal(&chunk).unwrap();
+        let typed: GenerateContentResponse =
+            serde_json::from_value(payload).expect("stream chunk should deserialize");
+        let candidates = typed
+            .candidates
+            .as_ref()
+            .expect("candidate should be present");
+        let parts = candidates[0]
+            .content
+            .as_ref()
+            .and_then(|content| content.parts.as_ref())
+            .expect("parts should be present");
+
+        assert_eq!(parts.len(), 1);
+        assert_eq!(
+            parts[0].text.as_deref(),
+            Some("signed thinking without visible text")
+        );
+        assert_eq!(parts[0].thought, Some(true));
+        assert_eq!(
+            parts[0].thought_signature.as_deref(),
+            Some("thought_signature_456")
+        );
+
+        let roundtripped = adapter
+            .stream_to_universal(serde_json::to_value(&typed).unwrap())
+            .unwrap()
+            .expect("stream chunk should be present");
+        let delta = roundtripped.choices[0]
+            .delta_view()
+            .expect("delta should be present");
+        assert_eq!(delta.reasoning.len(), 1);
+        assert_eq!(
+            delta.reasoning[0].content.as_deref(),
+            Some("signed thinking without visible text")
+        );
+        assert_eq!(
+            delta.reasoning_signature.as_deref(),
+            Some("thought_signature_456")
         );
     }
 

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -27,9 +27,9 @@ use crate::universal::tools::UniversalTool;
 use crate::universal::ToolContentPart;
 use crate::universal::{
     extract_system_messages, flatten_consecutive_messages, FinishReason, TokenBudget,
-    UniversalParams, UniversalRequest, UniversalResponse, UniversalStreamChoice,
-    UniversalStreamChunk, UniversalStreamDelta, UniversalToolCallDelta, UniversalToolFunctionDelta,
-    UniversalUsage, UserContent,
+    UniversalParams, UniversalReasoningDelta, UniversalRequest, UniversalResponse,
+    UniversalStreamChoice, UniversalStreamChunk, UniversalStreamDelta, UniversalToolCallDelta,
+    UniversalToolFunctionDelta, UniversalUsage, UserContent,
 };
 
 /// Adapter for Google AI GenerateContent API.
@@ -532,11 +532,21 @@ impl ProviderAdapter for GoogleAdapter {
                 .and_then(|content| content.parts)
                 .unwrap_or_default();
 
-            let text = parts
-                .iter()
-                .filter_map(|part| part.text.as_deref())
-                .collect::<Vec<_>>()
-                .join("");
+            let mut text_segments = Vec::new();
+            let mut reasoning = Vec::new();
+            for part in &parts {
+                let Some(text) = part.text.as_deref() else {
+                    continue;
+                };
+                if part.thought == Some(true) {
+                    reasoning.push(UniversalReasoningDelta {
+                        content: Some(text.to_string()),
+                    });
+                } else {
+                    text_segments.push(text);
+                }
+            }
+            let text = text_segments.join("");
             let reasoning_signature = parts.iter().find_map(|part| part.thought_signature.clone());
 
             let response_id = typed_payload.response_id.as_deref();
@@ -590,7 +600,7 @@ impl ProviderAdapter for GoogleAdapter {
                 role: Some("assistant".to_string()),
                 content: Some(text),
                 tool_calls,
-                reasoning: vec![],
+                reasoning,
                 reasoning_signature,
             };
 
@@ -1282,6 +1292,52 @@ mod tests {
         assert_eq!(
             delta.tool_calls[1].id.as_deref(),
             Some("call_response_456_1")
+        );
+    }
+
+    #[test]
+    fn test_google_stream_keeps_thought_text_out_of_content() {
+        let adapter = GoogleAdapter;
+        let payload = json!({
+            "responseId": "response_json_thinking",
+            "candidates": [{
+                "index": 0,
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "text": "**Analyzing caption**\nI should summarize the microphone comparison.",
+                            "thought": true
+                        },
+                        {
+                            "text": "{\"topic\":\"microphones\",\"confidence\":0.95}",
+                            "thoughtSignature": "thought_signature_123"
+                        }
+                    ]
+                },
+                "finishReason": "STOP"
+            }]
+        });
+
+        let chunk = adapter
+            .stream_to_universal(payload)
+            .unwrap()
+            .expect("stream chunk should be present");
+        let choice = chunk.choices.first().expect("choice should be present");
+        let delta = choice.delta_view().expect("delta should be present");
+
+        assert_eq!(
+            delta.content.as_deref(),
+            Some("{\"topic\":\"microphones\",\"confidence\":0.95}")
+        );
+        assert_eq!(delta.reasoning.len(), 1);
+        assert_eq!(
+            delta.reasoning[0].content.as_deref(),
+            Some("**Analyzing caption**\nI should summarize the microphone comparison.")
+        );
+        assert_eq!(
+            delta.reasoning_signature.as_deref(),
+            Some("thought_signature_123")
         );
     }
 

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -79,18 +79,19 @@ pub(crate) fn responses_stream_events_from_universal(chunk: &UniversalStreamChun
                 "delta": reasoning
             }));
         }
+        let output_index_offset = if reasoning.is_empty() { 0 } else { 1 };
 
         if let Some(content) = delta.content.as_deref().filter(|s| !s.is_empty()) {
             events.push(serde_json::json!({
                 "type": "response.output_text.delta",
-                "output_index": choice.index,
+                "output_index": choice.index + output_index_offset,
                 "content_index": 0,
                 "delta": content
             }));
         }
 
         for tool_call in &delta.tool_calls {
-            let output_index = tool_call.index.unwrap_or(0);
+            let output_index = tool_call.index.unwrap_or(0) + output_index_offset;
             let call_id = tool_call.id.as_deref();
             let name = tool_call
                 .function
@@ -2037,6 +2038,51 @@ mod tests {
     }
 
     #[test]
+    fn test_responses_stream_events_from_universal_mixed_reasoning_content_offsets_text_index() {
+        #[derive(Deserialize)]
+        struct StreamEvent {
+            #[serde(rename = "type")]
+            event_type: String,
+            output_index: u32,
+            delta: Option<String>,
+        }
+
+        let chunk = UniversalStreamChunk::new(
+            Some("resp_google".to_string()),
+            Some("gemini-2.5-flash".to_string()),
+            vec![UniversalStreamChoice {
+                index: 0,
+                delta: Some(json!({
+                    "role": "assistant",
+                    "content": "{\"answer\":\"visible json\"}",
+                    "reasoning": [{
+                        "content": "thinking in the same candidate"
+                    }]
+                })),
+                finish_reason: Some("stop".to_string()),
+            }],
+            None,
+            None,
+        );
+
+        let events = responses_stream_events_from_universal(&chunk);
+        let reasoning: StreamEvent = serde_json::from_value(events[0].clone()).unwrap();
+        let text: StreamEvent = serde_json::from_value(events[1].clone()).unwrap();
+        assert_eq!(
+            reasoning.event_type,
+            "response.reasoning_summary_text.delta"
+        );
+        assert_eq!(reasoning.output_index, 0);
+        assert_eq!(
+            reasoning.delta.as_deref(),
+            Some("thinking in the same candidate")
+        );
+        assert_eq!(text.event_type, "response.output_text.delta");
+        assert_eq!(text.output_index, 1);
+        assert_eq!(text.delta.as_deref(), Some("{\"answer\":\"visible json\"}"));
+    }
+
+    #[test]
     fn test_responses_stream_from_universal_mixed_reasoning_and_tool_call_returns_single_event() {
         #[derive(Deserialize)]
         struct StreamEvent {
@@ -2077,5 +2123,64 @@ mod tests {
         let event: StreamEvent = serde_json::from_value(event).unwrap();
         assert_eq!(event.event_type, "response.reasoning_summary_text.delta");
         assert_eq!(event.delta, "thinking before the tool");
+    }
+
+    #[test]
+    fn test_responses_stream_events_from_universal_mixed_reasoning_tool_offsets_tool_index() {
+        #[derive(Deserialize)]
+        struct StreamEvent {
+            #[serde(rename = "type")]
+            event_type: String,
+            output_index: u32,
+            delta: Option<String>,
+        }
+
+        let chunk = UniversalStreamChunk::new(
+            Some("resp_google".to_string()),
+            Some("gemini-2.5-flash".to_string()),
+            vec![UniversalStreamChoice {
+                index: 0,
+                delta: Some(json!({
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning": [{
+                        "content": "thinking before the tool"
+                    }],
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_response_123_0",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_creator",
+                            "arguments": "{\"query\":\"microphone comparison\"}"
+                        }
+                    }]
+                })),
+                finish_reason: None,
+            }],
+            None,
+            None,
+        );
+
+        let events = responses_stream_events_from_universal(&chunk);
+        let reasoning: StreamEvent = serde_json::from_value(events[0].clone()).unwrap();
+        let tool_start: StreamEvent = serde_json::from_value(events[1].clone()).unwrap();
+        let tool_args: StreamEvent = serde_json::from_value(events[2].clone()).unwrap();
+        assert_eq!(
+            reasoning.event_type,
+            "response.reasoning_summary_text.delta"
+        );
+        assert_eq!(reasoning.output_index, 0);
+        assert_eq!(tool_start.event_type, "response.output_item.added");
+        assert_eq!(tool_start.output_index, 1);
+        assert_eq!(
+            tool_args.event_type,
+            "response.function_call_arguments.delta"
+        );
+        assert_eq!(tool_args.output_index, 1);
+        assert_eq!(
+            tool_args.delta.as_deref(),
+            Some("{\"query\":\"microphone comparison\"}")
+        );
     }
 }

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -79,19 +79,29 @@ pub(crate) fn responses_stream_events_from_universal(chunk: &UniversalStreamChun
                 "delta": reasoning
             }));
         }
-        let output_index_offset = if reasoning.is_empty() { 0 } else { 1 };
+        let mut next_output_index = choice.index;
+        if !reasoning.is_empty() {
+            next_output_index += 1;
+        }
 
         if let Some(content) = delta.content.as_deref().filter(|s| !s.is_empty()) {
+            let output_index = next_output_index;
+            next_output_index += 1;
             events.push(serde_json::json!({
                 "type": "response.output_text.delta",
-                "output_index": choice.index + output_index_offset,
+                "output_index": output_index,
                 "content_index": 0,
                 "delta": content
             }));
         }
 
         for tool_call in &delta.tool_calls {
-            let output_index = tool_call.index.unwrap_or(0) + output_index_offset;
+            let tool_index = tool_call.index.unwrap_or(0);
+            let output_index = if next_output_index == choice.index {
+                tool_index
+            } else {
+                next_output_index + tool_index
+            };
             let call_id = tool_call.id.as_deref();
             let name = tool_call
                 .function
@@ -2181,6 +2191,118 @@ mod tests {
         assert_eq!(
             tool_args.delta.as_deref(),
             Some("{\"query\":\"microphone comparison\"}")
+        );
+    }
+
+    #[test]
+    fn test_responses_stream_events_from_universal_reasoning_text_and_tool_use_distinct_indexes() {
+        #[derive(Deserialize)]
+        struct StreamEvent {
+            #[serde(rename = "type")]
+            event_type: String,
+            output_index: u32,
+            delta: Option<String>,
+        }
+
+        let chunk = UniversalStreamChunk::new(
+            Some("resp_google".to_string()),
+            Some("gemini-2.5-flash".to_string()),
+            vec![UniversalStreamChoice {
+                index: 0,
+                delta: Some(json!({
+                    "role": "assistant",
+                    "content": "{\"answer\":\"visible json\"}",
+                    "reasoning": [{
+                        "content": "thinking before text and tool"
+                    }],
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_response_123_0",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_creator",
+                            "arguments": "{\"query\":\"microphone comparison\"}"
+                        }
+                    }]
+                })),
+                finish_reason: None,
+            }],
+            None,
+            None,
+        );
+
+        let events = responses_stream_events_from_universal(&chunk);
+        let reasoning: StreamEvent = serde_json::from_value(events[0].clone()).unwrap();
+        let text: StreamEvent = serde_json::from_value(events[1].clone()).unwrap();
+        let tool_start: StreamEvent = serde_json::from_value(events[2].clone()).unwrap();
+        let tool_args: StreamEvent = serde_json::from_value(events[3].clone()).unwrap();
+
+        assert_eq!(
+            reasoning.event_type,
+            "response.reasoning_summary_text.delta"
+        );
+        assert_eq!(reasoning.output_index, 0);
+        assert_eq!(text.event_type, "response.output_text.delta");
+        assert_eq!(text.output_index, 1);
+        assert_eq!(tool_start.event_type, "response.output_item.added");
+        assert_eq!(tool_start.output_index, 2);
+        assert_eq!(
+            tool_args.event_type,
+            "response.function_call_arguments.delta"
+        );
+        assert_eq!(tool_args.output_index, 2);
+        assert_eq!(
+            tool_args.delta.as_deref(),
+            Some("{\"query\":\"microphone comparison\"}")
+        );
+    }
+
+    #[test]
+    fn test_responses_stream_events_from_universal_tool_only_preserves_output_index() {
+        #[derive(Deserialize)]
+        struct StreamEvent {
+            #[serde(rename = "type")]
+            event_type: String,
+            output_index: u32,
+            delta: Option<String>,
+        }
+
+        let chunk = UniversalStreamChunk::new(
+            None,
+            None,
+            vec![UniversalStreamChoice {
+                index: 2,
+                delta: Some(json!({
+                    "tool_calls": [{
+                        "index": 2,
+                        "id": "call_response_456_2",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_creator",
+                            "arguments": "{\"query\":\"studio lights\"}"
+                        }
+                    }]
+                })),
+                finish_reason: None,
+            }],
+            None,
+            None,
+        );
+
+        let events = responses_stream_events_from_universal(&chunk);
+        let tool_start: StreamEvent = serde_json::from_value(events[0].clone()).unwrap();
+        let tool_args: StreamEvent = serde_json::from_value(events[1].clone()).unwrap();
+
+        assert_eq!(tool_start.event_type, "response.output_item.added");
+        assert_eq!(tool_start.output_index, 2);
+        assert_eq!(
+            tool_args.event_type,
+            "response.function_call_arguments.delta"
+        );
+        assert_eq!(tool_args.output_index, 2);
+        assert_eq!(
+            tool_args.delta.as_deref(),
+            Some("{\"query\":\"studio lights\"}")
         );
     }
 }

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -60,12 +60,21 @@ fn system_text(message: &Message) -> Option<&str> {
 pub struct ResponsesAdapter;
 
 pub(crate) fn responses_stream_events_from_universal(chunk: &UniversalStreamChunk) -> Vec<Value> {
+    responses_stream_events_from_universal_with_output_index_offset(chunk, 0)
+}
+
+pub(crate) fn responses_stream_events_from_universal_with_output_index_offset(
+    chunk: &UniversalStreamChunk,
+    output_index_offset: u32,
+) -> Vec<Value> {
     let Some(choice) = chunk.choices.first() else {
         return Vec::new();
     };
 
     let mut events = Vec::new();
     if let Some(delta) = choice.delta_view() {
+        let reasoning_output_index = choice.index;
+        let base_output_index = choice.index + output_index_offset;
         let reasoning = delta
             .reasoning
             .iter()
@@ -74,14 +83,14 @@ pub(crate) fn responses_stream_events_from_universal(chunk: &UniversalStreamChun
         if !reasoning.is_empty() {
             events.push(serde_json::json!({
                 "type": "response.reasoning_summary_text.delta",
-                "output_index": choice.index,
+                "output_index": reasoning_output_index,
                 "summary_index": 0,
                 "delta": reasoning
             }));
         }
-        let mut next_output_index = choice.index;
+        let mut next_output_index = base_output_index;
         if !reasoning.is_empty() {
-            next_output_index += 1;
+            next_output_index = next_output_index.max(reasoning_output_index + 1);
         }
 
         if let Some(content) = delta.content.as_deref().filter(|s| !s.is_empty()) {
@@ -97,8 +106,8 @@ pub(crate) fn responses_stream_events_from_universal(chunk: &UniversalStreamChun
 
         for tool_call in &delta.tool_calls {
             let tool_index = tool_call.index.unwrap_or(0);
-            let output_index = if next_output_index == choice.index {
-                tool_index
+            let output_index = if next_output_index == base_output_index {
+                tool_index + output_index_offset
             } else {
                 next_output_index + tool_index
             };

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -59,6 +59,115 @@ fn system_text(message: &Message) -> Option<&str> {
 /// Adapter for OpenAI Responses API (used by reasoning models like o1).
 pub struct ResponsesAdapter;
 
+pub(crate) fn responses_stream_events_from_universal(chunk: &UniversalStreamChunk) -> Vec<Value> {
+    let Some(choice) = chunk.choices.first() else {
+        return Vec::new();
+    };
+
+    let mut events = Vec::new();
+    if let Some(delta) = choice.delta_view() {
+        let reasoning = delta
+            .reasoning
+            .iter()
+            .filter_map(|r| r.content.as_deref())
+            .collect::<String>();
+        if !reasoning.is_empty() {
+            events.push(serde_json::json!({
+                "type": "response.reasoning_summary_text.delta",
+                "output_index": choice.index,
+                "summary_index": 0,
+                "delta": reasoning
+            }));
+        }
+
+        if let Some(content) = delta.content.as_deref().filter(|s| !s.is_empty()) {
+            events.push(serde_json::json!({
+                "type": "response.output_text.delta",
+                "output_index": choice.index,
+                "content_index": 0,
+                "delta": content
+            }));
+        }
+
+        for tool_call in &delta.tool_calls {
+            let output_index = tool_call.index.unwrap_or(0);
+            let call_id = tool_call.id.as_deref();
+            let name = tool_call
+                .function
+                .as_ref()
+                .and_then(|f| f.name.as_deref())
+                .unwrap_or("");
+            if let Some(call_id) = call_id {
+                events.push(serde_json::json!({
+                    "type": "response.output_item.added",
+                    "output_index": output_index,
+                    "item": {
+                        "type": "function_call",
+                        "status": "in_progress",
+                        "call_id": call_id,
+                        "name": name,
+                        "arguments": ""
+                    }
+                }));
+            }
+
+            if let Some(arguments) = tool_call
+                .function
+                .as_ref()
+                .and_then(|f| f.arguments.as_deref())
+                .filter(|arguments| !arguments.is_empty())
+            {
+                events.push(serde_json::json!({
+                    "type": "response.function_call_arguments.delta",
+                    "output_index": output_index,
+                    "delta": arguments
+                }));
+            }
+        }
+    }
+
+    if choice.finish_reason.is_some() {
+        events.push(responses_terminal_stream_event(chunk));
+    }
+
+    events
+}
+
+fn responses_terminal_stream_event(chunk: &UniversalStreamChunk) -> Value {
+    let finish_reason = chunk.choices.first().and_then(|c| c.finish_reason.as_ref());
+    let status = match finish_reason {
+        Some(reason) if reason == "length" => "incomplete",
+        _ => "completed",
+    };
+
+    let id = chunk
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("resp_{}", PLACEHOLDER_ID));
+    let response = match &chunk.usage {
+        Some(usage) => serde_json::json!({
+            "id": id,
+            "object": "response",
+            "model": chunk.model.as_deref().unwrap_or(PLACEHOLDER_MODEL),
+            "status": status,
+            "output": [],
+            "usage": usage.to_provider_value(ProviderFormat::Responses)
+        }),
+        None => serde_json::json!({
+            "id": id,
+            "object": "response",
+            "model": chunk.model.as_deref().unwrap_or(PLACEHOLDER_MODEL),
+            "status": status,
+            "output": []
+        }),
+    };
+
+    serde_json::json!({
+        "type": if status == "completed" { "response.completed" } else { "response.incomplete" },
+        "response": response
+    })
+}
+
 #[derive(Debug, Deserialize, Default)]
 struct ResponsesOutputItemAddedEvent {
     item: Option<Value>,
@@ -976,110 +1085,17 @@ impl ProviderAdapter for ResponsesAdapter {
             }));
         }
 
-        let build_terminal_event = |chunk: &UniversalStreamChunk| {
-            let finish_reason = chunk.choices.first().and_then(|c| c.finish_reason.as_ref());
-            let status = match finish_reason.map(|r| r.as_str()) {
-                Some("length") => "incomplete",
-                _ => "completed",
-            };
-
-            let id = chunk
-                .id
-                .clone()
-                .unwrap_or_else(|| format!("resp_{}", PLACEHOLDER_ID));
-            let mut response = serde_json::json!({
-                "id": id,
-                "object": "response",
-                "model": chunk.model.as_deref().unwrap_or(PLACEHOLDER_MODEL),
-                "status": status,
-                "output": []
-            });
-
-            if let Some(usage) = &chunk.usage {
-                if let Some(obj) = response.as_object_mut() {
-                    obj.insert("usage".into(), usage.to_provider_value(self.format()));
-                }
-            }
-
-            serde_json::json!({
-                "type": if status == "completed" { "response.completed" } else { "response.incomplete" },
-                "response": response
-            })
-        };
-
-        if let Some(choice) = chunk.choices.first() {
-            if let Some(delta) = choice.delta_view() {
-                let mut events = Vec::new();
-                let reasoning = delta
-                    .reasoning
-                    .iter()
-                    .filter_map(|r| r.content.as_deref())
-                    .collect::<String>();
-                if !reasoning.is_empty() {
-                    events.push(serde_json::json!({
-                        "type": "response.reasoning_summary_text.delta",
-                        "output_index": choice.index,
-                        "summary_index": 0,
-                        "delta": reasoning
-                    }));
-                }
-                if let Some(content) = delta.content.as_deref().filter(|s| !s.is_empty()) {
-                    events.push(serde_json::json!({
-                        "type": "response.output_text.delta",
-                        "output_index": choice.index,
-                        "content_index": 0,
-                        "delta": content
-                    }));
-                }
-                for tool_call in &delta.tool_calls {
-                    let output_index = tool_call.index.unwrap_or(0);
-                    let call_id = tool_call.id.as_deref();
-                    let name = tool_call
-                        .function
-                        .as_ref()
-                        .and_then(|f| f.name.as_deref())
-                        .unwrap_or("");
-                    if let Some(call_id) = call_id {
-                        events.push(serde_json::json!({
-                            "type": "response.output_item.added",
-                            "output_index": output_index,
-                            "item": {
-                                "type": "function_call",
-                                "status": "in_progress",
-                                "call_id": call_id,
-                                "name": name,
-                                "arguments": ""
-                            }
-                        }));
-                    }
-                    if let Some(arguments) = tool_call
-                        .function
-                        .as_ref()
-                        .and_then(|f| f.arguments.as_deref())
-                        .filter(|arguments| !arguments.is_empty())
-                    {
-                        events.push(serde_json::json!({
-                            "type": "response.function_call_arguments.delta",
-                            "output_index": output_index,
-                            "delta": arguments
-                        }));
-                    }
-                }
-                if !events.is_empty() {
-                    if has_finish {
-                        events.push(build_terminal_event(chunk));
-                    }
-                    return Ok(if events.len() == 1 {
-                        events.remove(0)
-                    } else {
-                        Value::Array(events)
-                    });
-                }
+        let stream_events = responses_stream_events_from_universal(chunk);
+        if has_reasoning {
+            if let Some(event) = stream_events.first() {
+                return Ok(event.clone());
             }
         }
-
         if has_finish {
-            return Ok(build_terminal_event(chunk));
+            return Ok(responses_terminal_stream_event(chunk));
+        }
+        if let Some(event) = stream_events.into_iter().next() {
+            return Ok(event);
         }
 
         // Check for content delta
@@ -1982,12 +1998,12 @@ mod tests {
     }
 
     #[test]
-    fn test_responses_stream_from_universal_mixed_reasoning_content_and_finish_emits_all_events() {
+    fn test_responses_stream_from_universal_mixed_reasoning_content_returns_single_event() {
         #[derive(Deserialize)]
         struct StreamEvent {
             #[serde(rename = "type")]
             event_type: String,
-            delta: Option<String>,
+            delta: String,
         }
 
         let adapter = ResponsesAdapter;
@@ -2014,32 +2030,19 @@ mod tests {
             }),
         );
 
-        let events = adapter.stream_from_universal(&chunk).unwrap();
-        let events: Vec<StreamEvent> = serde_json::from_value(events).unwrap();
-        assert_eq!(events.len(), 3);
-        assert_eq!(
-            events[0].event_type,
-            "response.reasoning_summary_text.delta"
-        );
-        assert_eq!(
-            events[0].delta.as_deref(),
-            Some("thinking in the same candidate")
-        );
-        assert_eq!(events[1].event_type, "response.output_text.delta");
-        assert_eq!(
-            events[1].delta.as_deref(),
-            Some("{\"answer\":\"visible json\"}")
-        );
-        assert_eq!(events[2].event_type, "response.completed");
+        let event = adapter.stream_from_universal(&chunk).unwrap();
+        let event: StreamEvent = serde_json::from_value(event).unwrap();
+        assert_eq!(event.event_type, "response.reasoning_summary_text.delta");
+        assert_eq!(event.delta, "thinking in the same candidate");
     }
 
     #[test]
-    fn test_responses_stream_from_universal_mixed_reasoning_and_tool_call_emits_all_events() {
+    fn test_responses_stream_from_universal_mixed_reasoning_and_tool_call_returns_single_event() {
         #[derive(Deserialize)]
         struct StreamEvent {
             #[serde(rename = "type")]
             event_type: String,
-            delta: Option<String>,
+            delta: String,
         }
 
         let adapter = ResponsesAdapter;
@@ -2070,22 +2073,9 @@ mod tests {
             None,
         );
 
-        let events = adapter.stream_from_universal(&chunk).unwrap();
-        let events: Vec<StreamEvent> = serde_json::from_value(events).unwrap();
-        assert_eq!(events.len(), 3);
-        assert_eq!(
-            events[0].event_type,
-            "response.reasoning_summary_text.delta"
-        );
-        assert_eq!(events[0].delta.as_deref(), Some("thinking before the tool"));
-        assert_eq!(events[1].event_type, "response.output_item.added");
-        assert_eq!(
-            events[2].event_type,
-            "response.function_call_arguments.delta"
-        );
-        assert_eq!(
-            events[2].delta.as_deref(),
-            Some("{\"query\":\"microphone comparison\"}")
-        );
+        let event = adapter.stream_from_universal(&chunk).unwrap();
+        let event: StreamEvent = serde_json::from_value(event).unwrap();
+        assert_eq!(event.event_type, "response.reasoning_summary_text.delta");
+        assert_eq!(event.delta, "thinking before the tool");
     }
 }

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -60,12 +60,13 @@ fn system_text(message: &Message) -> Option<&str> {
 pub struct ResponsesAdapter;
 
 pub(crate) fn responses_stream_events_from_universal(chunk: &UniversalStreamChunk) -> Vec<Value> {
-    responses_stream_events_from_universal_with_output_index_offset(chunk, 0)
+    responses_stream_events_from_universal_with_output_index_offset(chunk, None, 0)
 }
 
 pub(crate) fn responses_stream_events_from_universal_with_output_index_offset(
     chunk: &UniversalStreamChunk,
-    output_index_offset: u32,
+    text_output_index: Option<u32>,
+    tool_output_index_offset: u32,
 ) -> Vec<Value> {
     let Some(choice) = chunk.choices.first() else {
         return Vec::new();
@@ -74,7 +75,7 @@ pub(crate) fn responses_stream_events_from_universal_with_output_index_offset(
     let mut events = Vec::new();
     if let Some(delta) = choice.delta_view() {
         let reasoning_output_index = choice.index;
-        let base_output_index = choice.index + output_index_offset;
+        let base_output_index = choice.index.max(tool_output_index_offset);
         let reasoning = delta
             .reasoning
             .iter()
@@ -94,8 +95,8 @@ pub(crate) fn responses_stream_events_from_universal_with_output_index_offset(
         }
 
         if let Some(content) = delta.content.as_deref().filter(|s| !s.is_empty()) {
-            let output_index = next_output_index;
-            next_output_index += 1;
+            let output_index = text_output_index.unwrap_or(next_output_index);
+            next_output_index = next_output_index.max(output_index + 1);
             events.push(serde_json::json!({
                 "type": "response.output_text.delta",
                 "output_index": output_index,
@@ -107,7 +108,7 @@ pub(crate) fn responses_stream_events_from_universal_with_output_index_offset(
         for tool_call in &delta.tool_calls {
             let tool_index = tool_call.index.unwrap_or(0);
             let output_index = if next_output_index == base_output_index {
-                tool_index + output_index_offset
+                tool_index + tool_output_index_offset
             } else {
                 next_output_index + tool_index
             };

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -71,6 +71,23 @@ struct ResponsesFunctionCallArgumentsDeltaEvent {
     output_index: Option<u32>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+struct ResponsesReasoningTextDeltaEvent {
+    delta: Option<String>,
+    output_index: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ResponsesAlternateReasoningDeltaEvent {
+    delta: Option<ResponsesAlternateReasoningDelta>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ResponsesAlternateReasoningDelta {
+    text: Option<String>,
+    index: Option<u32>,
+}
+
 pub(crate) fn parse_responses_extras(
     extras: Option<&Map<String, Value>>,
 ) -> Result<OpenAIResponsesExtrasView, TransformError> {
@@ -679,6 +696,46 @@ impl ProviderAdapter for ResponsesAdapter {
                 )))
             }
 
+            "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
+                let (text, output_index) = if is_alternate_format {
+                    let parsed: ResponsesAlternateReasoningDeltaEvent =
+                        serde_json::from_value(payload.clone()).map_err(|e| {
+                            TransformError::DeserializationFailed(format!(
+                                "Responses alternate reasoning delta event: {}",
+                                e
+                            ))
+                        })?;
+                    let delta = parsed.delta.unwrap_or_default();
+                    (delta.text, delta.index.unwrap_or(0))
+                } else {
+                    let parsed: ResponsesReasoningTextDeltaEvent =
+                        serde_json::from_value(payload.clone()).map_err(|e| {
+                            TransformError::DeserializationFailed(format!(
+                                "Responses reasoning delta event: {}",
+                                e
+                            ))
+                        })?;
+                    (parsed.delta, parsed.output_index.unwrap_or(0))
+                };
+
+                Ok(Some(UniversalStreamChunk::new(
+                    None,
+                    None,
+                    vec![UniversalStreamChoice {
+                        index: output_index,
+                        delta: Some(serde_json::json!({
+                            "role": "assistant",
+                            "reasoning": [{
+                                "content": text.unwrap_or_default()
+                            }]
+                        })),
+                        finish_reason: None,
+                    }],
+                    None,
+                    None,
+                )))
+            }
+
             "response.completed" => {
                 // Final event with usage
                 let response = payload.get("response");
@@ -874,6 +931,11 @@ impl ProviderAdapter for ResponsesAdapter {
             .first()
             .and_then(|c| c.delta_view())
             .is_some_and(|d| !d.tool_calls.is_empty());
+        let has_reasoning = chunk
+            .choices
+            .first()
+            .and_then(|c| c.delta_view())
+            .is_some_and(|d| !d.reasoning.is_empty());
 
         // Check if this is an initial metadata chunk (has model/id/usage but no content)
         // Exclude chunks with tool_calls - those must be handled by the tool call path
@@ -881,6 +943,7 @@ impl ProviderAdapter for ResponsesAdapter {
             (chunk.model.is_some() || chunk.id.is_some() || chunk.usage.is_some())
                 && !has_finish
                 && !has_tool_calls
+                && !has_reasoning
                 && chunk
                     .choices
                     .first()
@@ -980,6 +1043,22 @@ impl ProviderAdapter for ResponsesAdapter {
                             "type": "response.function_call_arguments.delta",
                             "output_index": output_index,
                             "delta": arguments
+                        }));
+                    }
+                }
+
+                if !delta.reasoning.is_empty() {
+                    let reasoning = delta
+                        .reasoning
+                        .iter()
+                        .filter_map(|r| r.content.as_deref())
+                        .collect::<String>();
+                    if !reasoning.is_empty() {
+                        return Ok(serde_json::json!({
+                            "type": "response.reasoning_summary_text.delta",
+                            "output_index": choice.index,
+                            "summary_index": 0,
+                            "delta": reasoning
                         }));
                     }
                 }
@@ -1803,5 +1882,44 @@ mod tests {
             .expect("keepalive should emit a chunk");
 
         assert!(chunk.is_keep_alive());
+    }
+
+    #[test]
+    fn test_responses_stream_from_universal_reasoning_only_is_not_metadata() {
+        #[derive(Deserialize)]
+        struct ReasoningDeltaEvent {
+            #[serde(rename = "type")]
+            event_type: String,
+            delta: String,
+        }
+
+        let adapter = ResponsesAdapter;
+        let chunk = UniversalStreamChunk::new(
+            Some("resp_google".to_string()),
+            Some("gemini-2.5-flash".to_string()),
+            vec![UniversalStreamChoice {
+                index: 0,
+                delta: Some(json!({
+                    "role": "assistant",
+                    "content": null,
+                    "reasoning": [{
+                        "content": "thinking before visible text"
+                    }]
+                })),
+                finish_reason: None,
+            }],
+            None,
+            Some(UniversalUsage {
+                prompt_tokens: Some(1),
+                completion_tokens: Some(2),
+                completion_reasoning_tokens: Some(2),
+                ..Default::default()
+            }),
+        );
+
+        let event = adapter.stream_from_universal(&chunk).unwrap();
+        let event: ReasoningDeltaEvent = serde_json::from_value(event).unwrap();
+        assert_eq!(event.event_type, "response.reasoning_summary_text.delta");
+        assert_eq!(event.delta, "thinking before visible text");
     }
 }

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -144,6 +144,34 @@ pub(crate) fn responses_stream_events_from_universal(chunk: &UniversalStreamChun
     events
 }
 
+pub(crate) fn responses_created_stream_event_from_universal(chunk: &UniversalStreamChunk) -> Value {
+    let id = chunk
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("resp_{}", PLACEHOLDER_ID));
+    let mut response = crate::serde_json::json!({
+        "id": id,
+        "object": "response",
+        "model": chunk.model.as_deref().unwrap_or(PLACEHOLDER_MODEL),
+        "status": "in_progress",
+        "output": []
+    });
+
+    if let Some(usage) = &chunk.usage {
+        if let Some(obj) = response.as_object_mut() {
+            obj.insert(
+                "usage".into(),
+                usage.to_provider_value(ProviderFormat::Responses),
+            );
+        }
+    }
+
+    crate::serde_json::json!({
+        "type": "response.created",
+        "response": response
+    })
+}
+
 fn responses_terminal_stream_event(chunk: &UniversalStreamChunk) -> Value {
     let finish_reason = chunk.choices.first().and_then(|c| c.finish_reason.as_ref());
     let status = match finish_reason {

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -988,6 +988,9 @@ impl ProviderAdapter for ResponsesAdapter {
                         .unwrap_or("");
                     let output_index = parsed.output_index.unwrap_or(0);
 
+                    // Preserve Responses output_index as a correlation key. Stateful
+                    // stream transforms remap it to a tool-relative index before
+                    // serializing to non-Responses targets.
                     return Ok(Some(UniversalStreamChunk::new(
                         None,
                         None,
@@ -1024,6 +1027,9 @@ impl ProviderAdapter for ResponsesAdapter {
                 let arguments = parsed.delta.unwrap_or_default();
                 let output_index = parsed.output_index.unwrap_or(0);
 
+                // Preserve Responses output_index as a correlation key. Stateful
+                // stream transforms remap it to the same tool-relative index as
+                // the corresponding response.output_item.added event.
                 Ok(Some(UniversalStreamChunk::new(
                     None,
                     None,

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -1007,41 +1007,73 @@ impl ProviderAdapter for ResponsesAdapter {
             })
         };
 
-        if !has_tool_calls {
-            if let Some(choice) = chunk.choices.first() {
-                if let Some(delta) = choice.delta_view() {
-                    let mut events = Vec::new();
-                    let reasoning = delta
-                        .reasoning
-                        .iter()
-                        .filter_map(|r| r.content.as_deref())
-                        .collect::<String>();
-                    if !reasoning.is_empty() {
+        if let Some(choice) = chunk.choices.first() {
+            if let Some(delta) = choice.delta_view() {
+                let mut events = Vec::new();
+                let reasoning = delta
+                    .reasoning
+                    .iter()
+                    .filter_map(|r| r.content.as_deref())
+                    .collect::<String>();
+                if !reasoning.is_empty() {
+                    events.push(serde_json::json!({
+                        "type": "response.reasoning_summary_text.delta",
+                        "output_index": choice.index,
+                        "summary_index": 0,
+                        "delta": reasoning
+                    }));
+                }
+                if let Some(content) = delta.content.as_deref().filter(|s| !s.is_empty()) {
+                    events.push(serde_json::json!({
+                        "type": "response.output_text.delta",
+                        "output_index": choice.index,
+                        "content_index": 0,
+                        "delta": content
+                    }));
+                }
+                for tool_call in &delta.tool_calls {
+                    let output_index = tool_call.index.unwrap_or(0);
+                    let call_id = tool_call.id.as_deref();
+                    let name = tool_call
+                        .function
+                        .as_ref()
+                        .and_then(|f| f.name.as_deref())
+                        .unwrap_or("");
+                    if let Some(call_id) = call_id {
                         events.push(serde_json::json!({
-                            "type": "response.reasoning_summary_text.delta",
-                            "output_index": choice.index,
-                            "summary_index": 0,
-                            "delta": reasoning
+                            "type": "response.output_item.added",
+                            "output_index": output_index,
+                            "item": {
+                                "type": "function_call",
+                                "status": "in_progress",
+                                "call_id": call_id,
+                                "name": name,
+                                "arguments": ""
+                            }
                         }));
                     }
-                    if let Some(content) = delta.content.as_deref().filter(|s| !s.is_empty()) {
+                    if let Some(arguments) = tool_call
+                        .function
+                        .as_ref()
+                        .and_then(|f| f.arguments.as_deref())
+                        .filter(|arguments| !arguments.is_empty())
+                    {
                         events.push(serde_json::json!({
-                            "type": "response.output_text.delta",
-                            "output_index": choice.index,
-                            "content_index": 0,
-                            "delta": content
+                            "type": "response.function_call_arguments.delta",
+                            "output_index": output_index,
+                            "delta": arguments
                         }));
                     }
-                    if !events.is_empty() {
-                        if has_finish {
-                            events.push(build_terminal_event(chunk));
-                        }
-                        return Ok(if events.len() == 1 {
-                            events.remove(0)
-                        } else {
-                            Value::Array(events)
-                        });
+                }
+                if !events.is_empty() {
+                    if has_finish {
+                        events.push(build_terminal_event(chunk));
                     }
+                    return Ok(if events.len() == 1 {
+                        events.remove(0)
+                    } else {
+                        Value::Array(events)
+                    });
                 }
             }
         }
@@ -1999,5 +2031,61 @@ mod tests {
             Some("{\"answer\":\"visible json\"}")
         );
         assert_eq!(events[2].event_type, "response.completed");
+    }
+
+    #[test]
+    fn test_responses_stream_from_universal_mixed_reasoning_and_tool_call_emits_all_events() {
+        #[derive(Deserialize)]
+        struct StreamEvent {
+            #[serde(rename = "type")]
+            event_type: String,
+            delta: Option<String>,
+        }
+
+        let adapter = ResponsesAdapter;
+        let chunk = UniversalStreamChunk::new(
+            Some("resp_google".to_string()),
+            Some("gemini-2.5-flash".to_string()),
+            vec![UniversalStreamChoice {
+                index: 0,
+                delta: Some(json!({
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning": [{
+                        "content": "thinking before the tool"
+                    }],
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_response_123_0",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_creator",
+                            "arguments": "{\"query\":\"microphone comparison\"}"
+                        }
+                    }]
+                })),
+                finish_reason: None,
+            }],
+            None,
+            None,
+        );
+
+        let events = adapter.stream_from_universal(&chunk).unwrap();
+        let events: Vec<StreamEvent> = serde_json::from_value(events).unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(
+            events[0].event_type,
+            "response.reasoning_summary_text.delta"
+        );
+        assert_eq!(events[0].delta.as_deref(), Some("thinking before the tool"));
+        assert_eq!(events[1].event_type, "response.output_item.added");
+        assert_eq!(
+            events[2].event_type,
+            "response.function_call_arguments.delta"
+        );
+        assert_eq!(
+            events[2].delta.as_deref(),
+            Some("{\"query\":\"microphone comparison\"}")
+        );
     }
 }

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -222,7 +222,6 @@ struct ResponsesFunctionCallArgumentsDeltaEvent {
 #[derive(Debug, Deserialize, Default)]
 struct ResponsesReasoningTextDeltaEvent {
     delta: Option<String>,
-    output_index: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -233,7 +232,6 @@ struct ResponsesAlternateReasoningDeltaEvent {
 #[derive(Debug, Deserialize, Default)]
 struct ResponsesAlternateReasoningDelta {
     text: Option<String>,
-    index: Option<u32>,
 }
 
 pub(crate) fn parse_responses_extras(
@@ -822,17 +820,11 @@ impl ProviderAdapter for ResponsesAdapter {
                     _ => Value::Null, // Empty or missing text becomes null
                 };
 
-                let output_index = payload
-                    .get("output_index")
-                    .or_else(|| delta_obj.and_then(|d| d.get("index")))
-                    .and_then(Value::as_u64)
-                    .unwrap_or(0) as u32;
-
                 Ok(Some(UniversalStreamChunk::new(
                     None,
                     None,
                     vec![UniversalStreamChoice {
-                        index: output_index,
+                        index: 0,
                         delta: Some(serde_json::json!({
                             "role": "assistant",
                             "content": content_value
@@ -845,7 +837,7 @@ impl ProviderAdapter for ResponsesAdapter {
             }
 
             "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
-                let (text, output_index) = if is_alternate_format {
+                let text = if is_alternate_format {
                     let parsed: ResponsesAlternateReasoningDeltaEvent =
                         serde_json::from_value(payload.clone()).map_err(|e| {
                             TransformError::DeserializationFailed(format!(
@@ -854,7 +846,7 @@ impl ProviderAdapter for ResponsesAdapter {
                             ))
                         })?;
                     let delta = parsed.delta.unwrap_or_default();
-                    (delta.text, delta.index.unwrap_or(0))
+                    delta.text
                 } else {
                     let parsed: ResponsesReasoningTextDeltaEvent =
                         serde_json::from_value(payload.clone()).map_err(|e| {
@@ -863,14 +855,14 @@ impl ProviderAdapter for ResponsesAdapter {
                                 e
                             ))
                         })?;
-                    (parsed.delta, parsed.output_index.unwrap_or(0))
+                    parsed.delta
                 };
 
                 Ok(Some(UniversalStreamChunk::new(
                     None,
                     None,
                     vec![UniversalStreamChoice {
-                        index: output_index,
+                        index: 0,
                         delta: Some(serde_json::json!({
                             "role": "assistant",
                             "reasoning": [{
@@ -1000,7 +992,7 @@ impl ProviderAdapter for ResponsesAdapter {
                         None,
                         None,
                         vec![UniversalStreamChoice {
-                            index: output_index,
+                            index: 0,
                             delta: Some(serde_json::json!({
                                 "role": "assistant",
                                 "content": Value::Null,
@@ -1036,7 +1028,7 @@ impl ProviderAdapter for ResponsesAdapter {
                     None,
                     None,
                     vec![UniversalStreamChoice {
-                        index: output_index,
+                        index: 0,
                         delta: Some(serde_json::json!({
                             "tool_calls": [{
                                 "index": output_index,
@@ -1995,6 +1987,47 @@ mod tests {
             .expect("keepalive should emit a chunk");
 
         assert!(chunk.is_keep_alive());
+    }
+
+    #[test]
+    fn test_responses_stream_to_universal_output_indexes_are_output_items_not_choices() {
+        let adapter = ResponsesAdapter;
+
+        let reasoning = adapter
+            .stream_to_universal(json!({
+                "type": "response.reasoning_summary_text.delta",
+                "output_index": 0,
+                "summary_index": 0,
+                "delta": "thinking before visible text"
+            }))
+            .expect("reasoning event should parse")
+            .expect("reasoning event should emit a chunk");
+        let reasoning_choice = reasoning.choices.first().expect("reasoning choice");
+        let reasoning_delta = reasoning_choice
+            .delta_view()
+            .expect("reasoning delta should parse");
+        assert_eq!(reasoning_choice.index, 0);
+        assert_eq!(
+            reasoning_delta.reasoning[0].content.as_deref(),
+            Some("thinking before visible text")
+        );
+
+        let text = adapter
+            .stream_to_universal(json!({
+                "type": "response.output_text.delta",
+                "output_index": 1,
+                "content_index": 0,
+                "delta": "{\"answer\":\"visible json\"}"
+            }))
+            .expect("text event should parse")
+            .expect("text event should emit a chunk");
+        let text_choice = text.choices.first().expect("text choice");
+        let text_delta = text_choice.delta_view().expect("text delta should parse");
+        assert_eq!(text_choice.index, 0);
+        assert_eq!(
+            text_delta.content.as_deref(),
+            Some("{\"answer\":\"visible json\"}")
+        );
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -976,10 +976,9 @@ impl ProviderAdapter for ResponsesAdapter {
             }));
         }
 
-        if has_finish {
+        let build_terminal_event = |chunk: &UniversalStreamChunk| {
             let finish_reason = chunk.choices.first().and_then(|c| c.finish_reason.as_ref());
             let status = match finish_reason.map(|r| r.as_str()) {
-                Some("stop") => "completed",
                 Some("length") => "incomplete",
                 _ => "completed",
             };
@@ -1002,10 +1001,53 @@ impl ProviderAdapter for ResponsesAdapter {
                 }
             }
 
-            return Ok(serde_json::json!({
+            serde_json::json!({
                 "type": if status == "completed" { "response.completed" } else { "response.incomplete" },
                 "response": response
-            }));
+            })
+        };
+
+        if !has_tool_calls {
+            if let Some(choice) = chunk.choices.first() {
+                if let Some(delta) = choice.delta_view() {
+                    let mut events = Vec::new();
+                    let reasoning = delta
+                        .reasoning
+                        .iter()
+                        .filter_map(|r| r.content.as_deref())
+                        .collect::<String>();
+                    if !reasoning.is_empty() {
+                        events.push(serde_json::json!({
+                            "type": "response.reasoning_summary_text.delta",
+                            "output_index": choice.index,
+                            "summary_index": 0,
+                            "delta": reasoning
+                        }));
+                    }
+                    if let Some(content) = delta.content.as_deref().filter(|s| !s.is_empty()) {
+                        events.push(serde_json::json!({
+                            "type": "response.output_text.delta",
+                            "output_index": choice.index,
+                            "content_index": 0,
+                            "delta": content
+                        }));
+                    }
+                    if !events.is_empty() {
+                        if has_finish {
+                            events.push(build_terminal_event(chunk));
+                        }
+                        return Ok(if events.len() == 1 {
+                            events.remove(0)
+                        } else {
+                            Value::Array(events)
+                        });
+                    }
+                }
+            }
+        }
+
+        if has_finish {
+            return Ok(build_terminal_event(chunk));
         }
 
         // Check for content delta
@@ -1043,22 +1085,6 @@ impl ProviderAdapter for ResponsesAdapter {
                             "type": "response.function_call_arguments.delta",
                             "output_index": output_index,
                             "delta": arguments
-                        }));
-                    }
-                }
-
-                if !delta.reasoning.is_empty() {
-                    let reasoning = delta
-                        .reasoning
-                        .iter()
-                        .filter_map(|r| r.content.as_deref())
-                        .collect::<String>();
-                    if !reasoning.is_empty() {
-                        return Ok(serde_json::json!({
-                            "type": "response.reasoning_summary_text.delta",
-                            "output_index": choice.index,
-                            "summary_index": 0,
-                            "delta": reasoning
                         }));
                     }
                 }
@@ -1921,5 +1947,57 @@ mod tests {
         let event: ReasoningDeltaEvent = serde_json::from_value(event).unwrap();
         assert_eq!(event.event_type, "response.reasoning_summary_text.delta");
         assert_eq!(event.delta, "thinking before visible text");
+    }
+
+    #[test]
+    fn test_responses_stream_from_universal_mixed_reasoning_content_and_finish_emits_all_events() {
+        #[derive(Deserialize)]
+        struct StreamEvent {
+            #[serde(rename = "type")]
+            event_type: String,
+            delta: Option<String>,
+        }
+
+        let adapter = ResponsesAdapter;
+        let chunk = UniversalStreamChunk::new(
+            Some("resp_google".to_string()),
+            Some("gemini-2.5-flash".to_string()),
+            vec![UniversalStreamChoice {
+                index: 0,
+                delta: Some(json!({
+                    "role": "assistant",
+                    "content": "{\"answer\":\"visible json\"}",
+                    "reasoning": [{
+                        "content": "thinking in the same candidate"
+                    }]
+                })),
+                finish_reason: Some("stop".to_string()),
+            }],
+            None,
+            Some(UniversalUsage {
+                prompt_tokens: Some(1),
+                completion_tokens: Some(4),
+                completion_reasoning_tokens: Some(2),
+                ..Default::default()
+            }),
+        );
+
+        let events = adapter.stream_from_universal(&chunk).unwrap();
+        let events: Vec<StreamEvent> = serde_json::from_value(events).unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(
+            events[0].event_type,
+            "response.reasoning_summary_text.delta"
+        );
+        assert_eq!(
+            events[0].delta.as_deref(),
+            Some("thinking in the same candidate")
+        );
+        assert_eq!(events[1].event_type, "response.output_text.delta");
+        assert_eq!(
+            events[1].delta.as_deref(),
+            Some("{\"answer\":\"visible json\"}")
+        );
+        assert_eq!(events[2].event_type, "response.completed");
     }
 }

--- a/crates/lingua/src/universal/reasoning.rs
+++ b/crates/lingua/src/universal/reasoning.rs
@@ -432,7 +432,7 @@ pub fn from_google(config: &Value) -> ReasoningConfig {
         enabled,
         effort,
         budget_tokens,
-        canonical: Some(ReasoningCanonical::BudgetTokens),
+        canonical: Some(ReasoningCanonical::GoogleThinkingBudget),
         ..Default::default()
     }
 }

--- a/crates/lingua/src/universal/reasoning.rs
+++ b/crates/lingua/src/universal/reasoning.rs
@@ -427,12 +427,17 @@ pub fn from_google(config: &Value) -> ReasoningConfig {
 
     let budget_tokens = config.get("thinkingBudget").and_then(Value::as_i64);
     let effort = budget_tokens.map(|b| budget_to_effort(b, None));
+    let canonical = if budget_tokens.is_some() {
+        ReasoningCanonical::GoogleThinkingBudget
+    } else {
+        ReasoningCanonical::GoogleIncludeThoughts
+    };
 
     ReasoningConfig {
         enabled,
         effort,
         budget_tokens,
-        canonical: Some(ReasoningCanonical::GoogleThinkingBudget),
+        canonical: Some(canonical),
         ..Default::default()
     }
 }

--- a/crates/lingua/src/universal/request.rs
+++ b/crates/lingua/src/universal/request.rs
@@ -304,6 +304,7 @@ impl UniversalParams {
 /// - `Effort`: From OpenAI (effort is canonical, budget_tokens derived)
 /// - `BudgetTokens`: From Anthropic/Bedrock budget-based thinking (budget_tokens is canonical, effort derived)
 /// - `GoogleThinkingBudget`: From Google `thinkingConfig.thinkingBudget` (preserve Google-native shape on same-provider roundtrip)
+/// - `GoogleIncludeThoughts`: From Google `thinkingConfig.includeThoughts` without budget/level (preserve provider default budget)
 #[derive(Debug, Clone, Default, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct ReasoningConfig {
@@ -429,6 +430,8 @@ pub enum ReasoningCanonical {
     BudgetTokens,
     /// Google `thinkingConfig.thinkingBudget` is the source of truth.
     GoogleThinkingBudget,
+    /// Google `thinkingConfig.includeThoughts` was provided without budget/level.
+    GoogleIncludeThoughts,
 }
 
 /// Summary mode for reasoning output.

--- a/crates/lingua/src/universal/request.rs
+++ b/crates/lingua/src/universal/request.rs
@@ -302,7 +302,8 @@ impl UniversalParams {
 /// Both `effort` and `budget_tokens` are always populated when reasoning is enabled.
 /// The `canonical` field indicates which was the original source of truth:
 /// - `Effort`: From OpenAI (effort is canonical, budget_tokens derived)
-/// - `BudgetTokens`: From Anthropic/Google (budget_tokens is canonical, effort derived)
+/// - `BudgetTokens`: From Anthropic/Bedrock budget-based thinking (budget_tokens is canonical, effort derived)
+/// - `GoogleThinkingBudget`: From Google `thinkingConfig.thinkingBudget` (preserve Google-native shape on same-provider roundtrip)
 #[derive(Debug, Clone, Default, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct ReasoningConfig {
@@ -424,8 +425,10 @@ impl AsRef<str> for ReasoningEffort {
 pub enum ReasoningCanonical {
     /// `effort` is the source of truth (from OpenAI Chat/Responses API)
     Effort,
-    /// `budget_tokens` is the source of truth (from Anthropic/Google)
+    /// `budget_tokens` is the source of truth (from Anthropic/Bedrock)
     BudgetTokens,
+    /// Google `thinkingConfig.thinkingBudget` is the source of truth.
+    GoogleThinkingBudget,
 }
 
 /// Summary mode for reasoning output.

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -807,6 +807,48 @@ export const paramsCases: TestCaseCollection = {
     bedrock: null,
   },
 
+  googleThinkingJsonSchemaParam: {
+    "chat-completions": null,
+    responses: null,
+    anthropic: null,
+    google: {
+      model: GOOGLE_MODEL,
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              text: [
+                "Analyze the caption and return a compact JSON summary.",
+                "Caption: A creator compares two microphone setups, explains why the cheaper lavalier performs better outdoors, and asks viewers to comment with their setup.",
+                'Return exactly {"topic": "...", "recommendation": "...", "confidence": 0.0}.',
+              ].join("\n"),
+            },
+          ],
+        },
+      ],
+      generationConfig: {
+        temperature: 0,
+        maxOutputTokens: 2048,
+        responseMimeType: "application/json",
+        responseJsonSchema: {
+          type: "object",
+          properties: {
+            topic: { type: "string" },
+            recommendation: { type: "string" },
+            confidence: { type: "number" },
+          },
+          required: ["topic", "recommendation", "confidence"],
+        },
+        thinkingConfig: {
+          thinkingBudget: 1024,
+          includeThoughts: true,
+        },
+      },
+    },
+    bedrock: null,
+  },
+
   jsonSchemaPrefixItemsParam: {
     "chat-completions": {
       model: OPENAI_CHAT_COMPLETIONS_MODEL,

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -7205,553 +7205,553 @@ data: {"choices":[],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"Ass","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"Ass","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"uming","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"uming","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" we","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" we","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" count","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" count","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" only","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" only","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" the","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" the","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"HH","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"HH","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"MM","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"MM","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":")","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":")","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" shown","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" shown","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" by","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" by","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" the","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" the","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" clock","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" clock","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" there","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" there","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" are","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" are","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"144","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"144","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" times","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" times","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" per","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" per","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" time","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" time","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" so","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" so","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"576","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"576","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" in","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" in","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" total","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" total","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"Counts","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"Counts","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" by","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" by","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" digit","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" digit","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"sum","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"sum","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" over","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" over","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" all","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" all","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" four","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" four","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" positions","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" positions","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"):\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"):\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"116","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"116","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"116","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"116","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"804","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"804","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"804","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"804","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"504","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"504","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"5","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"5","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"504","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"504","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"6","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"6","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"7","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"7","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"8","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"8","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"9","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"9","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"Most","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"Most","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" common","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" common","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" each","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" each","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" appearing","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" appearing","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"116","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"116","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" times","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" times","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"R","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"R","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"arest","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"arest","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"6","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"6","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"7","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"7","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"8","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"8","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"9","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"9","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" each","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" each","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" appearing","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" appearing","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" times","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" times","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"Percent","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"Percent","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"ages","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"ages","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"of","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"of","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" all","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" all","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"576","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"576","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"):\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"):\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" or","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" or","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"116","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"116","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" /","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" /","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"576","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"576","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"97","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"97","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" /","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" /","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"480","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"480","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ≈","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ≈","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"20","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"20","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"208","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"208","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"%\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"%\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"6","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"6","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"7","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"7","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"8","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"8","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"9","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"9","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"):","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"):","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"264","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" /","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" /","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"576","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"576","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"11","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"11","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" /","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" /","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"240","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"240","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ≈","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ≈","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"583","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"583","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"%\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"%\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"So","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"So","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" the","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" the","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" most","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" most","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" common","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" common","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" are","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" are","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"0","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"about","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"about","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"20","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"20","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"21","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"21","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"%","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"%","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" each","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" each","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"),","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"),","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" the","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" the","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" rare","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" rare","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"st","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"st","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" digits","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" are","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" are","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"6","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"6","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"7","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"7","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"8","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"8","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"9","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"9","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"about","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"about","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"58","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"58","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"%","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"%","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" each","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" each","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":").","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":").","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
@@ -7795,53 +7795,53 @@ data: {"choices":[],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" San","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" San","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Francisco","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Francisco","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" CA","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" CA","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"45","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"45","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"°F","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"°F","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" cloudy","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" cloudy","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" New","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" New","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" York","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" York","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" NY","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" NY","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"65","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"65","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"°F","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"°F","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" sunny","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" sunny","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
@@ -7869,321 +7869,321 @@ data: {"choices":[],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"Step","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"Step","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-by","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-by","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-step","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-step","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Step","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Step","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Distance","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Distance","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" of","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" of","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" each","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" each","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" part","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" part","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" -","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" -","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Part","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Part","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"60","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"60","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" for","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" for","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" hours","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" hours","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" →","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" →","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" distance","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" distance","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"60","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"60","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ×","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ×","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"120","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"120","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" miles","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" miles","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" -","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" -","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Part","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Part","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"80","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"80","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" for","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" for","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" hour","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" hour","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" →","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" →","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" distance","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" distance","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"80","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"80","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ×","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ×","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"80","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"80","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" miles","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" miles","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Step","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Step","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Total","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Total","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" distance","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" distance","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" traveled","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" traveled","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" -","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" -","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"120","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"120","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" +","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" +","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"80","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"80","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"200","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"200","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" miles","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" miles","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Step","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Step","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Total","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Total","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" time","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" time","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" -","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" -","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"2","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" +","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" +","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"1","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" hours","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" hours","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Step","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Step","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"4","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Average","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Average","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" speed","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" speed","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" -","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" -","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Total","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Total","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" distance","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" distance","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ÷","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ÷","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" total","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" total","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" time","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" time","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"200","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"200","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" miles","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" miles","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ÷","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ÷","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" hours","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" hours","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" =","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"200","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"200","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"/","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"/","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ≈","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ≈","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"66","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"66","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"67","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"67","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"Answer","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"Answer","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"200","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"200","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"/","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"/","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"3","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" about","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" about","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" ","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"66","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"66","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"7","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"7","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" mph","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
@@ -8227,187 +8227,187 @@ data: {"choices":[],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"Typically","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"Typically","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" blue","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" blue","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" during","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" during","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" a","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" a","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" clear","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" clear","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" day","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" day","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"Colors","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"Colors","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" change","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" change","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" with","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" with","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" time","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" time","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" conditions","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" conditions","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Day","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Day","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"time","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"time","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" clear","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" clear","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" blue","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" blue","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Sunrise","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Sunrise","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"/S","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"/S","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"unset","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"unset","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" red","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" red","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" orange","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" orange","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" or","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" or","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" pink","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" pink","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Cloud","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Cloud","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"y","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"y","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"/","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"/","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"over","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"over","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"cast","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"cast","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" gray","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" gray","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Night","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Night","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" dark","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" dark","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"/","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"/","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"black","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"black","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" Storm","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" Storm","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"y","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"y","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" skies","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" skies","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":":","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" gray","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" gray","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-blue","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-blue","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" or","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" or","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" gray","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" gray","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-green","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-green","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"ish","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"ish","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"-","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" In","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" In","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" space","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" space","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" (","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"no","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"no","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" atmosphere","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" atmosphere","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"):","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"):","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" black","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" black","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"If","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"If","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" you","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" you","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" tell","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" tell","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" me","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" me","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" the","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" the","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" time","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" time","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" and","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" location","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" location","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":",","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" I","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" I","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" can","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" can","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" give","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" give","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" a","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" a","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" more","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" more","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" specific","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" specific","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" color","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" color","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" for","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" for","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" that","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" that","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":" moment","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":" moment","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
@@ -8435,9 +8435,9 @@ data: {"choices":[],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"Paris","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":"Paris","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":".","role":"assistant"},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
@@ -8477,23 +8477,23 @@ data: {"choices":[],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":null,"role":"assistant","tool_calls":[{"function":{"arguments":"","name":"get_weather"},"id":"call_Q7ylzllh6yaOZHOT7kvfjTaj","index":1,"type":"function"}]},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":null,"role":"assistant","tool_calls":[{"function":{"arguments":"","name":"get_weather"},"id":"call_Q7ylzllh6yaOZHOT7kvfjTaj","index":1,"type":"function"}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{\\""},"index":1}]},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{\\""},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"location"},"index":1}]},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"location"},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"\\":\\""},"index":1}]},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"\\":\\""},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"San"},"index":1}]},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"San"},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":" Francisco"},"index":1}]},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":" Francisco"},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":","},"index":1}]},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":","},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":" CA"},"index":1}]},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":" CA"},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"\\"}"},"index":1}]},"finish_reason":null,"index":1}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"\\"}"},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -7189,7 +7189,7 @@ data: [DONE]
 `;
 
 exports[`streaming: chat-completions → google > simpleRequest > streaming 1`] = `
-"data: {"choices":[{"delta":{"content":"**Answering the Query**\\n\\nI'm focused on providing a clear and factual answer. The user has posed a direct question, and I'm ensuring the response is concise and accurate, meeting their information needs precisely. I'm prioritizing clarity and directness in my approach to best address their inquiry.\\n\\n\\n","role":"assistant"},"finish_reason":null,"index":0}],"id":"8Tr6afj2BdWk1MkPpP-rgQM","model":"gemini-2.5-flash","object":"chat.completion.chunk","usage":{"completion_tokens":18,"completion_tokens_details":{"reasoning_tokens":18},"prompt_tokens":8,"total_tokens":26}}
+"data: {"choices":[{"delta":{"content":"","reasoning":[{"content":"**Answering the Query**\\n\\nI'm focused on providing a clear and factual answer. The user has posed a direct question, and I'm ensuring the response is concise and accurate, meeting their information needs precisely. I'm prioritizing clarity and directness in my approach to best address their inquiry.\\n\\n\\n"}],"role":"assistant"},"finish_reason":null,"index":0}],"id":"8Tr6afj2BdWk1MkPpP-rgQM","model":"gemini-2.5-flash","object":"chat.completion.chunk","usage":{"completion_tokens":18,"completion_tokens_details":{"reasoning_tokens":18},"prompt_tokens":8,"total_tokens":26}}
 
 data: {"choices":[{"delta":{"content":"The capital of France is **Paris**.","role":"assistant"},"finish_reason":"stop","index":0}],"id":"8Tr6afj2BdWk1MkPpP-rgQM","model":"gemini-2.5-flash","object":"chat.completion.chunk","usage":{"completion_tokens":25,"completion_tokens_details":{"reasoning_tokens":18},"prompt_tokens":8,"total_tokens":33}}
 
@@ -10353,35 +10353,35 @@ data: {"response":{"id":"resp_transformed","model":"transformed","object":"respo
 `;
 
 exports[`streaming: responses → google > complexReasoningRequest > streaming 1`] = `
-"event: response.output_text.delta
-data: {"content_index":0,"delta":"**Defining the Objective**\\n\\nOkay, I'm working on the problem of identifying the most and least frequent digits on a digital clock over a 24-hour period. I've begun to analyze the parameters, and I'm focusing on breaking down the time range (00:00 to 23:59) to count the digit appearances methodically. This approach is key to an effective solution.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+"event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":65,"output_tokens_details":{"reasoning_tokens":65},"total_tokens":140}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Analyzing Digit Frequencies**\\n\\nI'm now diving deep into the specifics of digit counting, broken down by position. I'm focusing on the units digit of the minutes (M2). The total number of digits displayed is 5760 (1440 * 4). I've got to determine which numbers appear most and least. I'm breaking down how often each digit (0-9) appears in each position to find the solution. I am trying to determine a method to make this problem more efficient.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":462,"output_tokens_details":{"reasoning_tokens":462},"total_tokens":537}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Calculating Digit Frequencies**\\n\\nI'm now determining the frequency of each digit in the minutes' tens place (M1). I have calculated that for M2, each digit (0-9) appears 144 times. I'm focusing on the position analysis to determine the occurrences of each digit. M1 cycles from 0-5 for every 10 minutes. I am analyzing the implications across the entire 24-hour period (00:00 to 23:59). My current focus is to efficiently determine the patterns.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":953,"output_tokens_details":{"reasoning_tokens":953},"total_tokens":1028}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Calculating Frequency Analysis**\\n\\nI've completed the initial frequency calculations for each digit position. Specifically, for M2, each digit appears 144 times, and for M1, digits 0-5 each occur 240 times, and 6-9 appear 0 times. My next step is to finalize the H1 and H2 digit occurrences, addressing the complexity of the hour constraints. I'll summarize these totals into the final tally.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":1341,"output_tokens_details":{"reasoning_tokens":1341},"total_tokens":1416}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Finalizing Calculations**\\n\\nI'm now finalizing the calculations for the tens (H1) and units (H2) of the hours. I've corrected an error in H2 calculations and now have a firm grasp on the frequency distribution. I'm focusing on consolidating all of the totals across the H1, H2, M1, and M2 positions for a complete, accurate count. The final step is determining the most and least frequent digits.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":1731,"output_tokens_details":{"reasoning_tokens":1731},"total_tokens":1806}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Calculating Total Counts**\\n\\nI'm now consolidating the frequency counts for all digit positions. Specifically, I've totaled each digit's occurrences in H1, H2, M1, and M2, accounting for all time constraints. From this analysis, I will determine the most and least frequent digits displayed over the entire 24-hour cycle. The final step is to verify the results.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":2223,"output_tokens_details":{"reasoning_tokens":2223},"total_tokens":2298}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Refining Calculation Accuracy**\\n\\nI'm now implementing the calculation refinements based on the detailed analysis. I've re-examined the H2 position, accounting for the varying hour constraints, and updated the frequency totals for digits 0-9. I'm focusing on validating these counts to ensure an accurate base for finding the most and least frequent digits.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":2662,"output_tokens_details":{"reasoning_tokens":2662},"total_tokens":2737}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Refining Calculation Accuracy**\\n\\nI'm now implementing calculation refinements based on the updated analysis of each digit position. I have re-evaluated the H2 position, accounting for the unique hour constraints, and have updated the frequency totals for digits 0-9. I'm focusing on validation of these counts.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":3251,"output_tokens_details":{"reasoning_tokens":3251},"total_tokens":3326}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Refining Calculations**\\n\\nI'm now refining the accuracy of the counts, re-evaluating each digit's occurrences in the hours and minutes. I am now double-checking the H1 and H2 hour calculations, particularly the impact of the hour constraints (0-23). I've found a more reliable and efficient approach.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":3591,"output_tokens_details":{"reasoning_tokens":3591},"total_tokens":3666}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Refining Hour Calculation**\\n\\nI'm now implementing calculation refinements based on the detailed analysis. I've re-evaluated the H2 position, accounting for the unique hour constraints, and have updated the frequency totals for digits 0-9. I'm focusing on validating these counts to ensure an accurate base for finding the most and least frequent digits.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":3662,"output_tokens_details":{"reasoning_tokens":3662},"total_tokens":3737}},"type":"response.created"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"Let's break down the problem by counting the occurrences of each digit (0-9) across all possible times from 0","output_index":0,"type":"response.output_text.delta"}
@@ -10548,14 +10548,14 @@ data: {"response":{"id":"US8oarqkA-zQ_uMPs83E8A4","model":"gemini-3.5-flash","ob
 `;
 
 exports[`streaming: responses → google > reasoningRequest > streaming 1`] = `
-"event: response.output_text.delta
-data: {"content_index":0,"delta":"**Defining the Goal**\\n\\nI've zeroed in on the core of the problem: determining the train's average speed. The formula is key: Total Distance divided by Total Time. I'm building my approach around this foundational understanding.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+"event: response.created
+data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":67,"output_tokens_details":{"reasoning_tokens":67},"total_tokens":104}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Calculating the Distance**\\n\\nI'm now calculating the distances for each leg of the journey. I'm using the Distance = Speed x Time formula, breaking down the trip into stage one and stage two. I've worked out the distance for each stage and summed those up, and the total distance traveled is 200 miles! Next, I am calculating the total time of the journey.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":412,"output_tokens_details":{"reasoning_tokens":412},"total_tokens":449}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Finalizing the Calculation**\\n\\nI've completed all calculations. The process went smoothly, step-by-step. I've calculated the total distance at 200 miles and the total time at 3 hours. Dividing to get the average speed, I get 66.67 mph (or exactly 66 and 2/3 mph). Now I'm structuring the answer for presentation, following all of the steps I used.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":592,"output_tokens_details":{"reasoning_tokens":592},"total_tokens":629}},"type":"response.created"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"Here's how to calculate the average speed step-by-step","output_index":0,"type":"response.output_text.delta"}
@@ -10585,11 +10585,11 @@ data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > reasoningRequestTruncated > streaming 1`] = `
-"event: response.output_text.delta
-data: {"content_index":0,"delta":"**Calculating Average Speed**\\n\\nOkay, I'm working on calculating the average speed. I've broken down the problem to use the average speed formula: (Total Distance) / (Total Time). My next step is figuring out how to determine the total distance and total time, given the information in the problem. I need to make sure I don't miss any steps!\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+"event: response.created
+data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":68,"output_tokens_details":{"reasoning_tokens":68},"total_tokens":105}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Defining Problem Stages**\\n\\nI'm now focusing on how the train's journey can be broken into stages. I've realized the travel is in at least two parts. I'm recalling the formula for average speed: (Total Distance) / (Total Time). I believe this is critical to tackling the problem methodically.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":92,"output_tokens_details":{"reasoning_tokens":92},"total_tokens":129}},"type":"response.created"}
 
 event: response.incomplete
 data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":94,"output_tokens_details":{"reasoning_tokens":92},"total_tokens":131}},"type":"response.incomplete"}
@@ -10598,17 +10598,17 @@ data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > reasoningWithOutput > streaming 1`] = `
-"event: response.output_text.delta
-data: {"content_index":0,"delta":"**Reviewing Basic Principles**\\n\\nI've started by breaking down the user's question. Now I'm recalling relevant background knowledge, specifically focusing on how light scattering affects sky color. I'm focusing on the contrast between daytime and sunrise/sunset.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+"event: response.created
+data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":65,"output_tokens_details":{"reasoning_tokens":65},"total_tokens":72}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Defining the Standard Answer**\\n\\nNow I'm focusing on the core answer: \\"The sky is blue.\\" I'm also ensuring that I can explain *why* it's blue, using Rayleigh scattering as the key. I'm building out a list of other possible sky colors, so I can add them for completeness. I'm focusing on the importance of clarity.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":359,"output_tokens_details":{"reasoning_tokens":359},"total_tokens":366}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Refining My Explanation**\\n\\nI'm now zeroing in on a polished response. I'm focusing on crafting a succinct explanation that balances clarity with completeness, accounting for Rayleigh scattering as the key. I'm prioritizing the inclusion of varied sky colors in different situations to provide a more nuanced answer.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":607,"output_tokens_details":{"reasoning_tokens":607},"total_tokens":614}},"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"**Crafting the Final Response**\\n\\nI'm now satisfied with the explanation and focusing on polishing the response. I've re-read it, to clarify that the user receives an easy to understand answer, which is also correct. I'm prioritizing accuracy and conciseness, ready to finalize the statement.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+event: response.created
+data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":714,"output_tokens_details":{"reasoning_tokens":714},"total_tokens":721}},"type":"response.created"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"The sky is most commonly **blue** during the day.\\n\\nThis is due to a phenomenon called **Rayleigh scattering**. Shorter wavelengths of light (like blue and violet) are scattered","output_index":0,"type":"response.output_text.delta"}
@@ -10632,8 +10632,8 @@ data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > simpleRequest > streaming 1`] = `
-"event: response.output_text.delta
-data: {"content_index":0,"delta":"**Answering the Query**\\n\\nOkay, I'm focusing on providing a direct and accurate response to the user's question. My primary concern is delivering the correct information clearly. I'm aiming for a concise and factual answer that meets the user's needs.\\n\\n\\n","output_index":0,"type":"response.output_text.delta"}
+"event: response.created
+data: {"response":{"id":"iG_VacqLI7aX_uMP96rw0Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":8,"input_tokens_details":{"cached_tokens":0},"output_tokens":17,"output_tokens_details":{"reasoning_tokens":17},"total_tokens":25}},"type":"response.created"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"The","output_index":0,"type":"response.output_text.delta"}

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -10521,6 +10521,9 @@ data: {"content_index":0,"delta":" **0** and **1** are the most common, both app
 event: response.output_text.delta
 data: {"content_index":0,"delta":"1%**\\n\\n**Rarest Digit(s):**\\nDigits **6, 7, 8,** and **9** are the rarest, all appearing **264** times.\\nPercentage: (264","output_index":0,"type":"response.output_text.delta"}
 
+event: response.output_text.delta
+data: {"content_index":0,"delta":" / 5760) * 100% $\\\\approx$ **4.58%**","output_index":0,"type":"response.output_text.delta"}
+
 event: response.completed
 data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":5889,"output_tokens_details":{"reasoning_tokens":3662},"total_tokens":5964}},"type":"response.completed"}
 
@@ -10528,7 +10531,10 @@ data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > multimodalRequest > streaming 1`] = `
-"event: response.incomplete
+"event: response.output_text.delta
+data: {"content_index":0,"delta":"In this image, I see a beautiful **","output_index":0,"type":"response.output_text.delta"}
+
+event: response.incomplete
 data: {"response":{"id":"iW_VaZ3aDdSa_uMPpsqI4Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":267,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":287},"total_tokens":563}},"type":"response.incomplete"}
 
 "
@@ -10578,6 +10584,9 @@ data: {"content_index":0,"delta":"2 hours + 1 hour = 3 hours\\n\\n**6. Calculate
 event: response.output_text.delta
 data: {"content_index":0,"delta":" 66.666... mph\\n\\n**7. Round to a practical number:**\\n*   Average Speed ≈ 66.67 mph\\n\\n**Answer:** The average speed of the train is approximately **66.","output_index":0,"type":"response.output_text.delta"}
 
+event: response.output_text.delta
+data: {"content_index":0,"delta":"67 mph**.","output_index":0,"type":"response.output_text.delta"}
+
 event: response.completed
 data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":895,"output_tokens_details":{"reasoning_tokens":592},"total_tokens":932}},"type":"response.completed"}
 
@@ -10590,6 +10599,9 @@ data: {"delta":"**Calculating Average Speed**\\n\\nOkay, I'm working on calculat
 
 event: response.reasoning_summary_text.delta
 data: {"delta":"**Defining Problem Stages**\\n\\nI'm now focusing on how the train's journey can be broken into stages. I've realized the travel is in at least two parts. I'm recalling the formula for average speed: (Total Distance) / (Total Time). I believe this is critical to tackling the problem methodically.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+
+event: response.output_text.delta
+data: {"content_index":0,"delta":"Let's break","output_index":0,"type":"response.output_text.delta"}
 
 event: response.incomplete
 data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":94,"output_tokens_details":{"reasoning_tokens":92},"total_tokens":131}},"type":"response.incomplete"}
@@ -10625,6 +10637,9 @@ data: {"content_index":0,"delta":" blue light and leaving the longer-wavelength 
 event: response.output_text.delta
 data: {"content_index":0,"delta":" It appears **black** (with stars), as that side of Earth is facing away from the sun, and there's no sunlight to scatter in the atmosphere.\\n*   **Pollution or Dust:** Can give it a hazy,","output_index":0,"type":"response.output_text.delta"}
 
+event: response.output_text.delta
+data: {"content_index":0,"delta":" brownish, or yellowish tint.\\n\\nSo, while **blue** is the most common answer for a clear daytime sky, it's certainly not its only color!","output_index":0,"type":"response.output_text.delta"}
+
 event: response.completed
 data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":983,"output_tokens_details":{"reasoning_tokens":714},"total_tokens":990}},"type":"response.completed"}
 
@@ -10637,6 +10652,9 @@ data: {"delta":"**Answering the Query**\\n\\nOkay, I'm focusing on providing a d
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"The","output_index":0,"type":"response.output_text.delta"}
+
+event: response.output_text.delta
+data: {"content_index":0,"delta":" capital of France is **Paris**.","output_index":0,"type":"response.output_text.delta"}
 
 event: response.completed
 data: {"response":{"id":"iG_VacqLI7aX_uMP96rw0Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":8,"input_tokens_details":{"cached_tokens":0},"output_tokens":24,"output_tokens_details":{"reasoning_tokens":17},"total_tokens":32}},"type":"response.completed"}
@@ -10652,7 +10670,10 @@ data: {"response":{"id":"iG_VaZqcI_GW_uMPtubRiQE","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > systemMessageArrayContent > streaming 1`] = `
-"event: response.incomplete
+"event: response.output_text.delta
+data: {"content_index":0,"delta":"To find recent errors in the \`project_logs\` (","output_index":0,"type":"response.output_text.delta"}
+
+event: response.incomplete
 data: {"response":{"id":"i2_VafqnDsbu_uMPxqqZkQ0","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":29,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":284},"total_tokens":325}},"type":"response.incomplete"}
 
 "

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -10317,7 +10317,10 @@ data: {"response":{"id":"resp_transformed","model":"transformed","object":"respo
 `;
 
 exports[`streaming: responses → google > complexReasoningRequest > streaming 1`] = `
-"event: response.reasoning_summary_text.delta
+"event: response.created
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":65,"output_tokens_details":{"reasoning_tokens":65},"total_tokens":140}},"type":"response.created"}
+
+event: response.reasoning_summary_text.delta
 data: {"delta":"**Defining the Objective**\\n\\nOkay, I'm working on the problem of identifying the most and least frequent digits on a digital clock over a 24-hour period. I've begun to analyze the parameters, and I'm focusing on breaking down the time range (00:00 to 23:59) to count the digit appearances methodically. This approach is key to an effective solution.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
@@ -10495,7 +10498,10 @@ data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > multimodalRequest > streaming 1`] = `
-"event: response.output_text.delta
+"event: response.created
+data: {"response":{"id":"iW_VaZ3aDdSa_uMPpsqI4Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":267,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":287},"total_tokens":563}},"type":"response.created"}
+
+event: response.output_text.delta
 data: {"content_index":0,"delta":"In this image, I see a beautiful **","output_index":0,"type":"response.output_text.delta"}
 
 event: response.incomplete
@@ -10505,7 +10511,10 @@ data: {"response":{"id":"iW_VaZ3aDdSa_uMPpsqI4Qw","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > parallelToolCallsRequest > streaming 1`] = `
-"event: response.output_text.delta
+"event: response.created
+data: {"response":{"id":"US8oarqkA-zQ_uMPs83E8A4","model":"gemini-3.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":151,"input_tokens_details":{"cached_tokens":0},"output_tokens":117,"output_tokens_details":{"reasoning_tokens":93},"total_tokens":268}},"type":"response.created"}
+
+event: response.output_text.delta
 data: {"content_index":0,"delta":"In San Francisco, it is currently 65°F and sunny. In New York, it is 45","output_index":0,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
@@ -10518,7 +10527,10 @@ data: {"response":{"id":"US8oarqkA-zQ_uMPs83E8A4","model":"gemini-3.5-flash","ob
 `;
 
 exports[`streaming: responses → google > reasoningRequest > streaming 1`] = `
-"event: response.reasoning_summary_text.delta
+"event: response.created
+data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":67,"output_tokens_details":{"reasoning_tokens":67},"total_tokens":104}},"type":"response.created"}
+
+event: response.reasoning_summary_text.delta
 data: {"delta":"**Defining the Goal**\\n\\nI've zeroed in on the core of the problem: determining the train's average speed. The formula is key: Total Distance divided by Total Time. I'm building my approach around this foundational understanding.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
@@ -10558,7 +10570,10 @@ data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > reasoningRequestTruncated > streaming 1`] = `
-"event: response.reasoning_summary_text.delta
+"event: response.created
+data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":68,"output_tokens_details":{"reasoning_tokens":68},"total_tokens":105}},"type":"response.created"}
+
+event: response.reasoning_summary_text.delta
 data: {"delta":"**Calculating Average Speed**\\n\\nOkay, I'm working on calculating the average speed. I've broken down the problem to use the average speed formula: (Total Distance) / (Total Time). My next step is figuring out how to determine the total distance and total time, given the information in the problem. I need to make sure I don't miss any steps!\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
@@ -10574,7 +10589,10 @@ data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > reasoningWithOutput > streaming 1`] = `
-"event: response.reasoning_summary_text.delta
+"event: response.created
+data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":65,"output_tokens_details":{"reasoning_tokens":65},"total_tokens":72}},"type":"response.created"}
+
+event: response.reasoning_summary_text.delta
 data: {"delta":"**Reviewing Basic Principles**\\n\\nI've started by breaking down the user's question. Now I'm recalling relevant background knowledge, specifically focusing on how light scattering affects sky color. I'm focusing on the contrast between daytime and sunrise/sunset.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
@@ -10611,7 +10629,10 @@ data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > simpleRequest > streaming 1`] = `
-"event: response.reasoning_summary_text.delta
+"event: response.created
+data: {"response":{"id":"iG_VacqLI7aX_uMP96rw0Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":8,"input_tokens_details":{"cached_tokens":0},"output_tokens":17,"output_tokens_details":{"reasoning_tokens":17},"total_tokens":25}},"type":"response.created"}
+
+event: response.reasoning_summary_text.delta
 data: {"delta":"**Answering the Query**\\n\\nOkay, I'm focusing on providing a direct and accurate response to the user's question. My primary concern is delivering the correct information clearly. I'm aiming for a concise and factual answer that meets the user's needs.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
@@ -10627,14 +10648,20 @@ data: {"response":{"id":"iG_VacqLI7aX_uMP96rw0Q8","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > simpleRequestTruncated > streaming 1`] = `
-"event: response.incomplete
+"event: response.created
+data: {"response":{"id":"iG_VaZqcI_GW_uMPtubRiQE","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":10}},"type":"response.created"}
+
+event: response.incomplete
 data: {"response":{"id":"iG_VaZqcI_GW_uMPtubRiQE","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":10}},"type":"response.incomplete"}
 
 "
 `;
 
 exports[`streaming: responses → google > systemMessageArrayContent > streaming 1`] = `
-"event: response.output_text.delta
+"event: response.created
+data: {"response":{"id":"i2_VafqnDsbu_uMPxqqZkQ0","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":29,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":284},"total_tokens":325}},"type":"response.created"}
+
+event: response.output_text.delta
 data: {"content_index":0,"delta":"To find recent errors in the \`project_logs\` (","output_index":0,"type":"response.output_text.delta"}
 
 event: response.incomplete
@@ -10644,7 +10671,10 @@ data: {"response":{"id":"i2_VafqnDsbu_uMPxqqZkQ0","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > toolCallRequest > streaming 1`] = `
-"event: response.output_item.added
+"event: response.created
+data: {"response":{"id":"YVv7aeCnCK30jMcPgsyniAw","model":"gemini-3-flash-preview","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":73,"input_tokens_details":{"cached_tokens":0},"output_tokens":19,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":92}},"type":"response.created"}
+
+event: response.output_item.added
 data: {"item":{"arguments":"","call_id":"etjq4utn","name":"get_weather","status":"in_progress","type":"function_call"},"output_index":0,"type":"response.output_item.added"}
 
 event: response.function_call_arguments.delta

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -8477,23 +8477,23 @@ data: {"choices":[],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":null,"role":"assistant","tool_calls":[{"function":{"arguments":"","name":"get_weather"},"id":"call_Q7ylzllh6yaOZHOT7kvfjTaj","index":1,"type":"function"}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":null,"role":"assistant","tool_calls":[{"function":{"arguments":"","name":"get_weather"},"id":"call_Q7ylzllh6yaOZHOT7kvfjTaj","index":0,"type":"function"}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{\\""},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":null,"tool_calls":[{"function":{"arguments":"{\\""},"index":0}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"location"},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":null,"tool_calls":[{"function":{"arguments":"location"},"index":0}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"\\":\\""},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":null,"tool_calls":[{"function":{"arguments":"\\":\\""},"index":0}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"San"},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":null,"tool_calls":[{"function":{"arguments":"San"},"index":0}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":" Francisco"},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":null,"tool_calls":[{"function":{"arguments":" Francisco"},"index":0}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":","},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":null,"tool_calls":[{"function":{"arguments":","},"index":0}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":" CA"},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":null,"tool_calls":[{"function":{"arguments":" CA"},"index":0}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"\\"}"},"index":1}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
+data: {"choices":[{"delta":{"content":null,"tool_calls":[{"function":{"arguments":"\\"}"},"index":0}]},"finish_reason":null,"index":0}],"object":"chat.completion.chunk"}
 
 data: {"choices":[],"object":"chat.completion.chunk"}
 

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -9789,167 +9789,167 @@ data: {"response":{"id":"msg_01E9HYVD5q13m6p2wwxQYUAX","model":"claude-sonnet-4-
 event: response.in_progress
 data: {"sequence_number":0,"type":"response.in_progress"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"Let","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" me think about this step by step. We have a digital clock that shows times from 00:00 to 23:59, which means there are 24 hours × 60 minutes = 1440","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" different times displayed.\\n\\nEach time has 4 digits in the format HH:MM.","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"\\n\\nLet me count how often each digit (0-9) appears.\\n\\nFor the hours (00-23):\\n- First digit (","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"tens of hours): \\n  - 0 appears in: 00-09 (10 times)\\n  - 1 appears in: 10","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"-19 (10 times)\\n  - 2 appears in: 20-23 (4 times)\\n  - Total appearances per complete day","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":": 10+10+4 = 24 times\\n\\n- Second digit (units of hours):\\n  - 0 appears in: 00, 10, 20 (3 times)\\n  -","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" 1 appears in: 01, 11, 21 (3 times)\\n  - 2 appears in: 02, 12, 22 (3 times)\\n  - 3 appears in: 03, 13, 23 (3","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" times)\\n  - 4 appears in: 04, 14 (2 times)\\n  - 5 appears in: 05, 15 (2 times)\\n  - 6 appears in: 06, 16 ","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"(2 times)\\n  - 7 appears in: 07, 17 (2 times)\\n  - 8 appears in: 08, 18 (2 times)\\n  - 9 appears in: 09, 19 (2 times","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":")\\n\\nFor the minutes (00-59):\\n- First digit (tens of minutes):\\n  - 0 appears in: 00-09 (10 times)\\n  - 1 appears in: 10-19","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" (10 times)\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"  - 2 appears in:","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" 20-29 (10 times)\\n  - 3 appears in: 30-39 (10 times)\\n  - 4 appears in: 40-49 (10 times)\\n  - 5 appears in: 50-59 (10","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" times)\\n  - Each digit 0-5 shows up 10 times in this position\\n\\n- Second digit (units of minutes):\\n  - All","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" digits 0-9 cycle through 6 times across the minute range, appearing once","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" in each group of 10 minutes\\n\\nNow I need to combine these frequencies. Since there are 1440 total times in a day, I","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"'ll multiply the hourly digit frequencies by 60 (the number of minutes)","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" and the minute digit frequencies by 24 (the number of hours).","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"\\n\\nFor","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" the tens place of hours: 0 appears in hours 00-09 (10 hours ×","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" 60 minutes = 600 occurrences), 1 appears in hours 10-19 (10 × 60 = 600), and ","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"2 appears in hours 20-23 (4 × 60 = 240). For the units place of hours: 0 shows up in hours 00, 10,","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" 20 (3 × 60 = 180 times), 1 appears in hours 01, 11, 21 (3 × ","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"60 = 180 times), and this pattern continues for each digit.","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" ","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"08, 18, each shows 60 times = 2 × 60 = 120 times\\n- 9: appears in hours 09, 19, each shows 60 times = 2 × 60 = 120 times","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"\\n\\nFor the tens place in minutes, each digit 0-4","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" appears across a 10-minute span throughout all 24 hours, giving","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" 10 × 24 = 240 occurrences per digit. This covers","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" minutes 00-09, 10-19, 20-29, 30-39, and 40-49 respectively.","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"\\n\\nIn","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" the units place of minutes, all digits 0-9 cycle through 6 times each hour (appearing in x0, x1, x","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"2... x9), so 6 × 24 = 144 times daily.\\n\\nTall","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"ying up digit 0: it appears 600 times in the","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" first position, 180 in the second, 240 in the third, and 144 in the fourth, totaling 1164 occurrences.","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"\\n\\nDigit","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" 1 matches this same distribution—1164 total","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":". Digit 2 appears less frequently in the first position (only 240 times, since","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" it only shows up in 20:xx","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"-23:xx), bringing its total to 804. Digits 3 ","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"through 5 don't appear in the first position at all, with digit 3","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" reaching 564 total and digits 4 and 5 each totaling 504. Digit 6 appears 0 times in the third","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" position since minutes only go up to 59.","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"\\n\\nDigits","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" 7, 8, and 9 follow the same pattern as digits 4 and 5—","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"they never appear in the first position or third position, giving each a total of 264 occ","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"urrences. Adding everything up: 1164 + 1164 + 804 + 564 + 504 + 504 + 264 + 264 + 264 +","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" 264 = 5760. Since there are 1440 minutes in a day, this checks out.","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"\\n\\nThe digits","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" 0 and 1 dominate with 1164 appearances each (about 20.21%), while 6 through 9 are","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" the least frequent at 264 each (roughly 4.58%). For digit 1 specifically","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" in the first position, the hours 10-19 contribute 600 occurrences across all ","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"60 minutes of each hour.","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
@@ -10098,23 +10098,23 @@ data: {"response":{"id":"msg_01XrumAP48awLewmcSBbzCPg","model":"claude-sonnet-4-
 event: response.in_progress
 data: {"sequence_number":0,"type":"response.in_progress"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"To","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" find the average speed, I need to calculate the total distance traveled and divide it by the total time.\\n\\nStep 1: Calculate distance for the first part\\n-","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" Speed = 60 mph\\n- Time = 2 hours\\n- Distance = Speed × Time = 60 × 2 = 120 miles\\n\\nStep 2: Calculate distance for the second part\\n- Speed = 80 mph\\n- Time =","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" 1 hour\\n- Distance = Speed × Time = 80 × 1 = 80 miles\\n\\nStep 3: Calculate total distance\\n- Total distance = 120 + 80 = 200 miles\\n\\nStep 4: Calculate total time\\n- Total time = ","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"2 + 1 = 3 hours\\n\\nStep 5: Calculate average speed\\n- Average speed = Total distance ÷ Total time\\n- Average speed = 200 ÷ 3 = 66.67 mph (","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"rounded to 2 decimal places)","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
@@ -10165,26 +10165,26 @@ data: {"response":{"id":"msg_01FfNLZRubc8dQWzS5ErsqzT","model":"claude-sonnet-4-
 event: response.in_progress
 data: {"sequence_number":0,"type":"response.in_progress"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"This","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" is a straightforward question about the color of the sky. The sky appears blue during the day under normal conditions. This is due","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" to a phenomenon called Rayleigh scattering, where molecules in Earth's atmosphere scatter blue light from the sun more than other colors.\\n\\nHowever, I should note that the sky","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" can appear different colors at different times:\\n- Blue during a clear","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" day\\n- Red, orange, pink during sunrise/sunset\\n- Gray or white when clou","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"dy\\n- Dark/black at night\\n- Other variations depending on conditions\\n\\nI'll","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" give a simple, accurate answer that addresses the most common scenario.","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
@@ -10229,11 +10229,11 @@ data: {"response":{"id":"msg_01QuhHd1Xv5ZLfCUKDd7HSkL","model":"claude-sonnet-4-
 event: response.in_progress
 data: {"sequence_number":0,"type":"response.in_progress"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"This","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+event: response.reasoning_summary_text.delta
+data: {"delta":" is a straightforward factual question. The capital of France is Paris.","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
@@ -10353,35 +10353,35 @@ data: {"response":{"id":"resp_transformed","model":"transformed","object":"respo
 `;
 
 exports[`streaming: responses → google > complexReasoningRequest > streaming 1`] = `
-"event: response.created
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":65,"output_tokens_details":{"reasoning_tokens":65},"total_tokens":140}},"type":"response.created"}
+"event: response.reasoning_summary_text.delta
+data: {"delta":"**Defining the Objective**\\n\\nOkay, I'm working on the problem of identifying the most and least frequent digits on a digital clock over a 24-hour period. I've begun to analyze the parameters, and I'm focusing on breaking down the time range (00:00 to 23:59) to count the digit appearances methodically. This approach is key to an effective solution.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":462,"output_tokens_details":{"reasoning_tokens":462},"total_tokens":537}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Analyzing Digit Frequencies**\\n\\nI'm now diving deep into the specifics of digit counting, broken down by position. I'm focusing on the units digit of the minutes (M2). The total number of digits displayed is 5760 (1440 * 4). I've got to determine which numbers appear most and least. I'm breaking down how often each digit (0-9) appears in each position to find the solution. I am trying to determine a method to make this problem more efficient.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":953,"output_tokens_details":{"reasoning_tokens":953},"total_tokens":1028}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Calculating Digit Frequencies**\\n\\nI'm now determining the frequency of each digit in the minutes' tens place (M1). I have calculated that for M2, each digit (0-9) appears 144 times. I'm focusing on the position analysis to determine the occurrences of each digit. M1 cycles from 0-5 for every 10 minutes. I am analyzing the implications across the entire 24-hour period (00:00 to 23:59). My current focus is to efficiently determine the patterns.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":1341,"output_tokens_details":{"reasoning_tokens":1341},"total_tokens":1416}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Calculating Frequency Analysis**\\n\\nI've completed the initial frequency calculations for each digit position. Specifically, for M2, each digit appears 144 times, and for M1, digits 0-5 each occur 240 times, and 6-9 appear 0 times. My next step is to finalize the H1 and H2 digit occurrences, addressing the complexity of the hour constraints. I'll summarize these totals into the final tally.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":1731,"output_tokens_details":{"reasoning_tokens":1731},"total_tokens":1806}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Finalizing Calculations**\\n\\nI'm now finalizing the calculations for the tens (H1) and units (H2) of the hours. I've corrected an error in H2 calculations and now have a firm grasp on the frequency distribution. I'm focusing on consolidating all of the totals across the H1, H2, M1, and M2 positions for a complete, accurate count. The final step is determining the most and least frequent digits.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":2223,"output_tokens_details":{"reasoning_tokens":2223},"total_tokens":2298}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Calculating Total Counts**\\n\\nI'm now consolidating the frequency counts for all digit positions. Specifically, I've totaled each digit's occurrences in H1, H2, M1, and M2, accounting for all time constraints. From this analysis, I will determine the most and least frequent digits displayed over the entire 24-hour cycle. The final step is to verify the results.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":2662,"output_tokens_details":{"reasoning_tokens":2662},"total_tokens":2737}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Refining Calculation Accuracy**\\n\\nI'm now implementing the calculation refinements based on the detailed analysis. I've re-examined the H2 position, accounting for the varying hour constraints, and updated the frequency totals for digits 0-9. I'm focusing on validating these counts to ensure an accurate base for finding the most and least frequent digits.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":3251,"output_tokens_details":{"reasoning_tokens":3251},"total_tokens":3326}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Refining Calculation Accuracy**\\n\\nI'm now implementing calculation refinements based on the updated analysis of each digit position. I have re-evaluated the H2 position, accounting for the unique hour constraints, and have updated the frequency totals for digits 0-9. I'm focusing on validation of these counts.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":3591,"output_tokens_details":{"reasoning_tokens":3591},"total_tokens":3666}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Refining Calculations**\\n\\nI'm now refining the accuracy of the counts, re-evaluating each digit's occurrences in the hours and minutes. I am now double-checking the H1 and H2 hour calculations, particularly the impact of the hour constraints (0-23). I've found a more reliable and efficient approach.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":3662,"output_tokens_details":{"reasoning_tokens":3662},"total_tokens":3737}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Refining Hour Calculation**\\n\\nI'm now implementing calculation refinements based on the detailed analysis. I've re-evaluated the H2 position, accounting for the unique hour constraints, and have updated the frequency totals for digits 0-9. I'm focusing on validating these counts to ensure an accurate base for finding the most and least frequent digits.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"Let's break down the problem by counting the occurrences of each digit (0-9) across all possible times from 0","output_index":0,"type":"response.output_text.delta"}
@@ -10548,14 +10548,14 @@ data: {"response":{"id":"US8oarqkA-zQ_uMPs83E8A4","model":"gemini-3.5-flash","ob
 `;
 
 exports[`streaming: responses → google > reasoningRequest > streaming 1`] = `
-"event: response.created
-data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":67,"output_tokens_details":{"reasoning_tokens":67},"total_tokens":104}},"type":"response.created"}
+"event: response.reasoning_summary_text.delta
+data: {"delta":"**Defining the Goal**\\n\\nI've zeroed in on the core of the problem: determining the train's average speed. The formula is key: Total Distance divided by Total Time. I'm building my approach around this foundational understanding.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":412,"output_tokens_details":{"reasoning_tokens":412},"total_tokens":449}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Calculating the Distance**\\n\\nI'm now calculating the distances for each leg of the journey. I'm using the Distance = Speed x Time formula, breaking down the trip into stage one and stage two. I've worked out the distance for each stage and summed those up, and the total distance traveled is 200 miles! Next, I am calculating the total time of the journey.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":592,"output_tokens_details":{"reasoning_tokens":592},"total_tokens":629}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Finalizing the Calculation**\\n\\nI've completed all calculations. The process went smoothly, step-by-step. I've calculated the total distance at 200 miles and the total time at 3 hours. Dividing to get the average speed, I get 66.67 mph (or exactly 66 and 2/3 mph). Now I'm structuring the answer for presentation, following all of the steps I used.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"Here's how to calculate the average speed step-by-step","output_index":0,"type":"response.output_text.delta"}
@@ -10585,11 +10585,11 @@ data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > reasoningRequestTruncated > streaming 1`] = `
-"event: response.created
-data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":68,"output_tokens_details":{"reasoning_tokens":68},"total_tokens":105}},"type":"response.created"}
+"event: response.reasoning_summary_text.delta
+data: {"delta":"**Calculating Average Speed**\\n\\nOkay, I'm working on calculating the average speed. I've broken down the problem to use the average speed formula: (Total Distance) / (Total Time). My next step is figuring out how to determine the total distance and total time, given the information in the problem. I need to make sure I don't miss any steps!\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":92,"output_tokens_details":{"reasoning_tokens":92},"total_tokens":129}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Defining Problem Stages**\\n\\nI'm now focusing on how the train's journey can be broken into stages. I've realized the travel is in at least two parts. I'm recalling the formula for average speed: (Total Distance) / (Total Time). I believe this is critical to tackling the problem methodically.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.incomplete
 data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":94,"output_tokens_details":{"reasoning_tokens":92},"total_tokens":131}},"type":"response.incomplete"}
@@ -10598,17 +10598,17 @@ data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > reasoningWithOutput > streaming 1`] = `
-"event: response.created
-data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":65,"output_tokens_details":{"reasoning_tokens":65},"total_tokens":72}},"type":"response.created"}
+"event: response.reasoning_summary_text.delta
+data: {"delta":"**Reviewing Basic Principles**\\n\\nI've started by breaking down the user's question. Now I'm recalling relevant background knowledge, specifically focusing on how light scattering affects sky color. I'm focusing on the contrast between daytime and sunrise/sunset.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":359,"output_tokens_details":{"reasoning_tokens":359},"total_tokens":366}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Defining the Standard Answer**\\n\\nNow I'm focusing on the core answer: \\"The sky is blue.\\" I'm also ensuring that I can explain *why* it's blue, using Rayleigh scattering as the key. I'm building out a list of other possible sky colors, so I can add them for completeness. I'm focusing on the importance of clarity.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":607,"output_tokens_details":{"reasoning_tokens":607},"total_tokens":614}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Refining My Explanation**\\n\\nI'm now zeroing in on a polished response. I'm focusing on crafting a succinct explanation that balances clarity with completeness, accounting for Rayleigh scattering as the key. I'm prioritizing the inclusion of varied sky colors in different situations to provide a more nuanced answer.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
-event: response.created
-data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":714,"output_tokens_details":{"reasoning_tokens":714},"total_tokens":721}},"type":"response.created"}
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Crafting the Final Response**\\n\\nI'm now satisfied with the explanation and focusing on polishing the response. I've re-read it, to clarify that the user receives an easy to understand answer, which is also correct. I'm prioritizing accuracy and conciseness, ready to finalize the statement.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"The sky is most commonly **blue** during the day.\\n\\nThis is due to a phenomenon called **Rayleigh scattering**. Shorter wavelengths of light (like blue and violet) are scattered","output_index":0,"type":"response.output_text.delta"}
@@ -10632,8 +10632,8 @@ data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","ob
 `;
 
 exports[`streaming: responses → google > simpleRequest > streaming 1`] = `
-"event: response.created
-data: {"response":{"id":"iG_VacqLI7aX_uMP96rw0Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":8,"input_tokens_details":{"cached_tokens":0},"output_tokens":17,"output_tokens_details":{"reasoning_tokens":17},"total_tokens":25}},"type":"response.created"}
+"event: response.reasoning_summary_text.delta
+data: {"delta":"**Answering the Query**\\n\\nOkay, I'm focusing on providing a direct and accurate response to the user's question. My primary concern is delivering the correct information clearly. I'm aiming for a concise and factual answer that meets the user's needs.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
 data: {"content_index":0,"delta":"The","output_index":0,"type":"response.output_text.delta"}

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -10683,6 +10683,9 @@ exports[`streaming: responses → google > toolCallRequest > streaming 1`] = `
 "event: response.output_item.added
 data: {"item":{"arguments":"","call_id":"etjq4utn","name":"get_weather","status":"in_progress","type":"function_call"},"output_index":0,"type":"response.output_item.added"}
 
+event: response.function_call_arguments.delta
+data: {"delta":"{\\"location\\":\\"San Francisco, CA\\"}","output_index":0,"type":"response.function_call_arguments.delta"}
+
 event: response.completed
 data: {"response":{"id":"YVv7aeCnCK30jMcPgsyniAw","model":"gemini-3-flash-preview","object":"response","output":[],"status":"completed","usage":{"input_tokens":73,"input_tokens_details":{"cached_tokens":0},"output_tokens":19,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":92}},"type":"response.completed"}
 

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -425,12 +425,6 @@ exports[`streaming: anthropic → chat-completions > anthropicMidConversationSys
 "event: message_start
 data: {"message":{"content":[],"id":"chatcmpl-DmKoKHtVYgdxqBqvTor9wW6MsS9pY","model":"gpt-5-nano-2025-08-07","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{}},"type":"message_start"}
 
-event: content_block_start
-data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
-
-event: content_block_stop
-data: {"index":0,"type":"content_block_stop"}
-
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"cache_read_input_tokens":0,"input_tokens":51,"output_tokens":16}}
 
@@ -443,12 +437,6 @@ data: {"type":"message_stop"}
 exports[`streaming: anthropic → chat-completions > anthropicMixedToolResultWithText > streaming 1`] = `
 "event: message_start
 data: {"message":{"content":[],"id":"chatcmpl-Dp4RF3MuIGYlGOoQIJBvJ6q7UDIo9","model":"gpt-5-nano-2025-08-07","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{}},"type":"message_start"}
-
-event: content_block_start
-data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
-
-event: content_block_stop
-data: {"index":0,"type":"content_block_stop"}
 
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"cache_read_input_tokens":0,"input_tokens":176,"output_tokens":1024}}
@@ -2435,12 +2423,6 @@ exports[`streaming: anthropic → chat-completions > multimodalRequest > streami
 "event: message_start
 data: {"message":{"content":[],"id":"chatcmpl-DQJks6CVOvWns8GNiynFRRn4ehgOp","model":"gpt-5-nano-2025-08-07","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{"input_tokens":0,"output_tokens":0}},"type":"message_start"}
 
-event: content_block_start
-data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
-
-event: content_block_stop
-data: {"index":0,"type":"content_block_stop"}
-
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"output_tokens":0}}
 
@@ -3047,12 +3029,6 @@ exports[`streaming: anthropic → chat-completions > reasoningRequestTruncated >
 "event: message_start
 data: {"message":{"content":[],"id":"chatcmpl-DQJkrNrNugghqC0hWDiKrEWQqNEAl","model":"gpt-5-nano-2025-08-07","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{"input_tokens":0,"output_tokens":0}},"type":"message_start"}
 
-event: content_block_start
-data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
-
-event: content_block_stop
-data: {"index":0,"type":"content_block_stop"}
-
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"output_tokens":0}}
 
@@ -3383,12 +3359,6 @@ exports[`streaming: anthropic → chat-completions > simpleRequestTruncated > st
 "event: message_start
 data: {"message":{"content":[],"id":"chatcmpl-DSQdxzW4LeTU2buaGgT2o0rexbRw2","model":"gpt-5-nano-2025-08-07","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{}},"type":"message_start"}
 
-event: content_block_start
-data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
-
-event: content_block_stop
-data: {"index":0,"type":"content_block_stop"}
-
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"cache_read_input_tokens":0,"input_tokens":15,"output_tokens":16}}
 
@@ -3401,12 +3371,6 @@ data: {"type":"message_stop"}
 exports[`streaming: anthropic → chat-completions > systemMessageArrayContent > streaming 1`] = `
 "event: message_start
 data: {"message":{"content":[],"id":"chatcmpl-DQJkv4fvJmyemAFjFO7Exu2n0aL8u","model":"gpt-5-nano-2025-08-07","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{"input_tokens":0,"output_tokens":0}},"type":"message_start"}
-
-event: content_block_start
-data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
-
-event: content_block_stop
-data: {"index":0,"type":"content_block_stop"}
 
 event: message_delta
 data: {"delta":{"stop_reason":"max_tokens"},"type":"message_delta","usage":{"output_tokens":0}}

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -10351,145 +10351,145 @@ event: response.reasoning_summary_text.delta
 data: {"delta":"**Refining Hour Calculation**\\n\\nI'm now implementing calculation refinements based on the detailed analysis. I've re-evaluated the H2 position, accounting for the unique hour constraints, and have updated the frequency totals for digits 0-9. I'm focusing on validating these counts to ensure an accurate base for finding the most and least frequent digits.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"Let's break down the problem by counting the occurrences of each digit (0-9) across all possible times from 0","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"Let's break down the problem by counting the occurrences of each digit (0-9) across all possible times from 0","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"0:00 to 23:59.\\n\\nFirst, let's determine the total number of digits displayed.\\n*   There are 24 hours (00 to 23).\\n*   There are","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"0:00 to 23:59.\\n\\nFirst, let's determine the total number of digits displayed.\\n*   There are 24 hours (00 to 23).\\n*   There are","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 60 minutes in each hour (00 to 59).\\n*   Total number of times displayed = 24 hours * 60 minutes = 1440 times.\\n*   Each time (e.","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 60 minutes in each hour (00 to 59).\\n*   Total number of times displayed = 24 hours * 60 minutes = 1440 times.\\n*   Each time (e.","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"g., 01:23) consists of 4 digits.\\n*   Total number of digits displayed = 1440 times * 4 digits/time = 5760 digits.\\n\\nNow, let's","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"g., 01:23) consists of 4 digits.\\n*   Total number of digits displayed = 1440 times * 4 digits/time = 5760 digits.\\n\\nNow, let's","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" count the occurrences of each digit (0-9) by considering their positions:\\n\\n1.  **M2 (Units of Minutes - Rightmost digit):**\\n    *   This digit cycles through 0, 1, 2","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" count the occurrences of each digit (0-9) by considering their positions:\\n\\n1.  **M2 (Units of Minutes - Rightmost digit):**\\n    *   This digit cycles through 0, 1, 2","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":", ..., 9, 0, 1, ...\\n    *   In a 60-minute cycle (00-59), each digit (0-9) appears 6 times (e.g., ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":", ..., 9, 0, 1, ...\\n    *   In a 60-minute cycle (00-59), each digit (0-9) appears 6 times (e.g., ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"0 appears in :00, :10, :20, :30, :40, :50).\\n    *   This pattern repeats for all 24 hours.\\n    *   So, each","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"0 appears in :00, :10, :20, :30, :40, :50).\\n    *   This pattern repeats for all 24 hours.\\n    *   So, each","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" digit 0-9 appears: 6 occurrences/hour * 24 hours = **144 times** in the M2 position.\\n\\n2.  **M1 (Tens of Minutes - Second digit from right):**\\n    ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" digit 0-9 appears: 6 occurrences/hour * 24 hours = **144 times** in the M2 position.\\n\\n2.  **M1 (Tens of Minutes - Second digit from right):**\\n    ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"*   This digit cycles through 0, 1, 2, 3, 4, 5.\\n    *   In a 60-minute cycle (00-59):\\n        *   0 appears 1","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"*   This digit cycles through 0, 1, 2, 3, 4, 5.\\n    *   In a 60-minute cycle (00-59):\\n        *   0 appears 1","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"0 times (00-09)\\n        *   1 appears 10 times (10-19)\\n        *   2 appears 10 times (20-29)\\n        *   3","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"0 times (00-09)\\n        *   1 appears 10 times (10-19)\\n        *   2 appears 10 times (20-29)\\n        *   3","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" appears 10 times (30-39)\\n        *   4 appears 10 times (40-49)\\n        *   5 appears 10 times (50-59)\\n    ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" appears 10 times (30-39)\\n        *   4 appears 10 times (40-49)\\n        *   5 appears 10 times (50-59)\\n    ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"*   Digits 6, 7, 8, 9 never appear in this position.\\n    *   This pattern repeats for all 24 hours.\\n    *   So, each digit 0-5 appears: 10","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"*   Digits 6, 7, 8, 9 never appear in this position.\\n    *   This pattern repeats for all 24 hours.\\n    *   So, each digit 0-5 appears: 10","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" occurrences/hour * 24 hours = **240 times** in the M1 position.\\n\\n3.  **H2 (Units of Hours - Second digit from left):**\\n    *   This digit's range","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" occurrences/hour * 24 hours = **240 times** in the M1 position.\\n\\n3.  **H2 (Units of Hours - Second digit from left):**\\n    *   This digit's range","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" depends on the H1 digit.\\n    *   For hours 00-19 (H1 is 0 or 1): The H2 digit cycles 0, 1, ..., 9. Each digit appears once for","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" depends on the H1 digit.\\n    *   For hours 00-19 (H1 is 0 or 1): The H2 digit cycles 0, 1, ..., 9. Each digit appears once for","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" each hour (e.g., in 01:XX, the '1' appears 60 times). There are 20 such hours (00-19).\\n        *   So, for digits 0-9","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" each hour (e.g., in 01:XX, the '1' appears 60 times). There are 20 such hours (00-19).\\n        *   So, for digits 0-9","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":": 1 occurrence/hour * 60 minutes/hour * 20 hours = **1200 times**. *This is incorrect. The 1 occurrence/hour already means it is present in that hour for 60 minutes","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":": 1 occurrence/hour * 60 minutes/hour * 20 hours = **1200 times**. *This is incorrect. The 1 occurrence/hour already means it is present in that hour for 60 minutes","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":".*\\n        *   Let's rephrase: In hours 00-09 (10 hours), each digit 0-9 appears in the H2 position for 60 minutes. So, 10 hours * ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":".*\\n        *   Let's rephrase: In hours 00-09 (10 hours), each digit 0-9 appears in the H2 position for 60 minutes. So, 10 hours * ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"60 minutes = 600 occurrences for H2=0 (e.g. 00:XX), H2=1 (01:XX), ..., H2=9 (09:XX).\\n        *   Similarly","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"60 minutes = 600 occurrences for H2=0 (e.g. 00:XX), H2=1 (01:XX), ..., H2=9 (09:XX).\\n        *   Similarly","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":", in hours 10-19 (10 hours), each digit 0-9 appears in the H2 position for 60 minutes. So, another 10 hours * 60 minutes = 600 occurrences.","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":", in hours 10-19 (10 hours), each digit 0-9 appears in the H2 position for 60 minutes. So, another 10 hours * 60 minutes = 600 occurrences.","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"\\n        *   No, this counts the hours wrong.\\n        *   Let's think of it as: How many times does the number 'X' appear in H2 *for each minute*?\\n        *   H2","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"\\n        *   No, this counts the hours wrong.\\n        *   Let's think of it as: How many times does the number 'X' appear in H2 *for each minute*?\\n        *   H2","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" takes values from 0-9 in the hours 00-09 (e.g., for 01:MM, H2 is 1). So, for each of these 10 hours (00,","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" takes values from 0-9 in the hours 00-09 (e.g., for 01:MM, H2 is 1). So, for each of these 10 hours (00,","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 01, ..., 09), the H2 digit is constant for 60 minutes. So, digits 0-9 each appear 60 times. (e.g., '0' is H2 in ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 01, ..., 09), the H2 digit is constant for 60 minutes. So, digits 0-9 each appear 60 times. (e.g., '0' is H2 in ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"00:XX - 60 times; '1' is H2 in 01:XX - 60 times).\\n        *   Similarly, for hours 10-19 (e.g., for","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"00:XX - 60 times; '1' is H2 in 01:XX - 60 times).\\n        *   Similarly, for hours 10-19 (e.g., for","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 11:MM, H2 is 1). Each digit 0-9 appears 60 times. (e.g., '0' is H2 in 10:XX - 60 times; '","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 11:MM, H2 is 1). Each digit 0-9 appears 60 times. (e.g., '0' is H2 in 10:XX - 60 times; '","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"1' is H2 in 11:XX - 60 times).\\n        *   So, for digits 0-9 from hours 00-19: 60 (from 0X:MM","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"1' is H2 in 11:XX - 60 times).\\n        *   So, for digits 0-9 from hours 00-19: 60 (from 0X:MM","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":") + 60 (from 1X:MM) = **120 times each**.\\n    *   For hours 20-23 (H1 is 2): The H2 digit cycles 0,","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":") + 60 (from 1X:MM) = **120 times each**.\\n    *   For hours 20-23 (H1 is 2): The H2 digit cycles 0,","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 1, 2, 3. Each digit appears once for each hour for 60 minutes.\\n        *   0 appears in 20:XX (60 times).\\n        *   1 appears in 21:XX","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 1, 2, 3. Each digit appears once for each hour for 60 minutes.\\n        *   0 appears in 20:XX (60 times).\\n        *   1 appears in 21:XX","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" (60 times).\\n        *   2 appears in 22:XX (60 times).\\n        *   3 appears in 23:XX (60 times).\\n        *   Digits 4-9","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" (60 times).\\n        *   2 appears in 22:XX (60 times).\\n        *   3 appears in 23:XX (60 times).\\n        *   Digits 4-9","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" never appear in this range.\\n    *   Total for H2:\\n        *   Digits 0-3: 120 (from 00-19) + 60 (from 20-23)","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" never appear in this range.\\n    *   Total for H2:\\n        *   Digits 0-3: 120 (from 00-19) + 60 (from 20-23)","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" = **180 times each**.\\n        *   Digits 4-9: 120 (from 00-19) + 0 (from 20-23) = **120","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" = **180 times each**.\\n        *   Digits 4-9: 120 (from 00-19) + 0 (from 20-23) = **120","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" times each**.\\n\\n4.  **H1 (Tens of Hours - Leftmost digit):**\\n    *   This digit can be 0, 1, or 2.\\n    *   Digit 0 appears for hours 00","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" times each**.\\n\\n4.  **H1 (Tens of Hours - Leftmost digit):**\\n    *   This digit can be 0, 1, or 2.\\n    *   Digit 0 appears for hours 00","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"-09 (10 hours). For each hour, it's displayed for 60 minutes.\\n        *   10 hours * 60 minutes/hour = **600 times**.\\n    *   Digit 1 appears","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"-09 (10 hours). For each hour, it's displayed for 60 minutes.\\n        *   10 hours * 60 minutes/hour = **600 times**.\\n    *   Digit 1 appears","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" for hours 10-19 (10 hours). For each hour, it's displayed for 60 minutes.\\n        *   10 hours * 60 minutes/hour = **600 times**.","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" for hours 10-19 (10 hours). For each hour, it's displayed for 60 minutes.\\n        *   10 hours * 60 minutes/hour = **600 times**.","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"\\n    *   Digit 2 appears for hours 20-23 (4 hours). For each hour, it's displayed for 60 minutes.\\n        *   4 hours * 60 minutes/hour =","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"\\n    *   Digit 2 appears for hours 20-23 (4 hours). For each hour, it's displayed for 60 minutes.\\n        *   4 hours * 60 minutes/hour =","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" **240 times**.\\n    *   Digits 3-9 never appear in this position.\\n\\n**Summary of Counts for Each Digit:**\\n\\n| Digit | M2 (Units of Min) | M1 (Tens of Min) | H","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" **240 times**.\\n    *   Digits 3-9 never appear in this position.\\n\\n**Summary of Counts for Each Digit:**\\n\\n| Digit | M2 (Units of Min) | M1 (Tens of Min) | H","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"2 (Units of Hr) | H1 (Tens of Hr) | Total Count |\\n| :---- | :---------------- | :--------------- | :--------------- | :-------------- | :---------- |\\n| **0** | 144","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"2 (Units of Hr) | H1 (Tens of Hr) | Total Count |\\n| :---- | :---------------- | :--------------- | :--------------- | :-------------- | :---------- |\\n| **0** | 144","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"               | 240              | 180              | 600             | **1164**    |\\n| **1** | 144               | 240              | 180              ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"               | 240              | 180              | 600             | **1164**    |\\n| **1** | 144               | 240              | 180              ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"| 600             | **1164**    |\\n| **2** | 144               | 240              | 180              | 240             | **80","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"| 600             | **1164**    |\\n| **2** | 144               | 240              | 180              | 240             | **80","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"4**     |\\n| **3** | 144               | 240              | 180              | 0               | **564**     |\\n| **4** | 14","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"4**     |\\n| **3** | 144               | 240              | 180              | 0               | **564**     |\\n| **4** | 14","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"4               | 240              | 120              | 0               | **504**     |\\n| **5** | 144               | 240              | 120","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"4               | 240              | 120              | 0               | **504**     |\\n| **5** | 144               | 240              | 120","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"              | 0               | **504**     |\\n| **6** | 144               | 0                | 120              | 0               | **264**     |\\n|","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"              | 0               | **504**     |\\n| **6** | 144               | 0                | 120              | 0               | **264**     |\\n|","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" **7** | 144               | 0                | 120              | 0               | **264**     |\\n| **8** | 144               | 0                | ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" **7** | 144               | 0                | 120              | 0               | **264**     |\\n| **8** | 144               | 0                | ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"120              | 0               | **264**     |\\n| **9** | 144               | 0                | 120              | 0               | **264**     ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"120              | 0               | **264**     |\\n| **9** | 144               | 0                | 120              | 0               | **264**     ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"|\\n| **Total** | | | | | **5760** |\\n\\nThe sum of the counts (5760) matches our total number of digits.\\n\\n**Most Common Digit(s):**\\nDigits","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"|\\n| **Total** | | | | | **5760** |\\n\\nThe sum of the counts (5760) matches our total number of digits.\\n\\n**Most Common Digit(s):**\\nDigits","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" **0** and **1** are the most common, both appearing **1164** times.\\nPercentage: (1164 / 5760) * 100% $\\\\approx$ **20.2","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" **0** and **1** are the most common, both appearing **1164** times.\\nPercentage: (1164 / 5760) * 100% $\\\\approx$ **20.2","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"1%**\\n\\n**Rarest Digit(s):**\\nDigits **6, 7, 8,** and **9** are the rarest, all appearing **264** times.\\nPercentage: (264","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"1%**\\n\\n**Rarest Digit(s):**\\nDigits **6, 7, 8,** and **9** are the rarest, all appearing **264** times.\\nPercentage: (264","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" / 5760) * 100% $\\\\approx$ **4.58%**","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" / 5760) * 100% $\\\\approx$ **4.58%**","output_index":1,"type":"response.output_text.delta"}
 
 event: response.completed
 data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":5889,"output_tokens_details":{"reasoning_tokens":3662},"total_tokens":5964}},"type":"response.completed"}
@@ -10540,28 +10540,28 @@ event: response.reasoning_summary_text.delta
 data: {"delta":"**Finalizing the Calculation**\\n\\nI've completed all calculations. The process went smoothly, step-by-step. I've calculated the total distance at 200 miles and the total time at 3 hours. Dividing to get the average speed, I get 66.67 mph (or exactly 66 and 2/3 mph). Now I'm structuring the answer for presentation, following all of the steps I used.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"Here's how to calculate the average speed step-by-step","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"Here's how to calculate the average speed step-by-step","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":":\\n\\n**1. Understand the Formula for Average Speed:**\\nAverage Speed = Total Distance / Total Time\\n\\n**2. Calculate the Distance for the First Part of the Journey:**\\n*   Speed = 60 mph\\n*   ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":":\\n\\n**1. Understand the Formula for Average Speed:**\\nAverage Speed = Total Distance / Total Time\\n\\n**2. Calculate the Distance for the First Part of the Journey:**\\n*   Speed = 60 mph\\n*   ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"Time = 2 hours\\n*   Distance₁ = Speed × Time = 60 mph × 2 hours = 120 miles\\n\\n**3. Calculate the Distance for the Second Part of the Journey:**\\n*   Speed = ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"Time = 2 hours\\n*   Distance₁ = Speed × Time = 60 mph × 2 hours = 120 miles\\n\\n**3. Calculate the Distance for the Second Part of the Journey:**\\n*   Speed = ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"80 mph\\n*   Time = 1 hour\\n*   Distance₂ = Speed × Time = 80 mph × 1 hour = 80 miles\\n\\n**4. Calculate the Total Distance Traveled:**\\n*   ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"80 mph\\n*   Time = 1 hour\\n*   Distance₂ = Speed × Time = 80 mph × 1 hour = 80 miles\\n\\n**4. Calculate the Total Distance Traveled:**\\n*   ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"Total Distance = Distance₁ + Distance₂ = 120 miles + 80 miles = 200 miles\\n\\n**5. Calculate the Total Time Taken:**\\n*   Total Time = Time₁ + Time₂ = ","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"Total Distance = Distance₁ + Distance₂ = 120 miles + 80 miles = 200 miles\\n\\n**5. Calculate the Total Time Taken:**\\n*   Total Time = Time₁ + Time₂ = ","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"2 hours + 1 hour = 3 hours\\n\\n**6. Calculate the Average Speed:**\\n*   Average Speed = Total Distance / Total Time\\n*   Average Speed = 200 miles / 3 hours\\n*   Average Speed =","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"2 hours + 1 hour = 3 hours\\n\\n**6. Calculate the Average Speed:**\\n*   Average Speed = Total Distance / Total Time\\n*   Average Speed = 200 miles / 3 hours\\n*   Average Speed =","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 66.666... mph\\n\\n**7. Round to a practical number:**\\n*   Average Speed ≈ 66.67 mph\\n\\n**Answer:** The average speed of the train is approximately **66.","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 66.666... mph\\n\\n**7. Round to a practical number:**\\n*   Average Speed ≈ 66.67 mph\\n\\n**Answer:** The average speed of the train is approximately **66.","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"67 mph**.","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"67 mph**.","output_index":1,"type":"response.output_text.delta"}
 
 event: response.completed
 data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":895,"output_tokens_details":{"reasoning_tokens":592},"total_tokens":932}},"type":"response.completed"}
@@ -10580,7 +10580,7 @@ event: response.reasoning_summary_text.delta
 data: {"delta":"**Defining Problem Stages**\\n\\nI'm now focusing on how the train's journey can be broken into stages. I've realized the travel is in at least two parts. I'm recalling the formula for average speed: (Total Distance) / (Total Time). I believe this is critical to tackling the problem methodically.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"Let's break","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"Let's break","output_index":1,"type":"response.output_text.delta"}
 
 event: response.incomplete
 data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":94,"output_tokens_details":{"reasoning_tokens":92},"total_tokens":131}},"type":"response.incomplete"}
@@ -10605,22 +10605,22 @@ event: response.reasoning_summary_text.delta
 data: {"delta":"**Crafting the Final Response**\\n\\nI'm now satisfied with the explanation and focusing on polishing the response. I've re-read it, to clarify that the user receives an easy to understand answer, which is also correct. I'm prioritizing accuracy and conciseness, ready to finalize the statement.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"The sky is most commonly **blue** during the day.\\n\\nThis is due to a phenomenon called **Rayleigh scattering**. Shorter wavelengths of light (like blue and violet) are scattered","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"The sky is most commonly **blue** during the day.\\n\\nThis is due to a phenomenon called **Rayleigh scattering**. Shorter wavelengths of light (like blue and violet) are scattered","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" more efficiently by the tiny nitrogen and oxygen molecules in Earth's atmosphere than longer wavelengths (like red and yellow). Because blue light is scattered in all directions, it appears to come from all parts of the sky, making it look blue.\\n\\nHowever,","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" more efficiently by the tiny nitrogen and oxygen molecules in Earth's atmosphere than longer wavelengths (like red and yellow). Because blue light is scattered in all directions, it appears to come from all parts of the sky, making it look blue.\\n\\nHowever,","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" the color of the sky can change dramatically depending on various factors:\\n\\n*   **Sunrise and Sunset:** It often appears **red, orange, pink, or purple**. At these times, the sunlight travels through much more atmosphere, scattering away most of the","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" the color of the sky can change dramatically depending on various factors:\\n\\n*   **Sunrise and Sunset:** It often appears **red, orange, pink, or purple**. At these times, the sunlight travels through much more atmosphere, scattering away most of the","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" blue light and leaving the longer-wavelength reds and oranges to reach our eyes directly.\\n*   **Overcast or Stormy Weather:** It can appear **grey or white** due to thick clouds reflecting and absorbing light.\\n*   **Night:**","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" blue light and leaving the longer-wavelength reds and oranges to reach our eyes directly.\\n*   **Overcast or Stormy Weather:** It can appear **grey or white** due to thick clouds reflecting and absorbing light.\\n*   **Night:**","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" It appears **black** (with stars), as that side of Earth is facing away from the sun, and there's no sunlight to scatter in the atmosphere.\\n*   **Pollution or Dust:** Can give it a hazy,","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" It appears **black** (with stars), as that side of Earth is facing away from the sun, and there's no sunlight to scatter in the atmosphere.\\n*   **Pollution or Dust:** Can give it a hazy,","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" brownish, or yellowish tint.\\n\\nSo, while **blue** is the most common answer for a clear daytime sky, it's certainly not its only color!","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" brownish, or yellowish tint.\\n\\nSo, while **blue** is the most common answer for a clear daytime sky, it's certainly not its only color!","output_index":1,"type":"response.output_text.delta"}
 
 event: response.completed
 data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":983,"output_tokens_details":{"reasoning_tokens":714},"total_tokens":990}},"type":"response.completed"}
@@ -10636,10 +10636,10 @@ event: response.reasoning_summary_text.delta
 data: {"delta":"**Answering the Query**\\n\\nOkay, I'm focusing on providing a direct and accurate response to the user's question. My primary concern is delivering the correct information clearly. I'm aiming for a concise and factual answer that meets the user's needs.\\n\\n\\n","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"The","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"The","output_index":1,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" capital of France is **Paris**.","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" capital of France is **Paris**.","output_index":1,"type":"response.output_text.delta"}
 
 event: response.completed
 data: {"response":{"id":"iG_VacqLI7aX_uMP96rw0Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":8,"input_tokens_details":{"cached_tokens":0},"output_tokens":24,"output_tokens_details":{"reasoning_tokens":17},"total_tokens":32}},"type":"response.completed"}

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -20918,6 +20918,91 @@ exports[`google → anthropic > googleResponseSchemaPropertyOrderingParam > resp
 }
 `;
 
+exports[`google → anthropic > googleThinkingJsonSchemaParam > request 1`] = `
+{
+  "max_tokens": 2048,
+  "messages": [
+    {
+      "content": "Analyze the caption and return a compact JSON summary.
+Caption: A creator compares two microphone setups, explains why the cheaper lavalier performs better outdoors, and asks viewers to comment with their setup.
+Return exactly {"topic": "...", "recommendation": "...", "confidence": 0.0}.",
+      "role": "user",
+    },
+  ],
+  "model": "claude-sonnet-4-5-20250929",
+  "output_config": {
+    "format": {
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence": {
+            "type": "number",
+          },
+          "recommendation": {
+            "type": "string",
+          },
+          "topic": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "topic",
+          "recommendation",
+          "confidence",
+        ],
+        "type": "object",
+      },
+      "type": "json_schema",
+    },
+  },
+  "thinking": {
+    "budget_tokens": 1024,
+    "type": "enabled",
+  },
+}
+`;
+
+exports[`google → anthropic > googleThinkingJsonSchemaParam > response 1`] = `
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Let me analyze this caption:
+
+The caption is about a creator comparing two microphone setups, specifically noting that a cheaper lavalier microphone performs better outdoors. They're asking viewers to share their setup.
+
+Topic: This is clearly about audio equipment/microphones, specifically for content creation.
+
+Recommendation: The creator is recommending or highlighting that the cheaper lavalier microphone performs better outdoors compared to another setup.
+
+Confidence: This is straightforward - the topic is clearly about microphones/audio equipment, and there's a clear comparison being made with a conclusion about outdoor performance. I'd say confidence is high, around 0.9 or 0.95.
+
+Let me format this as the required JSON:",
+            "thought": true,
+            "thoughtSignature": "ErAHCm4IDhgCKkDpggyvjNahOhXmo7j9sVZCH0ts6UIRQPhRaackCyvJxX6jzLRpWrMqdHTkE5Is28iUHIlV5G+Ava6Bh6EBvls1MhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM+YTvdpV2VMJ/e+fMGgx2ooZOBZgDpUAJ9f8iMGJtNpmLX5NE1ktsLvHIMYXNJ9bW4GLwD9l6YJQ31nI0fkR8lpKb0/96uOB1/d2adirvBcmW0twxopu8xWPeiTkK2A1NRavZOCQOp3G5cc5ZjXbT85POp+KrmwhEDUe4K2ajCpHJNQcpUSiazlrxK9ctcU+kYxUMBD4RhquDhYcpbtzv9aSpT3l2FnnO66jmvgpZrI3oPjWT7F0JVfkckwLIFRpR2RGBu5orjQN9UK3jeeN8YCAOEWkYDEkhioIGIK3xvxt+tkTF87bnd6Fjcbna4yfcHROevH1rFyYppZkyvCy3dbTcMji2aj5mWVatGjKuSDnLagkF5VSNnDi5e5wg1gHEK8lZZ8yeKtbYbeeQKdg+AHrG6uxvaeUxdfQ2631AqO/2cLGmoST/BAgwQB0ZRbCVob+jDWf+Ua6cHVOusjn44pUE68/2rPixnZ3khC7NwOgLkkoMaf43aAe01CFVrmIg1k4gS8yqORVJESWDs8vWWQ8mxV3QqWe83kGU0on1dw2iE9stW1R5bxZjEzknYJnrc375f1HsIR7Tdnjp7Y9+lEz54HyOMZPRUoLvaNpZSDREIrK1ulUT/06U6R6PmgPULa4tPhPO/01gOfTus5XWlrSWlBqu/62Z/re1K7tPzeHQQFphi5W1RhODhV3EN1w2zcosGSV/2TM2+O9aHPF3ghvzfaUzAH+0UEgaZBXbq+P4kLlv//RAnqpqwTuabcC4DNGLazTElFMgzj5PT4qbz0QKm/K9GuVyOqcAc6xaSr6hl9MM5J0btUjE1FYB5b89FJ1FchnR3qWkmtuG+Jj9mz436VIu/TDByQcjdfIgNo2hL7Mepfk40pbykqGny5wPSawrgLvoDAZHrW3Vpp8BXRG+/4pS91487Rp/NehZb/vz2hjb/Do0zgMTt7MDAqhgSxhpOi81IjrkOyq7oqPVPMtFAVlNJxuYwHSeKPaKH0rckFCuXHOerJDNp9EeduwVZ1GIH4as2dVKwNA1+30lThUvUOjr/AP8b9uu/OEbC+e22wJsmQUtSDjlo3Hb/ywhnEzHYyjATz6g+d2GsDYYAQ==",
+          },
+          {
+            "text": "{"confidence":0.95,"recommendation":"Use a cheaper lavalier microphone for better outdoor audio performance","topic":"Microphone setup comparison for content creation"}",
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 0,
+    },
+  ],
+  "modelVersion": "claude-sonnet-4-5-20250929",
+  "usageMetadata": {
+    "cachedContentTokenCount": 0,
+    "candidatesTokenCount": 199,
+    "promptTokenCount": 290,
+    "totalTokenCount": 489,
+  },
+}
+`;
+
 exports[`google → anthropic > googleToolCallThoughtSignatureReplayParam > request 1`] = `
 {
   "max_tokens": 4096,
@@ -23527,6 +23612,75 @@ exports[`google → chat-completions > googleResponseSchemaPropertyOrderingParam
 }
 `;
 
+exports[`google → chat-completions > googleThinkingJsonSchemaParam > request 1`] = `
+{
+  "max_completion_tokens": 2048,
+  "messages": [
+    {
+      "content": "Analyze the caption and return a compact JSON summary.
+Caption: A creator compares two microphone setups, explains why the cheaper lavalier performs better outdoors, and asks viewers to comment with their setup.
+Return exactly {"topic": "...", "recommendation": "...", "confidence": 0.0}.",
+      "role": "user",
+    },
+  ],
+  "model": "gpt-5-nano",
+  "reasoning_effort": "medium",
+  "response_format": {
+    "json_schema": {
+      "name": "response",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence": {
+            "type": "number",
+          },
+          "recommendation": {
+            "type": "string",
+          },
+          "topic": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "topic",
+          "recommendation",
+          "confidence",
+        ],
+        "type": "object",
+      },
+    },
+    "type": "json_schema",
+  },
+}
+`;
+
+exports[`google → chat-completions > googleThinkingJsonSchemaParam > response 1`] = `
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "{"topic":"Outdoor lavalier microphone comparison","recommendation":"Highlight practical test results showing budget lavalier can outperform in outdoor conditions and invite audience to share their own setups.","confidence":0.0}",
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 0,
+    },
+  ],
+  "modelVersion": "gpt-5-nano-2025-08-07",
+  "usageMetadata": {
+    "cachedContentTokenCount": 0,
+    "candidatesTokenCount": 54,
+    "promptTokenCount": 106,
+    "thoughtsTokenCount": 960,
+    "totalTokenCount": 1120,
+  },
+}
+`;
+
 exports[`google → chat-completions > googleToolCallThoughtSignatureReplayParam > request 1`] = `
 {
   "messages": [
@@ -25979,6 +26133,90 @@ exports[`google → responses > googleResponseSchemaPropertyOrderingParam > resp
     "promptTokenCount": 42,
     "thoughtsTokenCount": 128,
     "totalTokenCount": 170,
+  },
+}
+`;
+
+exports[`google → responses > googleThinkingJsonSchemaParam > request 1`] = `
+{
+  "input": [
+    {
+      "content": "Analyze the caption and return a compact JSON summary.
+Caption: A creator compares two microphone setups, explains why the cheaper lavalier performs better outdoors, and asks viewers to comment with their setup.
+Return exactly {"topic": "...", "recommendation": "...", "confidence": 0.0}.",
+      "role": "user",
+    },
+  ],
+  "max_output_tokens": 2048,
+  "model": "gpt-5-nano",
+  "reasoning": {
+    "effort": "medium",
+  },
+  "text": {
+    "format": {
+      "name": "response",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence": {
+            "type": "number",
+          },
+          "recommendation": {
+            "type": "string",
+          },
+          "topic": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "topic",
+          "recommendation",
+          "confidence",
+        ],
+        "type": "object",
+      },
+      "type": "json_schema",
+    },
+  },
+}
+`;
+
+exports[`google → responses > googleThinkingJsonSchemaParam > response 1`] = `
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "",
+            "thought": true,
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 0,
+    },
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "{"confidence":0.0,"recommendation":"Highlight price‑performance tradeoffs between the mics and invite viewers to share their own outdoor setups to boost engagement.","topic":"Mic setup comparison and outdoor performance with audience engagement"}",
+          },
+        ],
+        "role": "model",
+      },
+      "finishReason": "STOP",
+      "index": 1,
+    },
+  ],
+  "modelVersion": "gpt-5-nano-2025-08-07",
+  "usageMetadata": {
+    "cachedContentTokenCount": 0,
+    "candidatesTokenCount": 110,
+    "promptTokenCount": 102,
+    "thoughtsTokenCount": 704,
+    "totalTokenCount": 916,
   },
 }
 `;

--- a/payloads/snapshots/googleThinkingJsonSchemaParam/google/followup-request.json
+++ b/payloads/snapshots/googleThinkingJsonSchemaParam/google/followup-request.json
@@ -1,0 +1,62 @@
+{
+  "model": "gemini-3.5-flash",
+  "contents": [
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "Analyze the caption and return a compact JSON summary.\nCaption: A creator compares two microphone setups, explains why the cheaper lavalier performs better outdoors, and asks viewers to comment with their setup.\nReturn exactly {\"topic\": \"...\", \"recommendation\": \"...\", \"confidence\": 0.0}."
+        }
+      ]
+    },
+    {
+      "role": "model",
+      "parts": [
+        {
+          "text": "**My Analysis of the Microphone Comparison Caption**\n\nOkay, so I've got this caption here: \"A creator compares two microphone setups, explains why the cheaper lavalier performs better outdoors, and asks viewers to comment with their setup.\" Right, so the task is to distill this into a concise JSON summary, using a specific schema. It looks like it's pretty straightforward, but I'll make sure I'm precise.\n\nFirst, I need to pinpoint the *topic*. \"Microphone setup comparison\" feels a bit generic, but accurate. \"Microphone comparison for outdoor use\" is also good, since that's where the nuance lies. I'll lean towards the latter, because it emphasizes the context.\n\nNext, the *recommendation*. The caption explicitly states that the \"cheaper lavalier performs better outdoors\". That's my key takeaway, so the recommendation will be \"Cheaper lavalier microphone for outdoor use\".\n\nFinally, the *confidence*. This one's easy. The text is unambiguous about the performance advantage and the comparison itself. The claim is explicit, so I'm giving it a very high confidence, let's say 0.95. I'd give it 1.0 but there's a chance something is lost in the description.\n\nNow, all that's left is to construct the JSON object based on the schema and generate the output.\n\n\n",
+          "thought": true
+        },
+        {
+          "text": "{\"topic\": \"Microphone setup comparison\", \"recommendation\": \"Use the cheaper lavalier microphone for outdoor recording\", \"confidence\": 0.95}",
+          "thoughtSignature": "EpEFCo4FAQw51sfAMqqfWjsxHCzgQK7tXTE+zUH7IxFVnQGSrx+S3Y6YJo9w8nNpF9qDRhrQkmbZwjE8RtXs/YIXSESK9Jka6msE8nC6h58TTH5B1S3bQgcVuayiEbs2/M5l4v5QahgXfwwtwt7TBnHLUBdufeiAAN9qdP16DfHGvA9xE06797gppsCHuJIaC70Vn/pqHobgWZo7mllJn5wN435ZS9GORary+fRgu9PO9HzifHh8Q6M+wXkuqv9wCO0UkhuEeXzUnyfuAe1WoIpR+ZrVJ/TVhY32uTDdy/zMZzBHrgUfsVHseW/zwxGDJW43XOz7U2PbBGnjyp6tWiU3hc195fRaIg7QS+nRbjeaL5PRZJPzU/Epmf+LklCwxge0Pd4V7vHfj7EF391SnXj3hAjdBv8pdLm5UIx6gUaiHPRH/bBKUx4V6p7gn+JzEVcqRtNbbu20f5SELgyz4DppTLxo3/R3ToJikZEiLrBhRJo4o2Eju3stEW3kuUOTuKYreybMbPzrXx1PpQmHoBieuJ6gTzEc4voqxKnpKe8u3IMCwwWrdGJSbLGEDxbw3U59eBDNEfYWD/WaSe1Wkmu7WHKgwS+G8agUjhTV7oms24/C/lKcj2VIqruEw9TteJiUwL8VujcZCSCh9rXtKsq8j/GfdC6Rr/32pC0IN8e3VLKDZwsDpq1AZaShuMXc3RkgJI1ucugRBBp1S7tey4v+iHYPvkZGj/IhVmM/c/QJpD1ye2dyLffhN3puJJMtVkVZqCeN2VGQWd3+k3cIIciZgcgL2U0Jv5i+cU/SAWbKG8WdF9fjlRN9ppsIBrBf33HUPU9KAsO16Mz20Px3rEiqmUfz28qwoVxOmGV0TkENWgyf"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "What should I do next?"
+        }
+      ]
+    }
+  ],
+  "generationConfig": {
+    "temperature": 0,
+    "maxOutputTokens": 2048,
+    "responseMimeType": "application/json",
+    "responseJsonSchema": {
+      "type": "object",
+      "properties": {
+        "topic": {
+          "type": "string"
+        },
+        "recommendation": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "topic",
+        "recommendation",
+        "confidence"
+      ]
+    },
+    "thinkingConfig": {
+      "thinkingBudget": 1024,
+      "includeThoughts": true
+    }
+  }
+}

--- a/payloads/snapshots/googleThinkingJsonSchemaParam/google/followup-response.json
+++ b/payloads/snapshots/googleThinkingJsonSchemaParam/google/followup-response.json
@@ -1,0 +1,31 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "{\"topic\": \"Microphone setup comparison\", \"recommendation\": \"Use the cheaper lavalier microphone for outdoor recording\", \"confidence\": 0.95}",
+            "thoughtSignature": "EjQKMgEMOdbHmJ5s6Z+KfgnqubqSvHnf/qq4X9hEy3B1C6QMpisnVj7/WcQyStAuiw8Ds9IX"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 537,
+    "candidatesTokenCount": 34,
+    "totalTokenCount": 571,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 537
+      }
+    ],
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "xj0waqWfNayDz7IPxdfoqQc"
+}

--- a/payloads/snapshots/googleThinkingJsonSchemaParam/google/request.json
+++ b/payloads/snapshots/googleThinkingJsonSchemaParam/google/request.json
@@ -1,0 +1,41 @@
+{
+  "model": "gemini-3.5-flash",
+  "contents": [
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "Analyze the caption and return a compact JSON summary.\nCaption: A creator compares two microphone setups, explains why the cheaper lavalier performs better outdoors, and asks viewers to comment with their setup.\nReturn exactly {\"topic\": \"...\", \"recommendation\": \"...\", \"confidence\": 0.0}."
+        }
+      ]
+    }
+  ],
+  "generationConfig": {
+    "temperature": 0,
+    "maxOutputTokens": 2048,
+    "responseMimeType": "application/json",
+    "responseJsonSchema": {
+      "type": "object",
+      "properties": {
+        "topic": {
+          "type": "string"
+        },
+        "recommendation": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "topic",
+        "recommendation",
+        "confidence"
+      ]
+    },
+    "thinkingConfig": {
+      "thinkingBudget": 1024,
+      "includeThoughts": true
+    }
+  }
+}

--- a/payloads/snapshots/googleThinkingJsonSchemaParam/google/response.json
+++ b/payloads/snapshots/googleThinkingJsonSchemaParam/google/response.json
@@ -1,0 +1,36 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "**My Analysis of the Microphone Comparison Caption**\n\nOkay, so I've got this caption here: \"A creator compares two microphone setups, explains why the cheaper lavalier performs better outdoors, and asks viewers to comment with their setup.\" Right, so the task is to distill this into a concise JSON summary, using a specific schema. It looks like it's pretty straightforward, but I'll make sure I'm precise.\n\nFirst, I need to pinpoint the *topic*. \"Microphone setup comparison\" feels a bit generic, but accurate. \"Microphone comparison for outdoor use\" is also good, since that's where the nuance lies. I'll lean towards the latter, because it emphasizes the context.\n\nNext, the *recommendation*. The caption explicitly states that the \"cheaper lavalier performs better outdoors\". That's my key takeaway, so the recommendation will be \"Cheaper lavalier microphone for outdoor use\".\n\nFinally, the *confidence*. This one's easy. The text is unambiguous about the performance advantage and the comparison itself. The claim is explicit, so I'm giving it a very high confidence, let's say 0.95. I'd give it 1.0 but there's a chance something is lost in the description.\n\nNow, all that's left is to construct the JSON object based on the schema and generate the output.\n\n\n",
+            "thought": true
+          },
+          {
+            "text": "{\"topic\": \"Microphone setup comparison\", \"recommendation\": \"Use the cheaper lavalier microphone for outdoor recording\", \"confidence\": 0.95}",
+            "thoughtSignature": "EpEFCo4FAQw51sfAMqqfWjsxHCzgQK7tXTE+zUH7IxFVnQGSrx+S3Y6YJo9w8nNpF9qDRhrQkmbZwjE8RtXs/YIXSESK9Jka6msE8nC6h58TTH5B1S3bQgcVuayiEbs2/M5l4v5QahgXfwwtwt7TBnHLUBdufeiAAN9qdP16DfHGvA9xE06797gppsCHuJIaC70Vn/pqHobgWZo7mllJn5wN435ZS9GORary+fRgu9PO9HzifHh8Q6M+wXkuqv9wCO0UkhuEeXzUnyfuAe1WoIpR+ZrVJ/TVhY32uTDdy/zMZzBHrgUfsVHseW/zwxGDJW43XOz7U2PbBGnjyp6tWiU3hc195fRaIg7QS+nRbjeaL5PRZJPzU/Epmf+LklCwxge0Pd4V7vHfj7EF391SnXj3hAjdBv8pdLm5UIx6gUaiHPRH/bBKUx4V6p7gn+JzEVcqRtNbbu20f5SELgyz4DppTLxo3/R3ToJikZEiLrBhRJo4o2Eju3stEW3kuUOTuKYreybMbPzrXx1PpQmHoBieuJ6gTzEc4voqxKnpKe8u3IMCwwWrdGJSbLGEDxbw3U59eBDNEfYWD/WaSe1Wkmu7WHKgwS+G8agUjhTV7oms24/C/lKcj2VIqruEw9TteJiUwL8VujcZCSCh9rXtKsq8j/GfdC6Rr/32pC0IN8e3VLKDZwsDpq1AZaShuMXc3RkgJI1ucugRBBp1S7tey4v+iHYPvkZGj/IhVmM/c/QJpD1ye2dyLffhN3puJJMtVkVZqCeN2VGQWd3+k3cIIciZgcgL2U0Jv5i+cU/SAWbKG8WdF9fjlRN9ppsIBrBf33HUPU9KAsO16Mz20Px3rEiqmUfz28qwoVxOmGV0TkENWgyf"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 63,
+    "candidatesTokenCount": 34,
+    "totalTokenCount": 235,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 63
+      }
+    ],
+    "thoughtsTokenCount": 138,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "wz0wapqVELXoz7IPlLPL6Qg"
+}

--- a/payloads/transforms/google_to_anthropic/googleThinkingJsonSchemaParam.json
+++ b/payloads/transforms/google_to_anthropic/googleThinkingJsonSchemaParam.json
@@ -1,0 +1,35 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_016g8eUVW5Xbd2Z5PXNJLRu8",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "thinking",
+      "thinking": "Let me analyze this caption:\n\nThe caption is about a creator comparing two microphone setups, specifically noting that a cheaper lavalier microphone performs better outdoors. They're asking viewers to share their setup.\n\nTopic: This is clearly about audio equipment/microphones, specifically for content creation.\n\nRecommendation: The creator is recommending or highlighting that the cheaper lavalier microphone performs better outdoors compared to another setup.\n\nConfidence: This is straightforward - the topic is clearly about microphones/audio equipment, and there's a clear comparison being made with a conclusion about outdoor performance. I'd say confidence is high, around 0.9 or 0.95.\n\nLet me format this as the required JSON:",
+      "signature": "ErAHCm4IDhgCKkDpggyvjNahOhXmo7j9sVZCH0ts6UIRQPhRaackCyvJxX6jzLRpWrMqdHTkE5Is28iUHIlV5G+Ava6Bh6EBvls1MhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM+YTvdpV2VMJ/e+fMGgx2ooZOBZgDpUAJ9f8iMGJtNpmLX5NE1ktsLvHIMYXNJ9bW4GLwD9l6YJQ31nI0fkR8lpKb0/96uOB1/d2adirvBcmW0twxopu8xWPeiTkK2A1NRavZOCQOp3G5cc5ZjXbT85POp+KrmwhEDUe4K2ajCpHJNQcpUSiazlrxK9ctcU+kYxUMBD4RhquDhYcpbtzv9aSpT3l2FnnO66jmvgpZrI3oPjWT7F0JVfkckwLIFRpR2RGBu5orjQN9UK3jeeN8YCAOEWkYDEkhioIGIK3xvxt+tkTF87bnd6Fjcbna4yfcHROevH1rFyYppZkyvCy3dbTcMji2aj5mWVatGjKuSDnLagkF5VSNnDi5e5wg1gHEK8lZZ8yeKtbYbeeQKdg+AHrG6uxvaeUxdfQ2631AqO/2cLGmoST/BAgwQB0ZRbCVob+jDWf+Ua6cHVOusjn44pUE68/2rPixnZ3khC7NwOgLkkoMaf43aAe01CFVrmIg1k4gS8yqORVJESWDs8vWWQ8mxV3QqWe83kGU0on1dw2iE9stW1R5bxZjEzknYJnrc375f1HsIR7Tdnjp7Y9+lEz54HyOMZPRUoLvaNpZSDREIrK1ulUT/06U6R6PmgPULa4tPhPO/01gOfTus5XWlrSWlBqu/62Z/re1K7tPzeHQQFphi5W1RhODhV3EN1w2zcosGSV/2TM2+O9aHPF3ghvzfaUzAH+0UEgaZBXbq+P4kLlv//RAnqpqwTuabcC4DNGLazTElFMgzj5PT4qbz0QKm/K9GuVyOqcAc6xaSr6hl9MM5J0btUjE1FYB5b89FJ1FchnR3qWkmtuG+Jj9mz436VIu/TDByQcjdfIgNo2hL7Mepfk40pbykqGny5wPSawrgLvoDAZHrW3Vpp8BXRG+/4pS91487Rp/NehZb/vz2hjb/Do0zgMTt7MDAqhgSxhpOi81IjrkOyq7oqPVPMtFAVlNJxuYwHSeKPaKH0rckFCuXHOerJDNp9EeduwVZ1GIH4as2dVKwNA1+30lThUvUOjr/AP8b9uu/OEbC+e22wJsmQUtSDjlo3Hb/ywhnEzHYyjATz6g+d2GsDYYAQ=="
+    },
+    {
+      "type": "text",
+      "text": "{\"confidence\":0.95,\"recommendation\":\"Use a cheaper lavalier microphone for better outdoor audio performance\",\"topic\":\"Microphone setup comparison for content creation\"}"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 290,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 199,
+    "output_tokens_details": {
+      "thinking_tokens": 159
+    },
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/payloads/transforms/google_to_chat-completions/googleThinkingJsonSchemaParam.json
+++ b/payloads/transforms/google_to_chat-completions/googleThinkingJsonSchemaParam.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-Dr5txekuHtMdQTzlbe12SreHWJRQx",
+  "object": "chat.completion",
+  "created": 1781546441,
+  "model": "gpt-5-nano-2025-08-07",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\"topic\":\"Outdoor lavalier microphone comparison\",\"recommendation\":\"Highlight practical test results showing budget lavalier can outperform in outdoor conditions and invite audience to share their own setups.\",\"confidence\":0.0}",
+        "refusal": null,
+        "annotations": []
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 106,
+    "completion_tokens": 1014,
+    "total_tokens": 1120,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 960,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/payloads/transforms/google_to_responses/googleThinkingJsonSchemaParam.json
+++ b/payloads/transforms/google_to_responses/googleThinkingJsonSchemaParam.json
@@ -1,0 +1,103 @@
+{
+  "id": "resp_0f34f6e2425442f3006a303dc8c3b88198917e4e6f9760b2c7",
+  "object": "response",
+  "created_at": 1781546440,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1781546447,
+  "error": null,
+  "frequency_penalty": 0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": 2048,
+  "max_tool_calls": null,
+  "model": "gpt-5-nano-2025-08-07",
+  "moderation": null,
+  "output": [
+    {
+      "id": "rs_0f34f6e2425442f3006a303dc91d188198a777728e7276f95a",
+      "type": "reasoning",
+      "content": [],
+      "summary": []
+    },
+    {
+      "id": "msg_0f34f6e2425442f3006a303dcf08f08198b1743e406f162609",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"confidence\":0.0,\"recommendation\":\"Highlight price‑performance tradeoffs between the mics and invite viewers to share their own outdoor setups to boost engagement.\",\"topic\":\"Mic setup comparison and outdoor performance with audience engagement\"}"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": "current_turn",
+    "effort": "medium",
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1,
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "description": null,
+      "name": "response",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence": {
+            "type": "number"
+          },
+          "recommendation": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic",
+          "recommendation",
+          "confidence"
+        ],
+        "type": "object"
+      },
+      "strict": true
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 102,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 814,
+    "output_tokens_details": {
+      "reasoning_tokens": 704
+    },
+    "total_tokens": 916
+  },
+  "user": null,
+  "metadata": {},
+  "output_text": "{\"confidence\":0.0,\"recommendation\":\"Highlight price‑performance tradeoffs between the mics and invite viewers to share their own outdoor setups to boost engagement.\",\"topic\":\"Mic setup comparison and outdoor performance with audience engagement\"}"
+}


### PR DESCRIPTION
## Why is this diff so big?

Google can put reasoning, visible text, signatures, tool starts, and finish data in the same provider chunk, while Responses and Anthropic require separate ordered events.

## What

Fix Google includeThoughts / reasoning stream handling so thought parts are kept separate from visible output instead of being flattened into parse-breaking content.

## Changes

- Preserve Google `thought: true` parts as universal reasoning deltas instead of assistant content.
- Preserve Google `thoughtSignature` values through reasoning, text, and function-call stream chunks.
- Emit valid target stream event sequences for mixed reasoning + text/tool chunks:
  - Google -> Responses emits separate reasoning, text, tool, and terminal events.
  - Google -> Anthropic emits ordered thinking/signature/text/tool blocks with valid content block indexes.
  - Google -> Chat Completions keeps visible content separate from reasoning.
- Normalize Responses stream output item indexes:
  - Responses `output_index` is treated as an output item index, not a universal choice index.
  - Responses function-call output item indexes are remapped to tool-relative indexes in stateful stream transforms.
- Preserve Google-native `thinkingBudget` roundtrips without forcing Anthropic/Bedrock budget reasoning into Gemini 3 `thinkingBudget`.
- Add recorded payload coverage for `googleThinkingJsonSchemaParam`.
- Update transform snapshots and narrow expected-diff entries for the intentional remaining provider differences.

