### PR TITLE
Support http/1 clients for `braintrust-llm-router`

### DIFF
--- a/crates/braintrust-llm-router/src/client.rs
+++ b/crates/braintrust-llm-router/src/client.rs
@@ -33,6 +33,8 @@ pub struct ClientSettings {
     pub request_timeout: Duration,
     pub pool_idle_timeout: Duration,
     pub pool_max_idle_per_host: usize,
+    // Force HTTP/1.1 for providers whose high-concurrency path performs better without HTTP/2 multiplexing.
+    pub http1_only: bool,
     pub user_agent: String,
     pub dns_overrides: Vec<DnsOverride>,
     pub follow_redirects: bool,
@@ -45,6 +47,7 @@ impl Default for ClientSettings {
             request_timeout: Duration::from_secs(600),
             pool_idle_timeout: Duration::from_secs(90),
             pool_max_idle_per_host: 16,
+            http1_only: false,
             user_agent: format!("braintrust-llm-router/{}", env!("CARGO_PKG_VERSION")),
             dns_overrides: Vec::new(),
             follow_redirects: true,
@@ -59,6 +62,10 @@ pub fn build_client(settings: &ClientSettings) -> Result<Client> {
         .pool_idle_timeout(settings.pool_idle_timeout)
         .pool_max_idle_per_host(settings.pool_max_idle_per_host)
         .user_agent(&settings.user_agent);
+
+    if settings.http1_only {
+        builder = builder.http1_only();
+    }
 
     if !settings.follow_redirects {
         builder = builder.redirect(Policy::none());
@@ -84,6 +91,7 @@ pub fn build_middleware_client(settings: &ClientSettings) -> Result<ClientWithMi
         client.connect_timeout_ms = settings.connect_timeout.as_millis() as u64,
         client.pool_idle_timeout_ms = settings.pool_idle_timeout.as_millis() as u64,
         client.pool_max_idle_per_host = settings.pool_max_idle_per_host as u64,
+        client.http1_only = settings.http1_only,
     );
 
     #[cfg(feature = "tracing")]
@@ -119,6 +127,7 @@ fn build_middleware_client_inner(settings: &ClientSettings) -> Result<ClientWith
         client.connect_timeout_ms = settings.connect_timeout.as_millis() as u64,
         client.pool_idle_timeout_ms = settings.pool_idle_timeout.as_millis() as u64,
         client.pool_max_idle_per_host = settings.pool_max_idle_per_host as u64,
+        client.http1_only = settings.http1_only,
     )
     .in_scope(|| {
         let client = build_client(settings)?;

--- a/crates/braintrust-llm-router/src/client.rs
+++ b/crates/braintrust-llm-router/src/client.rs
@@ -4,10 +4,11 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use dashmap::DashMap;
+use http::Extensions;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use reqwest::{redirect::Policy, Client, ClientBuilder};
-use reqwest_middleware::ClientWithMiddleware;
+use reqwest::{redirect::Policy, Client, ClientBuilder, Request, Response};
+use reqwest_middleware::{ClientWithMiddleware, Middleware, Next};
 use reqwest_retry::{
     default_on_request_failure, policies::ExponentialBackoff, RetryTransientMiddleware, Retryable,
     RetryableStrategy,
@@ -155,8 +156,43 @@ fn build_retrying_middleware_client(client: Client) -> ClientWithMiddleware {
     );
 
     reqwest_middleware::ClientBuilder::new(client)
+        .with(ResponseMetadataMiddleware)
         .with(retry_middleware)
         .build()
+}
+
+struct ResponseMetadataMiddleware;
+
+#[async_trait::async_trait]
+impl Middleware for ResponseMetadataMiddleware {
+    async fn handle(
+        &self,
+        req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<Response> {
+        let response = next.run(req, extensions).await?;
+
+        #[cfg(feature = "tracing")]
+        tracing::Span::current().record(
+            "http.response.version",
+            http_version_label(response.version()),
+        );
+
+        Ok(response)
+    }
+}
+
+#[cfg(feature = "tracing")]
+fn http_version_label(version: reqwest::Version) -> &'static str {
+    match version {
+        reqwest::Version::HTTP_09 => "HTTP/0.9",
+        reqwest::Version::HTTP_10 => "HTTP/1.0",
+        reqwest::Version::HTTP_11 => "HTTP/1.1",
+        reqwest::Version::HTTP_2 => "HTTP/2",
+        reqwest::Version::HTTP_3 => "HTTP/3",
+        _ => "unknown",
+    }
 }
 
 fn retryable_transport_failure(err: &reqwest_middleware::Error) -> Option<Retryable> {

--- a/crates/braintrust-llm-router/src/lib.rs
+++ b/crates/braintrust-llm-router/src/lib.rs
@@ -1,7 +1,10 @@
 mod auth;
 mod catalog;
 mod client;
-pub use client::{clear_override_client, set_override_client, ClientSettings, DnsOverride};
+pub use client::{
+    build_middleware_client, clear_override_client, set_override_client, ClientSettings,
+    DnsOverride,
+};
 pub use reqwest_middleware::ClientWithMiddleware;
 mod error;
 mod providers;

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -761,13 +761,14 @@ impl Router {
                     attempt = attempt,
                     http.url = tracing::field::Empty,
                     http.status_code = tracing::field::Empty,
+                    http.response.version = tracing::field::Empty,
                 );
                 async {
                     provider
                         .complete(payload.clone(), auth, &spec, format, client_headers)
                         .await
                 }
-                .instrument(span)
+                .instrument(span.clone())
                 .await
             };
 


### PR DESCRIPTION
some providers like baseten prefer http 1.1 -> https://docs.baseten.co/inference/performance-client