### PR TITLE
Parse streaming errors

### DIFF
--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -1037,6 +1037,14 @@
       "errors": [
         { "pattern": "InputItemType::AdditionalTools", "reason": "Responses additional_tools is a mid-conversation tool definition item with no universal representation" }
       ]
+    },
+    {
+      "testCase": "responsesStreamImageDownloadFailureParam",
+      "source": "Responses",
+      "target": "*",
+      "errors": [
+        { "pattern": "InputItemType::AdditionalTools", "reason": "Responses additional_tools is a mid-conversation tool definition item with no universal representation" }
+      ]
     }
   ]
 }

--- a/crates/generate-types/src/main.rs
+++ b/crates/generate-types/src/main.rs
@@ -239,6 +239,7 @@ fn create_essential_openai_schemas(spec: &serde_json::Value) -> serde_json::Valu
     let chat_stream_response_type = "CreateChatCompletionStreamResponse";
     let responses_request_type = "CreateResponse";
     let responses_response_type = "Response";
+    let responses_stream_response_type = "ResponseStreamEvent";
 
     let default_map = serde_json::Map::new();
     let all_schemas = spec
@@ -283,6 +284,12 @@ fn create_essential_openai_schemas(spec: &serde_json::Value) -> serde_json::Valu
         &mut essential_schemas,
         &mut processed,
     );
+    add_openai_schema_with_dependencies(
+        responses_stream_response_type,
+        all_schemas,
+        &mut essential_schemas,
+        &mut processed,
+    );
 
     // Fix all $ref paths to point to #/definitions/ instead of #/components/schemas/
     let mut fixed_schemas = serde_json::Map::new();
@@ -309,7 +316,8 @@ fn create_essential_openai_schemas(spec: &serde_json::Value) -> serde_json::Valu
                 "type": "object",
                 "properties": {
                     "responses_request": {"$ref": "#/definitions/CreateResponse"},
-                    "responses_response": {"$ref": "#/definitions/Response"}
+                    "responses_response": {"$ref": "#/definitions/Response"},
+                    "responses_stream_response": {"$ref": "#/definitions/ResponseStreamEvent"}
                 }
             }
         ],
@@ -562,6 +570,8 @@ fn preprocess_anthropic_schema_for_separation(spec: &serde_json::Value) -> serde
     for schema_name in &response_schemas {
         add_dependencies_recursively(schema_name, all_schemas, &mut separated_schemas);
     }
+    add_dependencies_recursively("MessageStreamEvent", all_schemas, &mut separated_schemas);
+    add_dependencies_recursively("ErrorResponse", all_schemas, &mut separated_schemas);
 
     // Step 3: Now clean the main request/response schemas to remove conflicting fields
     for schema_name in &request_schemas {
@@ -595,7 +605,9 @@ fn preprocess_anthropic_schema_for_separation(spec: &serde_json::Value) -> serde
                 "title": "ResponseType",
                 "type": "object",
                 "properties": {
-                    "response": {"$ref": "#/definitions/Message"}
+                    "response": {"$ref": "#/definitions/Message"},
+                    "stream_event": {"$ref": "#/definitions/MessageStreamEvent"},
+                    "error_response": {"$ref": "#/definitions/ErrorResponse"}
                 }
             },
         ],
@@ -968,6 +980,15 @@ fn post_process_quicktype_output_for_anthropic(quicktype_output: &str) -> String
 
     // Add serde skip_serializing_if for Optional fields
     processed = add_serde_skip_if_none(&processed);
+
+    processed.push_str(
+        r#"
+
+// Compatibility aliases for names used by Lingua's hand-written adapters.
+pub type MessageRole = PurpleRole;
+pub type ResponseLocationCitation = Citation;
+"#,
+    );
 
     processed
 }

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -570,6 +570,19 @@ pub(crate) fn transform_stream_chunk_step(
     let source_adapter = detection.adapter;
     let source_format = source_adapter.format();
     let source_is_native_stream = matches!(detection.kind, DetectKind::Stream);
+
+    if source_format == target_format && source_is_native_stream {
+        let universal = source_adapter.stream_to_universal(chunk).ok().flatten();
+        return Ok(StreamTransformStep {
+            result: TransformResult::PassThrough(chunk_bytes),
+            source_format,
+            source_is_native_stream,
+            universal,
+            event_type,
+            is_passthrough: true,
+        });
+    }
+
     let universal = match detection.kind {
         DetectKind::Stream => source_adapter.stream_to_universal(chunk)?,
         DetectKind::Response => {
@@ -580,17 +593,6 @@ pub(crate) fn transform_stream_chunk_step(
             unreachable!("stream detection never falls back to request payloads")
         }
     };
-
-    if source_format == target_format && matches!(detection.kind, DetectKind::Stream) {
-        return Ok(StreamTransformStep {
-            result: TransformResult::PassThrough(chunk_bytes),
-            source_format,
-            source_is_native_stream,
-            universal,
-            event_type,
-            is_passthrough: true,
-        });
-    }
 
     let target_adapter = adapter_for_format(target_format)
         .ok_or(TransformError::UnsupportedTargetFormat(target_format))?;
@@ -1534,6 +1536,45 @@ mod tests {
                 .and_then(Value::as_str),
             Some("Hello from Vertex")
         );
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
+    fn test_transform_stream_chunk_passthrough_responses_error_event() {
+        let payload = json!({
+            "type": "error",
+            "code": "invalid_tool_arguments",
+            "message": "bad request",
+            "param": null,
+            "sequence_number": 1
+        });
+        let input = to_bytes(&payload);
+        let input_ptr = input.as_ptr();
+
+        let result = transform_stream_chunk(input, ProviderFormat::Responses).unwrap();
+
+        assert!(result.is_passthrough());
+        assert_eq!(result.into_bytes().as_ptr(), input_ptr);
+    }
+
+    #[test]
+    #[cfg(feature = "anthropic")]
+    fn test_transform_stream_chunk_passthrough_anthropic_error_event() {
+        let payload = json!({
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "bad request"
+            },
+            "request_id": null
+        });
+        let input = to_bytes(&payload);
+        let input_ptr = input.as_ptr();
+
+        let result = transform_stream_chunk(input, ProviderFormat::Anthropic).unwrap();
+
+        assert!(result.is_passthrough());
+        assert_eq!(result.into_bytes().as_ptr(), input_ptr);
     }
 
     #[test]

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -50,6 +50,37 @@ pub const DEFAULT_MAX_TOKENS: i64 = 4096;
 const JSON_OBJECT_SHIM_TOOL_NAME: &str = "json";
 const JSON_OBJECT_SHIM_TOOL_DESCRIPTION: &str = "Output the result in JSON format";
 
+#[derive(Debug, Clone, Deserialize)]
+struct AnthropicStreamErrorEvent {
+    error: Option<AnthropicStreamError>,
+}
+
+impl AnthropicStreamErrorEvent {
+    fn display_message(self) -> String {
+        self.error
+            .and_then(AnthropicStreamError::display_message)
+            .unwrap_or_else(|| "unknown stream error".to_string())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AnthropicStreamError {
+    message: Option<String>,
+    #[serde(rename = "type")]
+    error_type: Option<String>,
+}
+
+impl AnthropicStreamError {
+    fn display_message(self) -> Option<String> {
+        match (self.message, self.error_type) {
+            (Some(message), Some(error_type)) => Some(format!("{message} ({error_type})")),
+            (Some(message), None) => Some(message),
+            (None, Some(error_type)) => Some(error_type),
+            (None, None) => None,
+        }
+    }
+}
+
 fn parse_anthropic_extras(
     extras: Option<&Map<String, Value>>,
 ) -> Result<AnthropicExtrasView, TransformError> {
@@ -733,6 +764,7 @@ impl ProviderAdapter for AnthropicAdapter {
                     | "message_delta"
                     | "message_stop"
                     | "ping"
+                    | "error"
             )
         } else {
             false
@@ -749,6 +781,16 @@ impl ProviderAdapter for AnthropicAdapter {
             .ok_or_else(|| TransformError::ToUniversalFailed("missing type field".to_string()))?;
 
         match event_type {
+            "error" => {
+                let event = serde_json::from_value::<AnthropicStreamErrorEvent>(payload.clone())
+                    .map_err(|error| {
+                        TransformError::DeserializationFailed(format!(
+                            "Anthropic stream error event: {error}"
+                        ))
+                    })?;
+                Err(TransformError::ToUniversalFailed(event.display_message()))
+            }
+
             "content_block_delta" => {
                 let delta = payload.get("delta");
                 let delta_type = delta.and_then(|d| d.get("type")).and_then(Value::as_str);
@@ -2287,6 +2329,25 @@ mod tests {
         let delta = choice.delta_view().expect("delta must exist");
         let first = delta.reasoning.first().expect("reasoning item must exist");
         assert_eq!(first.content.as_deref(), Some("initial thought"),);
+    }
+
+    #[test]
+    fn test_stream_to_universal_error_event() {
+        let adapter = AnthropicAdapter;
+        let error = adapter
+            .stream_to_universal(json!({
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "bad request"
+                }
+            }))
+            .expect_err("error event should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "Conversion to universal format failed: bad request (invalid_request_error)"
+        );
     }
 
     #[test]

--- a/crates/lingua/src/providers/anthropic/adapter.rs
+++ b/crates/lingua/src/providers/anthropic/adapter.rs
@@ -23,8 +23,8 @@ use crate::providers::anthropic::detect::{
     system_messages_are_supported_and_well_placed, try_parse_anthropic_source,
 };
 use crate::providers::anthropic::generated::{
-    ContentBlock, EffortLevel, OutputConfig, Thinking, ThinkingType, Tool, ToolChoice,
-    ToolChoiceType,
+    ContentBlock, EffortLevel, ErrorResponse, ErrorType, OutputConfig, Thinking, ThinkingType,
+    Tool, ToolChoice, ToolChoiceType,
 };
 use crate::providers::anthropic::params::{AnthropicExtrasView, AnthropicParams};
 use crate::providers::anthropic::try_parse_anthropic;
@@ -50,35 +50,18 @@ pub const DEFAULT_MAX_TOKENS: i64 = 4096;
 const JSON_OBJECT_SHIM_TOOL_NAME: &str = "json";
 const JSON_OBJECT_SHIM_TOOL_DESCRIPTION: &str = "Output the result in JSON format";
 
-#[derive(Debug, Clone, Deserialize)]
-struct AnthropicStreamErrorEvent {
-    error: Option<AnthropicStreamError>,
+fn anthropic_stream_error_message(event: ErrorResponse) -> String {
+    format!(
+        "{} ({})",
+        event.error.message,
+        anthropic_error_type_message(event.error.error_type)
+    )
 }
 
-impl AnthropicStreamErrorEvent {
-    fn display_message(self) -> String {
-        self.error
-            .and_then(AnthropicStreamError::display_message)
-            .unwrap_or_else(|| "unknown stream error".to_string())
-    }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct AnthropicStreamError {
-    message: Option<String>,
-    #[serde(rename = "type")]
-    error_type: Option<String>,
-}
-
-impl AnthropicStreamError {
-    fn display_message(self) -> Option<String> {
-        match (self.message, self.error_type) {
-            (Some(message), Some(error_type)) => Some(format!("{message} ({error_type})")),
-            (Some(message), None) => Some(message),
-            (None, Some(error_type)) => Some(error_type),
-            (None, None) => None,
-        }
-    }
+fn anthropic_error_type_message(error_type: ErrorType) -> String {
+    serde_json::to_string(&error_type)
+        .map(|serialized| serialized.trim_matches('"').to_string())
+        .unwrap_or_else(|_| format!("{error_type:?}"))
 }
 
 fn parse_anthropic_extras(
@@ -782,13 +765,15 @@ impl ProviderAdapter for AnthropicAdapter {
 
         match event_type {
             "error" => {
-                let event = serde_json::from_value::<AnthropicStreamErrorEvent>(payload.clone())
-                    .map_err(|error| {
+                let event =
+                    serde_json::from_value::<ErrorResponse>(payload.clone()).map_err(|error| {
                         TransformError::DeserializationFailed(format!(
                             "Anthropic stream error event: {error}"
                         ))
                     })?;
-                Err(TransformError::ToUniversalFailed(event.display_message()))
+                Err(TransformError::ToUniversalFailed(
+                    anthropic_stream_error_message(event),
+                ))
             }
 
             "content_block_delta" => {

--- a/crates/lingua/src/providers/anthropic/generated.rs
+++ b/crates/lingua/src/providers/anthropic/generated.rs
@@ -27,7 +27,60 @@ pub struct AnthropicSchemas {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request: Option<CreateMessageParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_response: Option<ErrorResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub response: Option<Message>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_event: Option<MessageStreamEvent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[ts(export_to = "anthropic/")]
+pub struct ErrorResponse {
+    pub error: Error,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(rename = "type")]
+    pub error_response_type: ErrorResponseType,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[ts(export_to = "anthropic/")]
+pub struct Error {
+    pub message: String,
+    #[serde(rename = "type")]
+    pub error_type: ErrorType,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(export_to = "anthropic/")]
+pub enum ErrorType {
+    #[serde(rename = "api_error")]
+    ApiError,
+    #[serde(rename = "authentication_error")]
+    AuthenticationError,
+    #[serde(rename = "billing_error")]
+    BillingError,
+    #[serde(rename = "invalid_request_error")]
+    InvalidRequestError,
+    #[serde(rename = "not_found_error")]
+    NotFoundError,
+    #[serde(rename = "overloaded_error")]
+    OverloadedError,
+    #[serde(rename = "permission_error")]
+    PermissionError,
+    #[serde(rename = "rate_limit_error")]
+    RateLimitError,
+    #[serde(rename = "timeout_error")]
+    TimeoutError,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(export_to = "anthropic/")]
+pub enum ErrorResponseType {
+    Error,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
@@ -304,7 +357,7 @@ pub enum Ttl {
 #[ts(export, export_to = "anthropic/")]
 pub struct InputMessage {
     pub content: MessageContent,
-    pub role: MessageRole,
+    pub role: PurpleRole,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
@@ -961,7 +1014,7 @@ pub enum InputContentBlockType {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 #[ts(export_to = "anthropic/")]
-pub enum MessageRole {
+pub enum PurpleRole {
     Assistant,
     System,
     User,
@@ -1805,7 +1858,7 @@ pub struct ContentBlock {
     /// PDF results in `page_location`, plain text results in `char_location`, and content
     /// document results in `content_block_location`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub citations: Option<Vec<ResponseLocationCitation>>,
+    pub citations: Option<Vec<Citation>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     #[serde(rename = "type")]
@@ -1835,7 +1888,7 @@ pub struct ContentBlock {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[ts(export_to = "anthropic/")]
-pub struct ResponseLocationCitation {
+pub struct Citation {
     /// The full text of the cited block range, concatenated.
     ///
     /// Always equals the contents of `content[start_block_index:end_block_index]` joined
@@ -1854,7 +1907,7 @@ pub struct ResponseLocationCitation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_char_index: Option<i64>,
     #[serde(rename = "type")]
-    pub response_location_citation_type: CitationType,
+    pub citation_type: CitationType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_page_number: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2214,3 +2267,147 @@ pub enum ServiceTierServiceTier {
     Priority,
     Standard,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[ts(export_to = "anthropic/")]
+pub struct MessageStreamEvent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<Message>,
+    #[serde(rename = "type")]
+    pub message_stream_event_type: MessageStreamEventType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta: Option<Delta>,
+    /// Billing and rate-limit usage.
+    ///
+    /// Anthropic's API bills and rate-limits by token counts, as tokens represent the underlying
+    /// cost to our systems.
+    ///
+    /// Under the hood, the API transforms requests into a format suitable for the model. The
+    /// model's output then goes through a parsing stage before becoming an API response. As a
+    /// result, the token counts in `usage` will not match one-to-one with the exact visible
+    /// content of an API request or response.
+    ///
+    /// For example, `output_tokens` will be non-zero, even for an empty string response from
+    /// Claude.
+    ///
+    /// Total input tokens in a request is the summation of `input_tokens`,
+    /// `cache_creation_input_tokens`, and `cache_read_input_tokens`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<MessageDeltaUsage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_block: Option<ContentBlock>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[ts(export_to = "anthropic/")]
+pub struct Delta {
+    /// Information about the container used in this request.
+    ///
+    /// This will be non-null if a container tool (e.g. code execution) was used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container: Option<Container>,
+    /// Structured information about why model output stopped.
+    ///
+    /// This is `null` when the `stop_reason` has no additional detail to report.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_details: Option<RefusalStopDetails>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<StopReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_sequence: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta_type: Option<DeltaType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial_json: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub citation: Option<Citation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(export_to = "anthropic/")]
+pub enum DeltaType {
+    #[serde(rename = "citations_delta")]
+    CitationsDelta,
+    #[serde(rename = "input_json_delta")]
+    InputJsonDelta,
+    #[serde(rename = "signature_delta")]
+    SignatureDelta,
+    #[serde(rename = "text_delta")]
+    TextDelta,
+    #[serde(rename = "thinking_delta")]
+    ThinkingDelta,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(export_to = "anthropic/")]
+pub enum MessageStreamEventType {
+    #[serde(rename = "content_block_delta")]
+    ContentBlockDelta,
+    #[serde(rename = "content_block_start")]
+    ContentBlockStart,
+    #[serde(rename = "content_block_stop")]
+    ContentBlockStop,
+    #[serde(rename = "message_delta")]
+    MessageDelta,
+    #[serde(rename = "message_start")]
+    MessageStart,
+    #[serde(rename = "message_stop")]
+    MessageStop,
+}
+
+/// Billing and rate-limit usage.
+///
+/// Anthropic's API bills and rate-limits by token counts, as tokens represent the underlying
+/// cost to our systems.
+///
+/// Under the hood, the API transforms requests into a format suitable for the model. The
+/// model's output then goes through a parsing stage before becoming an API response. As a
+/// result, the token counts in `usage` will not match one-to-one with the exact visible
+/// content of an API request or response.
+///
+/// For example, `output_tokens` will be non-zero, even for an empty string response from
+/// Claude.
+///
+/// Total input tokens in a request is the summation of `input_tokens`,
+/// `cache_creation_input_tokens`, and `cache_read_input_tokens`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[ts(export_to = "anthropic/")]
+pub struct MessageDeltaUsage {
+    /// The cumulative number of input tokens used to create the cache entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<i64>,
+    /// The cumulative number of input tokens read from the cache.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<i64>,
+    /// The cumulative number of input tokens which were used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<i64>,
+    /// The cumulative number of output tokens which were used.
+    pub output_tokens: i64,
+    /// Breakdown of output tokens by category.
+    ///
+    /// `output_tokens` remains the inclusive, authoritative total used for billing.
+    /// This object provides a read-only decomposition for observability — for example,
+    /// how many of the billed output tokens were spent on internal reasoning that may
+    /// have been summarized before being returned to you.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens_details: Option<OutputTokensDetails>,
+    /// The number of server tool requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_tool_use: Option<ServerToolUsage>,
+}
+
+// Compatibility aliases for names used by Lingua's hand-written adapters.
+pub type MessageRole = PurpleRole;
+pub type ResponseLocationCitation = Citation;

--- a/crates/lingua/src/providers/openai/generated.rs
+++ b/crates/lingua/src/providers/openai/generated.rs
@@ -34,6 +34,8 @@ pub struct OpenaiSchemas {
     pub responses_request: Option<CreateResponseClass>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub responses_response: Option<TheResponseObject>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub responses_stream_response: Option<ResponseStreamEvent>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
@@ -1327,12 +1329,12 @@ pub struct ChatCompletionTokenLogprob {
     pub token: String,
     /// List of the most likely tokens and their log probability, at this token position. The
     /// number of entries may be fewer than the requested `top_logprobs`.
-    pub top_logprobs: Vec<TopLogprob>,
+    pub top_logprobs: Vec<ContentTopLogprob>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[ts(export_to = "openai/")]
-pub struct TopLogprob {
+pub struct ContentTopLogprob {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes: Option<Vec<i64>>,
     /// The log probability of this token, if it is within the top 20 most likely tokens.
@@ -5194,6 +5196,22 @@ pub enum Truncation {
     Disabled,
 }
 
+/// Properties of the completed response.
+///
+///
+/// The response that was created.
+///
+///
+/// The response that is in progress.
+///
+///
+/// The response that failed.
+///
+///
+/// The response that was incomplete.
+///
+///
+/// The full response object that is queued.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[ts(export_to = "openai/")]
 pub struct TheResponseObject {
@@ -5445,6 +5463,12 @@ pub enum TheResponseObjectObject {
     Response,
 }
 
+/// The output item that was added.
+///
+///
+/// The output item that was marked done.
+///
+///
 /// An output message from the model.
 ///
 ///
@@ -6670,6 +6694,908 @@ pub struct InputTokensDetails {
 pub struct OutputTokensDetails {
     /// The number of reasoning tokens.
     pub reasoning_tokens: i64,
+}
+
+/// Emitted when there is a partial audio response.
+///
+/// Emitted when the audio response is complete.
+///
+/// Emitted when there is a partial transcript of audio.
+///
+/// Emitted when the full audio transcript is completed.
+///
+/// Emitted when a partial code snippet is streamed by the code interpreter.
+///
+/// Emitted when the code snippet is finalized by the code interpreter.
+///
+/// Emitted when the code interpreter call is completed.
+///
+/// Emitted when a code interpreter call is in progress.
+///
+/// Emitted when the code interpreter is actively interpreting the code snippet.
+///
+/// Emitted when the model response is complete.
+///
+/// Emitted when a new content part is added.
+///
+/// Emitted when a content part is done.
+///
+/// An event that is emitted when a response is created.
+///
+///
+/// Emitted when an error occurs.
+///
+/// Emitted when a file search call is completed (results found).
+///
+/// Emitted when a file search call is initiated.
+///
+/// Emitted when a file search is currently searching.
+///
+/// Emitted when there is a partial function-call arguments delta.
+///
+/// Emitted when function-call arguments are finalized.
+///
+/// Emitted when the response is in progress.
+///
+/// An event that is emitted when a response fails.
+///
+///
+/// An event that is emitted when a response finishes as incomplete.
+///
+///
+/// Emitted when a new output item is added.
+///
+/// Emitted when an output item is marked done.
+///
+/// Emitted when a new reasoning summary part is added.
+///
+/// Emitted when a reasoning summary part is completed.
+///
+/// Emitted when a delta is added to a reasoning summary text.
+///
+/// Emitted when a reasoning summary text is completed.
+///
+/// Emitted when a delta is added to a reasoning text.
+///
+/// Emitted when a reasoning text is completed.
+///
+/// Emitted when there is a partial refusal text.
+///
+/// Emitted when refusal text is finalized.
+///
+/// Emitted when there is an additional text delta.
+///
+/// Emitted when text content is finalized.
+///
+/// Emitted when a web search call is completed.
+///
+/// Emitted when a web search call is initiated.
+///
+/// Emitted when a web search call is executing.
+///
+/// Emitted when an image generation tool call has completed and the final image is
+/// available.
+///
+///
+/// Emitted when an image generation tool call is actively generating an image (intermediate
+/// state).
+///
+///
+/// Emitted when an image generation tool call is in progress.
+///
+///
+/// Emitted when a partial image is available during image generation streaming.
+///
+///
+/// Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
+///
+///
+/// Emitted when the arguments for an MCP tool call are finalized.
+///
+///
+/// Emitted when an MCP  tool call has completed successfully.
+///
+///
+/// Emitted when an MCP  tool call has failed.
+///
+///
+/// Emitted when an MCP  tool call is in progress.
+///
+///
+/// Emitted when the list of available MCP tools has been successfully retrieved.
+///
+///
+/// Emitted when the attempt to list available MCP tools has failed.
+///
+///
+/// Emitted when the system is in the process of retrieving the list of available MCP
+/// tools.
+///
+///
+/// Emitted when an annotation is added to output text content.
+///
+///
+/// Emitted when a response is queued and waiting to be processed.
+///
+///
+/// Event representing a delta (partial update) to the input of a custom tool call.
+///
+///
+/// Event indicating that input for a custom tool call is complete.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[ts(export_to = "openai/")]
+pub struct ResponseStreamEvent {
+    /// A chunk of Base64 encoded response audio bytes.
+    ///
+    ///
+    /// The partial transcript of the audio response.
+    ///
+    ///
+    /// The partial code snippet being streamed by the code interpreter.
+    ///
+    /// The function-call arguments delta that is added.
+    ///
+    ///
+    /// The text delta that was added to the summary.
+    ///
+    ///
+    /// The text delta that was added to the reasoning content.
+    ///
+    ///
+    /// The refusal text that is added.
+    ///
+    ///
+    /// The text delta that was added.
+    ///
+    ///
+    /// A JSON string containing the partial update to the arguments for the MCP tool call.
+    ///
+    ///
+    /// The incremental input data (delta) for the custom tool call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta: Option<String>,
+    /// A sequence number for this chunk of the stream response.
+    ///
+    ///
+    /// The sequence number of the delta.
+    ///
+    ///
+    /// The sequence number of this event.
+    ///
+    /// The sequence number of this event, used to order streaming events.
+    ///
+    /// The sequence number for this event.
+    ///
+    /// The sequence number of this event.
+    ///
+    ///
+    /// The sequence number of the web search call being processed.
+    ///
+    /// The sequence number of the image generation item being processed.
+    pub sequence_number: i64,
+    /// The type of the event. Always `response.audio.delta`.
+    ///
+    ///
+    /// The type of the event. Always `response.audio.done`.
+    ///
+    ///
+    /// The type of the event. Always `response.audio.transcript.delta`.
+    ///
+    ///
+    /// The type of the event. Always `response.audio.transcript.done`.
+    ///
+    ///
+    /// The type of the event. Always `response.code_interpreter_call_code.delta`.
+    ///
+    /// The type of the event. Always `response.code_interpreter_call_code.done`.
+    ///
+    /// The type of the event. Always `response.code_interpreter_call.completed`.
+    ///
+    /// The type of the event. Always `response.code_interpreter_call.in_progress`.
+    ///
+    /// The type of the event. Always `response.code_interpreter_call.interpreting`.
+    ///
+    /// The type of the event. Always `response.completed`.
+    ///
+    ///
+    /// The type of the event. Always `response.content_part.added`.
+    ///
+    ///
+    /// The type of the event. Always `response.content_part.done`.
+    ///
+    ///
+    /// The type of the event. Always `response.created`.
+    ///
+    ///
+    /// The type of the event. Always `error`.
+    ///
+    ///
+    /// The type of the event. Always `response.file_search_call.completed`.
+    ///
+    ///
+    /// The type of the event. Always `response.file_search_call.in_progress`.
+    ///
+    ///
+    /// The type of the event. Always `response.file_search_call.searching`.
+    ///
+    ///
+    /// The type of the event. Always `response.function_call_arguments.delta`.
+    ///
+    ///
+    /// The type of the event. Always `response.in_progress`.
+    ///
+    ///
+    /// The type of the event. Always `response.failed`.
+    ///
+    ///
+    /// The type of the event. Always `response.incomplete`.
+    ///
+    ///
+    /// The type of the event. Always `response.output_item.added`.
+    ///
+    ///
+    /// The type of the event. Always `response.output_item.done`.
+    ///
+    ///
+    /// The type of the event. Always `response.reasoning_summary_part.added`.
+    ///
+    ///
+    /// The type of the event. Always `response.reasoning_summary_part.done`.
+    ///
+    ///
+    /// The type of the event. Always `response.reasoning_summary_text.delta`.
+    ///
+    ///
+    /// The type of the event. Always `response.reasoning_summary_text.done`.
+    ///
+    ///
+    /// The type of the event. Always `response.reasoning_text.delta`.
+    ///
+    ///
+    /// The type of the event. Always `response.reasoning_text.done`.
+    ///
+    ///
+    /// The type of the event. Always `response.refusal.delta`.
+    ///
+    ///
+    /// The type of the event. Always `response.refusal.done`.
+    ///
+    ///
+    /// The type of the event. Always `response.output_text.delta`.
+    ///
+    ///
+    /// The type of the event. Always `response.output_text.done`.
+    ///
+    ///
+    /// The type of the event. Always `response.web_search_call.completed`.
+    ///
+    ///
+    /// The type of the event. Always `response.web_search_call.in_progress`.
+    ///
+    ///
+    /// The type of the event. Always `response.web_search_call.searching`.
+    ///
+    ///
+    /// The type of the event. Always 'response.image_generation_call.completed'.
+    ///
+    /// The type of the event. Always 'response.image_generation_call.generating'.
+    ///
+    /// The type of the event. Always 'response.image_generation_call.in_progress'.
+    ///
+    /// The type of the event. Always 'response.image_generation_call.partial_image'.
+    ///
+    /// The type of the event. Always 'response.mcp_call_arguments.delta'.
+    ///
+    /// The type of the event. Always 'response.mcp_call_arguments.done'.
+    ///
+    /// The type of the event. Always 'response.mcp_call.completed'.
+    ///
+    /// The type of the event. Always 'response.mcp_call.failed'.
+    ///
+    /// The type of the event. Always 'response.mcp_call.in_progress'.
+    ///
+    /// The type of the event. Always 'response.mcp_list_tools.completed'.
+    ///
+    /// The type of the event. Always 'response.mcp_list_tools.failed'.
+    ///
+    /// The type of the event. Always 'response.mcp_list_tools.in_progress'.
+    ///
+    /// The type of the event. Always 'response.output_text.annotation.added'.
+    ///
+    /// The type of the event. Always 'response.queued'.
+    ///
+    /// The event type identifier.
+    #[serde(rename = "type")]
+    pub response_stream_event_type: ResponseStreamEventType,
+    #[ts(type = "unknown")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_id: Option<serde_json::Value>,
+    /// The unique identifier of the code interpreter tool call item.
+    ///
+    /// The ID of the output item that the content part was added to.
+    ///
+    ///
+    /// The ID of the output item that the file search call is initiated.
+    ///
+    ///
+    /// The ID of the output item that the function-call arguments delta is added to.
+    ///
+    ///
+    /// The ID of the item.
+    ///
+    /// The ID of the item this summary part is associated with.
+    ///
+    ///
+    /// The ID of the item this summary text delta is associated with.
+    ///
+    ///
+    /// The ID of the item this summary text is associated with.
+    ///
+    ///
+    /// The ID of the item this reasoning text delta is associated with.
+    ///
+    ///
+    /// The ID of the item this reasoning text is associated with.
+    ///
+    ///
+    /// The ID of the output item that the refusal text is added to.
+    ///
+    ///
+    /// The ID of the output item that the refusal text is finalized.
+    ///
+    ///
+    /// The ID of the output item that the text delta was added to.
+    ///
+    ///
+    /// The ID of the output item that the text content is finalized.
+    ///
+    ///
+    /// Unique ID for the output item associated with the web search call.
+    ///
+    ///
+    /// The unique identifier of the image generation item being processed.
+    ///
+    /// The unique identifier of the MCP tool call item being processed.
+    ///
+    /// The ID of the MCP tool call item that completed.
+    ///
+    /// The ID of the MCP tool call item that failed.
+    ///
+    /// The ID of the MCP tool call item that produced this output.
+    ///
+    /// The ID of the MCP tool call item that is being processed.
+    ///
+    /// The unique identifier of the item to which the annotation is being added.
+    ///
+    /// Unique identifier for the API item associated with this event.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_id: Option<String>,
+    /// The index of the output item in the response for which the code is being streamed.
+    ///
+    /// The index of the output item in the response for which the code is finalized.
+    ///
+    /// The index of the output item in the response for which the code interpreter call is
+    /// completed.
+    ///
+    /// The index of the output item in the response for which the code interpreter call is in
+    /// progress.
+    ///
+    /// The index of the output item in the response for which the code interpreter is
+    /// interpreting code.
+    ///
+    /// The index of the output item that the content part was added to.
+    ///
+    ///
+    /// The index of the output item that the file search call is initiated.
+    ///
+    ///
+    /// The index of the output item that the file search call is searching.
+    ///
+    ///
+    /// The index of the output item that the function-call arguments delta is added to.
+    ///
+    ///
+    /// The index of the output item.
+    ///
+    /// The index of the output item that was added.
+    ///
+    ///
+    /// The index of the output item that was marked done.
+    ///
+    ///
+    /// The index of the output item this summary part is associated with.
+    ///
+    ///
+    /// The index of the output item this summary text delta is associated with.
+    ///
+    ///
+    /// The index of the output item this summary text is associated with.
+    ///
+    ///
+    /// The index of the output item this reasoning text delta is associated with.
+    ///
+    ///
+    /// The index of the output item this reasoning text is associated with.
+    ///
+    ///
+    /// The index of the output item that the refusal text is added to.
+    ///
+    ///
+    /// The index of the output item that the refusal text is finalized.
+    ///
+    ///
+    /// The index of the output item that the text delta was added to.
+    ///
+    ///
+    /// The index of the output item that the text content is finalized.
+    ///
+    ///
+    /// The index of the output item that the web search call is associated with.
+    ///
+    ///
+    /// The index of the output item in the response's output array.
+    ///
+    /// The index of the output item that completed.
+    ///
+    /// The index of the output item that failed.
+    ///
+    /// The index of the output item that was processed.
+    ///
+    /// The index of the output item that is being processed.
+    ///
+    /// The index of the output this delta applies to.
+    ///
+    /// The index of the output this event applies to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_index: Option<i64>,
+    /// The final code snippet output by the code interpreter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    /// Properties of the completed response.
+    ///
+    ///
+    /// The response that was created.
+    ///
+    ///
+    /// The response that is in progress.
+    ///
+    ///
+    /// The response that failed.
+    ///
+    ///
+    /// The response that was incomplete.
+    ///
+    ///
+    /// The full response object that is queued.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response: Option<TheResponseObject>,
+    /// The index of the content part that was added.
+    ///
+    ///
+    /// The index of the content part that is done.
+    ///
+    ///
+    /// The index of the reasoning content part this delta is associated with.
+    ///
+    ///
+    /// The index of the reasoning content part.
+    ///
+    ///
+    /// The index of the content part that the refusal text is added to.
+    ///
+    ///
+    /// The index of the content part that the refusal text is finalized.
+    ///
+    ///
+    /// The index of the content part that the text delta was added to.
+    ///
+    ///
+    /// The index of the content part that the text content is finalized.
+    ///
+    ///
+    /// The index of the content part within the output item.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_index: Option<i64>,
+    /// The content part that was added.
+    ///
+    ///
+    /// The content part that is done.
+    ///
+    ///
+    /// The summary part that was added.
+    ///
+    ///
+    /// The completed summary part.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub part: Option<OutputContent>,
+    /// The error message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub param: Option<String>,
+    /// The function-call arguments.
+    ///
+    /// A JSON string containing the finalized arguments for the MCP tool call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<String>,
+    /// The name of the function that was called.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The output item that was added.
+    ///
+    ///
+    /// The output item that was marked done.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item: Option<OutputItem>,
+    /// The index of the summary part within the reasoning summary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary_index: Option<i64>,
+    /// The full text of the completed reasoning summary.
+    ///
+    ///
+    /// The full text of the completed reasoning content.
+    ///
+    ///
+    /// The text content that is finalized.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// The refusal text that is finalized.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refusal: Option<String>,
+    /// The log probabilities of the tokens in the delta.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<Vec<ResponseLogProb>>,
+    /// Base64-encoded partial image data, suitable for rendering as an image.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial_image_b64: Option<String>,
+    /// 0-based index for the partial image (backend is 1-based, but this is 0-based for the
+    /// user).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial_image_index: Option<i64>,
+    /// The annotation object being added. (See annotation schema for details.)
+    #[ts(type = "unknown")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotation: Option<serde_json::Map<String, serde_json::Value>>,
+    /// The index of the annotation within the content part.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotation_index: Option<i64>,
+    /// The complete input data for the custom tool call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<String>,
+}
+
+/// A logprob is the logarithmic probability that the model assigns to producing
+/// a particular token at a given position in the sequence. Less-negative (higher)
+/// logprob values indicate greater model confidence in that token choice.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[ts(export_to = "openai/")]
+pub struct ResponseLogProb {
+    /// The log probability of this token.
+    pub logprob: f64,
+    /// A possible text token.
+    pub token: String,
+    /// The log probabilities of up to 20 of the most likely tokens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_logprobs: Option<Vec<LogprobTopLogprob>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[ts(export_to = "openai/")]
+pub struct LogprobTopLogprob {
+    /// The log probability of this token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprob: Option<f64>,
+    /// A possible text token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+}
+
+/// The content part that was added.
+///
+///
+/// The content part that is done.
+///
+///
+/// A text output from the model.
+///
+/// A refusal from the model.
+///
+/// Reasoning text from the model.
+///
+/// The summary part that was added.
+///
+///
+/// The completed summary part.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[ts(export_to = "openai/")]
+pub struct OutputContent {
+    /// The annotations of the text output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<Vec<Annotation>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<Vec<LogProbability>>,
+    /// The text output from the model.
+    ///
+    /// The reasoning text from the model.
+    ///
+    /// The text of the summary part.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// The type of the output text. Always `output_text`.
+    ///
+    /// The type of the refusal. Always `refusal`.
+    ///
+    /// The type of the reasoning text. Always `reasoning_text`.
+    ///
+    /// The type of the summary part. Always `summary_text`.
+    #[serde(rename = "type")]
+    pub output_content_type: PartType,
+    /// The refusal explanation from the model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refusal: Option<String>,
+}
+
+/// The type of the output text. Always `output_text`.
+///
+/// The type of the refusal. Always `refusal`.
+///
+/// The type of the reasoning text. Always `reasoning_text`.
+///
+/// The type of the summary part. Always `summary_text`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(export_to = "openai/")]
+pub enum PartType {
+    #[serde(rename = "output_text")]
+    OutputText,
+    #[serde(rename = "reasoning_text")]
+    ReasoningText,
+    Refusal,
+    #[serde(rename = "summary_text")]
+    SummaryText,
+}
+
+/// The type of the event. Always `response.audio.delta`.
+///
+///
+/// The type of the event. Always `response.audio.done`.
+///
+///
+/// The type of the event. Always `response.audio.transcript.delta`.
+///
+///
+/// The type of the event. Always `response.audio.transcript.done`.
+///
+///
+/// The type of the event. Always `response.code_interpreter_call_code.delta`.
+///
+/// The type of the event. Always `response.code_interpreter_call_code.done`.
+///
+/// The type of the event. Always `response.code_interpreter_call.completed`.
+///
+/// The type of the event. Always `response.code_interpreter_call.in_progress`.
+///
+/// The type of the event. Always `response.code_interpreter_call.interpreting`.
+///
+/// The type of the event. Always `response.completed`.
+///
+///
+/// The type of the event. Always `response.content_part.added`.
+///
+///
+/// The type of the event. Always `response.content_part.done`.
+///
+///
+/// The type of the event. Always `response.created`.
+///
+///
+/// The type of the event. Always `error`.
+///
+///
+/// The type of the event. Always `response.file_search_call.completed`.
+///
+///
+/// The type of the event. Always `response.file_search_call.in_progress`.
+///
+///
+/// The type of the event. Always `response.file_search_call.searching`.
+///
+///
+/// The type of the event. Always `response.function_call_arguments.delta`.
+///
+///
+/// The type of the event. Always `response.in_progress`.
+///
+///
+/// The type of the event. Always `response.failed`.
+///
+///
+/// The type of the event. Always `response.incomplete`.
+///
+///
+/// The type of the event. Always `response.output_item.added`.
+///
+///
+/// The type of the event. Always `response.output_item.done`.
+///
+///
+/// The type of the event. Always `response.reasoning_summary_part.added`.
+///
+///
+/// The type of the event. Always `response.reasoning_summary_part.done`.
+///
+///
+/// The type of the event. Always `response.reasoning_summary_text.delta`.
+///
+///
+/// The type of the event. Always `response.reasoning_summary_text.done`.
+///
+///
+/// The type of the event. Always `response.reasoning_text.delta`.
+///
+///
+/// The type of the event. Always `response.reasoning_text.done`.
+///
+///
+/// The type of the event. Always `response.refusal.delta`.
+///
+///
+/// The type of the event. Always `response.refusal.done`.
+///
+///
+/// The type of the event. Always `response.output_text.delta`.
+///
+///
+/// The type of the event. Always `response.output_text.done`.
+///
+///
+/// The type of the event. Always `response.web_search_call.completed`.
+///
+///
+/// The type of the event. Always `response.web_search_call.in_progress`.
+///
+///
+/// The type of the event. Always `response.web_search_call.searching`.
+///
+///
+/// The type of the event. Always 'response.image_generation_call.completed'.
+///
+/// The type of the event. Always 'response.image_generation_call.generating'.
+///
+/// The type of the event. Always 'response.image_generation_call.in_progress'.
+///
+/// The type of the event. Always 'response.image_generation_call.partial_image'.
+///
+/// The type of the event. Always 'response.mcp_call_arguments.delta'.
+///
+/// The type of the event. Always 'response.mcp_call_arguments.done'.
+///
+/// The type of the event. Always 'response.mcp_call.completed'.
+///
+/// The type of the event. Always 'response.mcp_call.failed'.
+///
+/// The type of the event. Always 'response.mcp_call.in_progress'.
+///
+/// The type of the event. Always 'response.mcp_list_tools.completed'.
+///
+/// The type of the event. Always 'response.mcp_list_tools.failed'.
+///
+/// The type of the event. Always 'response.mcp_list_tools.in_progress'.
+///
+/// The type of the event. Always 'response.output_text.annotation.added'.
+///
+/// The type of the event. Always 'response.queued'.
+///
+/// The event type identifier.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(export_to = "openai/")]
+pub enum ResponseStreamEventType {
+    Error,
+    #[serde(rename = "response.audio.delta")]
+    ResponseAudioDelta,
+    #[serde(rename = "response.audio.done")]
+    ResponseAudioDone,
+    #[serde(rename = "response.audio.transcript.delta")]
+    ResponseAudioTranscriptDelta,
+    #[serde(rename = "response.audio.transcript.done")]
+    ResponseAudioTranscriptDone,
+    #[serde(rename = "response.code_interpreter_call_code.delta")]
+    ResponseCodeInterpreterCallCodeDelta,
+    #[serde(rename = "response.code_interpreter_call_code.done")]
+    ResponseCodeInterpreterCallCodeDone,
+    #[serde(rename = "response.code_interpreter_call.completed")]
+    ResponseCodeInterpreterCallCompleted,
+    #[serde(rename = "response.code_interpreter_call.in_progress")]
+    ResponseCodeInterpreterCallInProgress,
+    #[serde(rename = "response.code_interpreter_call.interpreting")]
+    ResponseCodeInterpreterCallInterpreting,
+    #[serde(rename = "response.completed")]
+    ResponseCompleted,
+    #[serde(rename = "response.content_part.added")]
+    ResponseContentPartAdded,
+    #[serde(rename = "response.content_part.done")]
+    ResponseContentPartDone,
+    #[serde(rename = "response.created")]
+    ResponseCreated,
+    #[serde(rename = "response.custom_tool_call_input.delta")]
+    ResponseCustomToolCallInputDelta,
+    #[serde(rename = "response.custom_tool_call_input.done")]
+    ResponseCustomToolCallInputDone,
+    #[serde(rename = "response.failed")]
+    ResponseFailed,
+    #[serde(rename = "response.file_search_call.completed")]
+    ResponseFileSearchCallCompleted,
+    #[serde(rename = "response.file_search_call.in_progress")]
+    ResponseFileSearchCallInProgress,
+    #[serde(rename = "response.file_search_call.searching")]
+    ResponseFileSearchCallSearching,
+    #[serde(rename = "response.function_call_arguments.delta")]
+    ResponseFunctionCallArgumentsDelta,
+    #[serde(rename = "response.function_call_arguments.done")]
+    ResponseFunctionCallArgumentsDone,
+    #[serde(rename = "response.image_generation_call.completed")]
+    ResponseImageGenerationCallCompleted,
+    #[serde(rename = "response.image_generation_call.generating")]
+    ResponseImageGenerationCallGenerating,
+    #[serde(rename = "response.image_generation_call.in_progress")]
+    ResponseImageGenerationCallInProgress,
+    #[serde(rename = "response.image_generation_call.partial_image")]
+    ResponseImageGenerationCallPartialImage,
+    #[serde(rename = "response.in_progress")]
+    ResponseInProgress,
+    #[serde(rename = "response.incomplete")]
+    ResponseIncomplete,
+    #[serde(rename = "response.mcp_call_arguments.delta")]
+    ResponseMcpCallArgumentsDelta,
+    #[serde(rename = "response.mcp_call_arguments.done")]
+    ResponseMcpCallArgumentsDone,
+    #[serde(rename = "response.mcp_call.completed")]
+    ResponseMcpCallCompleted,
+    #[serde(rename = "response.mcp_call.failed")]
+    ResponseMcpCallFailed,
+    #[serde(rename = "response.mcp_call.in_progress")]
+    ResponseMcpCallInProgress,
+    #[serde(rename = "response.mcp_list_tools.completed")]
+    ResponseMcpListToolsCompleted,
+    #[serde(rename = "response.mcp_list_tools.failed")]
+    ResponseMcpListToolsFailed,
+    #[serde(rename = "response.mcp_list_tools.in_progress")]
+    ResponseMcpListToolsInProgress,
+    #[serde(rename = "response.output_item.added")]
+    ResponseOutputItemAdded,
+    #[serde(rename = "response.output_item.done")]
+    ResponseOutputItemDone,
+    #[serde(rename = "response.output_text.annotation.added")]
+    ResponseOutputTextAnnotationAdded,
+    #[serde(rename = "response.output_text.delta")]
+    ResponseOutputTextDelta,
+    #[serde(rename = "response.output_text.done")]
+    ResponseOutputTextDone,
+    #[serde(rename = "response.queued")]
+    ResponseQueued,
+    #[serde(rename = "response.reasoning_summary_part.added")]
+    ResponseReasoningSummaryPartAdded,
+    #[serde(rename = "response.reasoning_summary_part.done")]
+    ResponseReasoningSummaryPartDone,
+    #[serde(rename = "response.reasoning_summary_text.delta")]
+    ResponseReasoningSummaryTextDelta,
+    #[serde(rename = "response.reasoning_summary_text.done")]
+    ResponseReasoningSummaryTextDone,
+    #[serde(rename = "response.reasoning_text.delta")]
+    ResponseReasoningTextDelta,
+    #[serde(rename = "response.reasoning_text.done")]
+    ResponseReasoningTextDone,
+    #[serde(rename = "response.refusal.delta")]
+    ResponseRefusalDelta,
+    #[serde(rename = "response.refusal.done")]
+    ResponseRefusalDone,
+    #[serde(rename = "response.web_search_call.completed")]
+    ResponseWebSearchCallCompleted,
+    #[serde(rename = "response.web_search_call.in_progress")]
+    ResponseWebSearchCallInProgress,
+    #[serde(rename = "response.web_search_call.searching")]
+    ResponseWebSearchCallSearching,
 }
 
 // Compatibility aliases for names used by Lingua's hand-written adapters.

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -78,6 +78,15 @@ fn response_error_code_message(code: ResponseErrorCode) -> String {
         .unwrap_or_else(|_| format!("{code:?}"))
 }
 
+fn is_responses_stream_error_event(payload: &Value) -> bool {
+    serde_json::from_value::<ResponseStreamEvent>(payload.clone()).is_ok_and(|event| {
+        matches!(
+            event.response_stream_event_type,
+            ResponseStreamEventType::Error
+        )
+    })
+}
+
 fn system_text(message: &Message) -> Option<&str> {
     match message {
         Message::System { content } => match content {
@@ -804,7 +813,11 @@ impl ProviderAdapter for ResponsesAdapter {
         payload
             .get("type")
             .and_then(Value::as_str)
-            .is_some_and(|t| t.starts_with("response.") || t == "keepalive" || t == "error")
+            .is_some_and(|t| {
+                t.starts_with("response.")
+                    || t == "keepalive"
+                    || (t == "error" && is_responses_stream_error_event(payload))
+            })
             || payload
                 .get("object")
                 .and_then(Value::as_str)
@@ -2039,6 +2052,20 @@ mod tests {
         });
 
         assert!(adapter.detect_stream_response(&payload));
+    }
+
+    #[test]
+    fn test_responses_detect_stream_response_rejects_anthropic_error() {
+        let adapter = ResponsesAdapter;
+        let payload = json!({
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "bad request"
+            }
+        });
+
+        assert!(!adapter.detect_stream_response(&payload));
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -38,6 +38,48 @@ use std::convert::TryInto;
 
 const OPENAI_RESPONSES_MIN_MAX_OUTPUT_TOKENS: i64 = 16;
 
+#[derive(Debug, Clone, Deserialize)]
+struct ResponsesStreamErrorEvent {
+    message: Option<String>,
+    error: Option<ResponsesStreamError>,
+    response: Option<ResponsesStreamFailedResponse>,
+}
+
+impl ResponsesStreamErrorEvent {
+    fn display_message(self) -> String {
+        self.error
+            .or_else(|| self.response.and_then(|response| response.error))
+            .and_then(ResponsesStreamError::display_message)
+            .or(self.message)
+            .unwrap_or_else(|| "unknown stream error".to_string())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ResponsesStreamFailedResponse {
+    error: Option<ResponsesStreamError>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ResponsesStreamError {
+    message: Option<String>,
+    code: Option<String>,
+    #[serde(rename = "type")]
+    error_type: Option<String>,
+}
+
+impl ResponsesStreamError {
+    fn display_message(self) -> Option<String> {
+        let code = self.code.or(self.error_type);
+        match (self.message, code) {
+            (Some(message), Some(code)) => Some(format!("{message} ({code})")),
+            (Some(message), None) => Some(message),
+            (None, Some(code)) => Some(code),
+            (None, None) => None,
+        }
+    }
+}
+
 fn system_text(message: &Message) -> Option<&str> {
     match message {
         Message::System { content } => match content {
@@ -764,7 +806,7 @@ impl ProviderAdapter for ResponsesAdapter {
         payload
             .get("type")
             .and_then(Value::as_str)
-            .is_some_and(|t| t.starts_with("response.") || t == "keepalive")
+            .is_some_and(|t| t.starts_with("response.") || t == "keepalive" || t == "error")
             || payload
                 .get("object")
                 .and_then(Value::as_str)
@@ -810,6 +852,16 @@ impl ProviderAdapter for ResponsesAdapter {
         let delta_obj = payload.get("delta");
 
         match event_type.as_str() {
+            "error" | "response.failed" => {
+                let event = serde_json::from_value::<ResponsesStreamErrorEvent>(payload.clone())
+                    .map_err(|error| {
+                        TransformError::DeserializationFailed(format!(
+                            "Responses stream error event: {error}"
+                        ))
+                    })?;
+                Err(TransformError::ToUniversalFailed(event.display_message()))
+            }
+
             "keepalive" => Ok(Some(UniversalStreamChunk::keep_alive())),
 
             "response.output_text.delta" => {
@@ -2003,6 +2055,47 @@ mod tests {
             .expect("keepalive should emit a chunk");
 
         assert!(chunk.is_keep_alive());
+    }
+
+    #[test]
+    fn test_responses_stream_error_allows_type_and_code_fields() {
+        let adapter = ResponsesAdapter;
+        let error = adapter
+            .stream_to_universal(json!({
+                "type": "error",
+                "error": {
+                    "message": "bad request",
+                    "type": "invalid_request_error",
+                    "code": "invalid_tool_arguments"
+                }
+            }))
+            .expect_err("error event should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "Conversion to universal format failed: bad request (invalid_tool_arguments)"
+        );
+    }
+
+    #[test]
+    fn test_responses_stream_response_failed_uses_response_error() {
+        let adapter = ResponsesAdapter;
+        let error = adapter
+            .stream_to_universal(json!({
+                "type": "response.failed",
+                "response": {
+                    "error": {
+                        "message": "download failed",
+                        "code": "failed_to_download_image"
+                    }
+                }
+            }))
+            .expect_err("failed response event should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "Conversion to universal format failed: download failed (failed_to_download_image)"
+        );
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -18,6 +18,7 @@ use crate::providers::openai::capabilities::{
 };
 use crate::providers::openai::generated::{
     InputItem, InputItemContent, InputItemRole, InputItemType, Instructions, OutputItemType,
+    ResponseErrorCode, ResponseStreamEvent, ResponseStreamEventType,
 };
 use crate::providers::openai::params::{OpenAIResponsesExtrasView, OpenAIResponsesParams};
 use crate::providers::openai::tool_parsing::parse_openai_responses_tools_array;
@@ -38,46 +39,43 @@ use std::convert::TryInto;
 
 const OPENAI_RESPONSES_MIN_MAX_OUTPUT_TOKENS: i64 = 16;
 
-#[derive(Debug, Clone, Deserialize)]
-struct ResponsesStreamErrorEvent {
-    message: Option<String>,
-    error: Option<ResponsesStreamError>,
-    response: Option<ResponsesStreamFailedResponse>,
-}
+fn responses_stream_error_message(event: ResponseStreamEvent) -> String {
+    let ResponseStreamEvent {
+        response_stream_event_type,
+        message,
+        code,
+        response,
+        ..
+    } = event;
 
-impl ResponsesStreamErrorEvent {
-    fn display_message(self) -> String {
-        self.error
-            .or_else(|| self.response.and_then(|response| response.error))
-            .and_then(ResponsesStreamError::display_message)
-            .or(self.message)
-            .unwrap_or_else(|| "unknown stream error".to_string())
+    match response_stream_event_type {
+        ResponseStreamEventType::Error => error_message_with_code(message, code),
+        ResponseStreamEventType::ResponseFailed => response
+            .and_then(|response| response.error)
+            .map(|error| {
+                error_message_with_code(
+                    Some(error.message),
+                    Some(response_error_code_message(error.code)),
+                )
+            })
+            .unwrap_or_else(|| error_message_with_code(message, code)),
+        _ => error_message_with_code(message, code),
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
-struct ResponsesStreamFailedResponse {
-    error: Option<ResponsesStreamError>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct ResponsesStreamError {
-    message: Option<String>,
-    code: Option<String>,
-    #[serde(rename = "type")]
-    error_type: Option<String>,
-}
-
-impl ResponsesStreamError {
-    fn display_message(self) -> Option<String> {
-        let code = self.code.or(self.error_type);
-        match (self.message, code) {
-            (Some(message), Some(code)) => Some(format!("{message} ({code})")),
-            (Some(message), None) => Some(message),
-            (None, Some(code)) => Some(code),
-            (None, None) => None,
-        }
+fn error_message_with_code(message: Option<String>, code: Option<String>) -> String {
+    match (message, code) {
+        (Some(message), Some(code)) => format!("{message} ({code})"),
+        (Some(message), None) => message,
+        (None, Some(code)) => code,
+        (None, None) => "unknown stream error".to_string(),
     }
+}
+
+fn response_error_code_message(code: ResponseErrorCode) -> String {
+    serde_json::to_string(&code)
+        .map(|serialized| serialized.trim_matches('"').to_string())
+        .unwrap_or_else(|_| format!("{code:?}"))
 }
 
 fn system_text(message: &Message) -> Option<&str> {
@@ -853,13 +851,15 @@ impl ProviderAdapter for ResponsesAdapter {
 
         match event_type.as_str() {
             "error" | "response.failed" => {
-                let event = serde_json::from_value::<ResponsesStreamErrorEvent>(payload.clone())
+                let event = serde_json::from_value::<ResponseStreamEvent>(payload.clone())
                     .map_err(|error| {
                         TransformError::DeserializationFailed(format!(
                             "Responses stream error event: {error}"
                         ))
                     })?;
-                Err(TransformError::ToUniversalFailed(event.display_message()))
+                Err(TransformError::ToUniversalFailed(
+                    responses_stream_error_message(event),
+                ))
             }
 
             "keepalive" => Ok(Some(UniversalStreamChunk::keep_alive())),
@@ -2063,11 +2063,10 @@ mod tests {
         let error = adapter
             .stream_to_universal(json!({
                 "type": "error",
-                "error": {
-                    "message": "bad request",
-                    "type": "invalid_request_error",
-                    "code": "invalid_tool_arguments"
-                }
+                "code": "invalid_tool_arguments",
+                "message": "bad request",
+                "param": null,
+                "sequence_number": 1
             }))
             .expect_err("error event should fail");
 
@@ -2083,7 +2082,16 @@ mod tests {
         let error = adapter
             .stream_to_universal(json!({
                 "type": "response.failed",
+                "sequence_number": 1,
                 "response": {
+                    "id": "resp_123",
+                    "object": "response",
+                    "created_at": 1,
+                    "model": "gpt-5",
+                    "tool_choice": "auto",
+                    "tools": [],
+                    "output": [],
+                    "parallel_tool_calls": true,
                     "error": {
                         "message": "download failed",
                         "code": "failed_to_download_image"

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -488,6 +488,53 @@ export const paramsCases: TestCaseCollection = {
     bedrock: null,
   },
 
+  responsesStreamImageDownloadFailureParam: {
+    "chat-completions": null,
+    responses: {
+      model: OPENAI_RESPONSES_MODEL,
+      input: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: "Describe this image.",
+            },
+            {
+              type: "input_image",
+              detail: "auto",
+              image_url: "https://example.com/not-an-image.png",
+            },
+          ],
+        },
+        {
+          type: "additional_tools",
+          role: "developer",
+          tools: [
+            {
+              type: "function",
+              name: "lookup_policy",
+              description: "Look up an internal policy by slug.",
+              parameters: {
+                type: "object",
+                properties: {
+                  slug: { type: "string" },
+                },
+                required: ["slug"],
+                additionalProperties: false,
+              },
+              strict: true,
+            },
+          ],
+        },
+      ],
+      max_output_tokens: 300,
+    },
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
   // === Text Response Configuration ===
 
   textFormatJsonObjectParam: {

--- a/payloads/scripts/file-manager.ts
+++ b/payloads/scripts/file-manager.ts
@@ -79,7 +79,13 @@ export function saveAllFiles(
   // Save error if it exists
   if (result.error) {
     const errorPath = join(testCaseDir, "error.json");
-    writeFileSync(errorPath, JSON.stringify({ error: result.error }, null, 2));
+    const errorCapture = {
+      error: result.error,
+      ...(result.errorDetails === undefined
+        ? {}
+        : { details: result.errorDetails }),
+    };
+    writeFileSync(errorPath, JSON.stringify(errorCapture, null, 2));
     savedFiles.push(errorPath);
   }
 

--- a/payloads/scripts/providers/openai-responses.ts
+++ b/payloads/scripts/providers/openai-responses.ts
@@ -46,6 +46,36 @@ type ReplayableResponseOutputItem = Extract<
   ResponseInputItem
 >;
 
+function openAIErrorDetails(error: unknown): unknown {
+  if (!(error instanceof Error)) {
+    return undefined;
+  }
+
+  const details: Record<string, unknown> = {
+    message: error.message,
+    name: error.name,
+  };
+  if ("status" in error) {
+    details.status = error.status;
+  }
+  if ("code" in error) {
+    details.code = error.code;
+  }
+  if ("type" in error) {
+    details.type = error.type;
+  }
+  if ("param" in error) {
+    details.param = error.param;
+  }
+  if ("request_id" in error) {
+    details.request_id = error.request_id;
+  }
+  if ("error" in error) {
+    details.error = error.error;
+  }
+  return details;
+}
+
 function isReplayableResponseOutputItem(
   item: ResponseOutputItem
 ): item is ReplayableResponseOutputItem {
@@ -278,6 +308,7 @@ export async function executeOpenAIResponses(
     }
   } catch (error) {
     result.error = String(error);
+    result.errorDetails = openAIErrorDetails(error);
   }
 
   return result;

--- a/payloads/scripts/types.ts
+++ b/payloads/scripts/types.ts
@@ -12,6 +12,7 @@ export interface CaptureResult<
   followupResponse?: TResponse;
   followupStreamingResponse?: TStreamChunk[];
   error?: string;
+  errorDetails?: unknown;
 }
 
 export interface ProviderCase<TPayload = unknown> {

--- a/payloads/snapshots/responsesStreamImageDownloadFailureParam/responses/error.json
+++ b/payloads/snapshots/responsesStreamImageDownloadFailureParam/responses/error.json
@@ -1,0 +1,17 @@
+{
+  "error": "Error: 400 Error while downloading file. Upstream status code: 404.",
+  "details": {
+    "message": "400 Error while downloading file. Upstream status code: 404.",
+    "name": "Error",
+    "status": 400,
+    "code": "invalid_value",
+    "type": "invalid_request_error",
+    "param": "url",
+    "error": {
+      "message": "Error while downloading file. Upstream status code: 404.",
+      "type": "invalid_request_error",
+      "param": "url",
+      "code": "invalid_value"
+    }
+  }
+}

--- a/payloads/snapshots/responsesStreamImageDownloadFailureParam/responses/request.json
+++ b/payloads/snapshots/responsesStreamImageDownloadFailureParam/responses/request.json
@@ -1,0 +1,44 @@
+{
+  "model": "gpt-5-nano",
+  "input": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "Describe this image."
+        },
+        {
+          "type": "input_image",
+          "detail": "auto",
+          "image_url": "https://example.com/not-an-image.png"
+        }
+      ]
+    },
+    {
+      "type": "additional_tools",
+      "role": "developer",
+      "tools": [
+        {
+          "type": "function",
+          "name": "lookup_policy",
+          "description": "Look up an internal policy by slug.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "slug": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "slug"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        }
+      ]
+    }
+  ],
+  "max_output_tokens": 300
+}

--- a/payloads/transforms/responses_to_anthropic/responsesStreamImageDownloadFailureParam.json
+++ b/payloads/transforms/responses_to_anthropic/responsesStreamImageDownloadFailureParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion to universal format failed: Unsupported mapping: cannot convert InputItemType::AdditionalTools to universal Message"
+}

--- a/payloads/transforms/responses_to_google/responsesStreamImageDownloadFailureParam.json
+++ b/payloads/transforms/responses_to_google/responsesStreamImageDownloadFailureParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion to universal format failed: Unsupported mapping: cannot convert InputItemType::AdditionalTools to universal Message"
+}

--- a/payloads/transforms/transform_errors.json
+++ b/payloads/transforms/transform_errors.json
@@ -11,10 +11,12 @@
     "reasoningRequestTruncated": "Anthropic requires max_tokens > budget_tokens; min budget (1024) exceeds max_tokens (100)",
     "webSearchToolParam": "Tool 'web_search_preview' of type 'web_search_preview' is not supported by anthropic",
     "codeInterpreterToolParam": "Expected: OpenAI Responses code_interpreter is provider-specific and is not a lossless equivalent of Anthropic bash",
-    "responsesAdditionalToolsParam": "Expected: Responses additional_tools is a mid-conversation tool definition item with no universal representation"
+    "responsesAdditionalToolsParam": "Expected: Responses additional_tools is a mid-conversation tool definition item with no universal representation",
+    "responsesStreamImageDownloadFailureParam": "Expected: Responses additional_tools is a mid-conversation tool definition item with no universal representation"
   },
   "responses_to_google": {
-    "responsesAdditionalToolsParam": "Expected: Responses additional_tools is a mid-conversation tool definition item with no universal representation"
+    "responsesAdditionalToolsParam": "Expected: Responses additional_tools is a mid-conversation tool definition item with no universal representation",
+    "responsesStreamImageDownloadFailureParam": "Expected: Responses additional_tools is a mid-conversation tool definition item with no universal representation"
   },
   "anthropic_to_chat-completions": {
     "codeInterpreterToolParam": "Expected: Anthropic bash is provider-specific and is not supported by OpenAI Chat Completions",


### PR DESCRIPTION
We didn't propagate the streaming error types from OpenAI or Anthropic through to Lingua, so errors were silently dropped.

Wrote a payload test to generate an error, then updated the openapi type generator to propagate streaming error types, and hook them into lingua.