### PR TITLE
Update tool handling conversion

### DIFF
--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -242,7 +242,10 @@
       "source": "Responses",
       "target": "ChatCompletions",
       "fields": [
-        { "pattern": "messages.length", "reason": "ChatCompletions has no dynamic tool discovery transcript blocks, so discovery-only messages are dropped" }
+        { "pattern": "messages[*].content[*].type", "reason": "ChatCompletions has no tool-discovery types, so tool_discovery_call/tool_discovery_result project to generic tool_call/tool_result and cannot be re-tagged as discovery on reparse" },
+        { "pattern": "messages[*].content[*].tools", "reason": "ChatCompletions tool results carry no structured tools list; discovered tools are serialized into the tool message content/output instead" },
+        { "pattern": "messages[*].content[*].output", "reason": "The discovery result payload is serialized into the ChatCompletions tool message output string" },
+        { "pattern": "messages[*].content[*].arguments", "reason": "ChatCompletions tool-call arguments round-trip as a JSON string wrapped in the universal valid/invalid arguments envelope" }
       ]
     },
     {
@@ -250,7 +253,12 @@
       "source": "Anthropic",
       "target": "ChatCompletions",
       "fields": [
-        { "pattern": "messages.length", "reason": "ChatCompletions has no dynamic tool discovery transcript blocks, so discovery-only messages are dropped" }
+        { "pattern": "messages[*].content[*].type", "reason": "ChatCompletions has no tool-discovery types, so tool_discovery_call/tool_discovery_result project to generic tool_call/tool_result and cannot be re-tagged as discovery on reparse" },
+        { "pattern": "messages[*].content[*].tools", "reason": "ChatCompletions tool results carry no structured tools list; discovered tools are serialized into the tool message content/output instead" },
+        { "pattern": "messages[*].content[*].output", "reason": "The discovery result payload is serialized into the ChatCompletions tool message output string" },
+        { "pattern": "messages[*].content[*].arguments", "reason": "ChatCompletions tool-call arguments round-trip as a JSON string wrapped in the universal valid/invalid arguments envelope" },
+        { "pattern": "messages[*].content[*].discovery_tool_name", "reason": "ChatCompletions identifies the discovery call by its function name (tool_name); discovery_tool_name is not preserved as a separate field" },
+        { "pattern": "messages[*].content[*].tool_name", "reason": "Discovery call/result names round-trip as the ChatCompletions function/tool name" }
       ]
     },
     {

--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -10,8 +10,8 @@ use crate::universal::convert::TryFromLLM;
 use crate::universal::defaults::{EMPTY_OBJECT_STR, PLACEHOLDER_ID, REFUSAL_TEXT};
 use crate::universal::{
     AssistantContent, AssistantContentPart, CacheControl, Message, ProviderOptions,
-    TextContentPart, ToolCallArguments, ToolContentPart, ToolResultContentPart, UserContent,
-    UserContentPart,
+    TextContentPart, ToolCallArguments, ToolContentPart, ToolDiscoveryResultContentPart,
+    ToolResultContentPart, UserContent, UserContentPart,
 };
 use crate::util::media::parse_base64_data_url;
 use base64::Engine;
@@ -3976,11 +3976,8 @@ impl TryFromLLM<Message> for ChatCompletionRequestMessageExt {
                     ToolContentPart::ToolResult(result) => {
                         tool_result_to_chat_completion_message(result)
                     }
-                    ToolContentPart::ToolDiscoveryResult(_) => {
-                        Err(ConvertError::UnsupportedMapping {
-                            from: "ToolDiscoveryResult".to_string(),
-                            to: "ChatCompletionRequestMessage",
-                        })
+                    ToolContentPart::ToolDiscoveryResult(result) => {
+                        tool_discovery_result_to_chat_completion_message(result)
                     }
                 }
             }
@@ -4000,13 +3997,17 @@ pub(crate) fn messages_to_chat_completion_messages(
     let mut result = Vec::new();
     for msg in messages {
         match msg {
-            Message::Assistant { content, .. } if assistant_content_is_discovery_only(&content) => {
-                continue;
-            }
             Message::Tool { content } => {
                 for part in content {
-                    if let ToolContentPart::ToolResult(tool_result) = part {
-                        result.push(tool_result_to_chat_completion_message(tool_result)?);
+                    match part {
+                        ToolContentPart::ToolResult(tool_result) => {
+                            result.push(tool_result_to_chat_completion_message(tool_result)?);
+                        }
+                        ToolContentPart::ToolDiscoveryResult(discovery_result) => {
+                            result.push(tool_discovery_result_to_chat_completion_message(
+                                discovery_result,
+                            )?);
+                        }
                     }
                 }
             }
@@ -4015,18 +4016,6 @@ pub(crate) fn messages_to_chat_completion_messages(
         }
     }
     Ok(result)
-}
-
-fn assistant_content_is_discovery_only(content: &AssistantContent) -> bool {
-    match content {
-        AssistantContent::String(_) => false,
-        AssistantContent::Array(parts) => {
-            !parts.is_empty()
-                && parts
-                    .iter()
-                    .all(|part| matches!(part, AssistantContentPart::ToolDiscoveryCall { .. }))
-        }
-    }
 }
 
 /// Convert a single tool result into a chat completions tool-role message.
@@ -4042,6 +4031,56 @@ pub(crate) fn tool_result_to_chat_completion_message(
             })?
         }
     };
+    Ok(ChatCompletionRequestMessageExt {
+        role: openai::ChatCompletionRequestMessageRole::Tool,
+        content: Some(ChatCompletionRequestMessageContentExt::String(
+            content_string,
+        )),
+        name: None,
+        tool_calls: None,
+        tool_call_id: Some(result.tool_call_id),
+        audio: None,
+        function_call: None,
+        refusal: None,
+        cache_control: None,
+        reasoning: None,
+        reasoning_signature: None,
+    })
+}
+
+fn tool_discovery_result_to_chat_completion_message(
+    result: ToolDiscoveryResultContentPart,
+) -> Result<ChatCompletionRequestMessageExt, ConvertError> {
+    let mut content = serde_json::Map::new();
+    content.insert(
+        "discovery_tool_name".to_string(),
+        serde_json::Value::String(result.discovery_tool_name),
+    );
+    content.insert(
+        "tools".to_string(),
+        serde_json::to_value(result.tools).map_err(|e| ConvertError::JsonSerializationFailed {
+            field: "tool_discovery_result.tools".to_string(),
+            error: e.to_string(),
+        })?,
+    );
+    if let Some(status) = result.status {
+        content.insert("status".to_string(), serde_json::Value::String(status));
+    }
+    if let Some(execution) = result.execution {
+        content.insert(
+            "execution".to_string(),
+            serde_json::Value::String(execution),
+        );
+    }
+
+    let content_string =
+        serde_json::to_string(&serde_json::Value::Object(content)).map_err(|e| {
+            ConvertError::JsonSerializationFailed {
+                field: "tool_discovery_result_content".to_string(),
+                error: e.to_string(),
+            }
+        })?;
+
     Ok(ChatCompletionRequestMessageExt {
         role: openai::ChatCompletionRequestMessageRole::Tool,
         content: Some(ChatCompletionRequestMessageContentExt::String(
@@ -4217,6 +4256,23 @@ fn extract_content_tool_calls_and_reasoning(
                             custom: None,
                         });
                     }
+                    AssistantContentPart::ToolDiscoveryCall {
+                        tool_call_id,
+                        discovery_tool_name,
+                        query,
+                        arguments,
+                        ..
+                    } => {
+                        tool_calls.push(openai::ToolCall {
+                            id: tool_call_id,
+                            tool_call_type: openai::FluffyType::Function,
+                            function: Some(openai::PurpleFunction {
+                                name: discovery_tool_name,
+                                arguments: tool_discovery_arguments_to_string(query, arguments)?,
+                            }),
+                            custom: None,
+                        });
+                    }
                     _ => {
                         // Handle other content types if needed
                     }
@@ -4245,6 +4301,24 @@ fn extract_content_tool_calls_and_reasoning(
         reasoning,
         reasoning_signature,
     ))
+}
+
+fn tool_discovery_arguments_to_string(
+    query: Option<String>,
+    arguments: Option<serde_json::Value>,
+) -> Result<String, ConvertError> {
+    let value = arguments.unwrap_or_else(|| match query {
+        Some(query) => serde_json::json!({ "query": query }),
+        None => serde_json::json!({}),
+    });
+
+    match value {
+        serde_json::Value::String(text) => Ok(text),
+        other => serde_json::to_string(&other).map_err(|e| ConvertError::JsonSerializationFailed {
+            field: "tool_discovery_call.arguments".to_string(),
+            error: e.to_string(),
+        }),
+    }
 }
 
 fn chat_completion_assistant_text_content(
@@ -4689,7 +4763,7 @@ mod tests {
     }
 
     #[test]
-    fn chat_messages_drop_discovery_only_history() {
+    fn chat_messages_project_tool_discovery_history() {
         let messages = vec![
             Message::Assistant {
                 content: AssistantContent::Array(vec![AssistantContentPart::ToolDiscoveryCall {
@@ -4708,7 +4782,11 @@ mod tests {
                     crate::universal::ToolDiscoveryResultContentPart {
                         tool_call_id: "call_tool_search_123".to_string(),
                         discovery_tool_name: "tool_search".to_string(),
-                        tools: vec![],
+                        tools: vec![crate::universal::ToolDiscoveryResultItem {
+                            tool_name: "search_code".to_string(),
+                            tool: None,
+                            provider_options: None,
+                        }],
                         status: Some("completed".to_string()),
                         execution: Some("server".to_string()),
                         provider_options: None,
@@ -4718,7 +4796,46 @@ mod tests {
         ];
 
         let converted = messages_to_chat_completion_messages(messages).unwrap();
-        assert!(converted.is_empty());
+        assert_eq!(converted.len(), 2);
+        assert!(matches!(
+            converted[0].role,
+            openai::ChatCompletionRequestMessageRole::Assistant
+        ));
+        assert!(converted[0].content.is_none());
+        assert_eq!(
+            converted[0]
+                .tool_calls
+                .as_ref()
+                .expect("assistant discovery call should become a tool call")[0]
+                .id,
+            "call_tool_search_123"
+        );
+        assert_eq!(
+            converted[0]
+                .tool_calls
+                .as_ref()
+                .expect("assistant discovery call should become a tool call")[0]
+                .function
+                .as_ref()
+                .expect("tool call should be a function")
+                .name,
+            "tool_search"
+        );
+        assert!(matches!(
+            converted[1].role,
+            openai::ChatCompletionRequestMessageRole::Tool
+        ));
+        assert_eq!(
+            converted[1].tool_call_id.as_deref(),
+            Some("call_tool_search_123")
+        );
+        let Some(ChatCompletionRequestMessageContentExt::String(content)) =
+            converted[1].content.as_ref()
+        else {
+            panic!("discovery result should become string tool content");
+        };
+        assert!(content.contains("tool_search"));
+        assert!(content.contains("search_code"));
     }
 
     #[test]
@@ -4750,7 +4867,14 @@ mod tests {
             converted[0].content,
             Some(ChatCompletionRequestMessageContentExt::String(ref text)) if text == "done"
         ));
-        assert!(converted[0].tool_calls.is_none());
+        assert_eq!(
+            converted[0]
+                .tool_calls
+                .as_ref()
+                .expect("discovery call should become a tool call")[0]
+                .id,
+            "call_tool_search_123"
+        );
     }
 
     #[test]

--- a/crates/lingua/src/python.rs
+++ b/crates/lingua/src/python.rs
@@ -7,7 +7,9 @@ use crate::providers::anthropic::convert::{
 };
 use crate::providers::anthropic::generated as anthropic;
 use crate::providers::google::generated as google;
-use crate::providers::openai::convert::ChatCompletionRequestMessageExt;
+use crate::providers::openai::convert::{
+    messages_to_chat_completion_messages, ChatCompletionRequestMessageExt,
+};
 use crate::providers::openai::generated as openai;
 use crate::serde_json;
 use crate::universal::{convert::TryFromLLM, Message};
@@ -98,7 +100,11 @@ fn lingua_to_chat_completions_messages<'py>(
     py: Python<'py>,
     value: &Bound<'py, PyAny>,
 ) -> PyResult<Bound<'py, PyAny>> {
-    convert_from_lingua::<Vec<Message>, Vec<ChatCompletionRequestMessageExt>>(py, value)
+    let messages: Vec<Message> = py_to_rust(py, value)?;
+    let chat_messages = messages_to_chat_completion_messages(messages).map_err(|e| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Conversion error: {:?}", e))
+    })?;
+    rust_to_py(py, &chat_messages)
 }
 
 /// Convert array of Responses API messages to Lingua Messages

--- a/crates/lingua/src/wasm.rs
+++ b/crates/lingua/src/wasm.rs
@@ -8,6 +8,7 @@ use crate::providers::anthropic::convert::{
 };
 use crate::providers::anthropic::generated as anthropic;
 use crate::providers::google::generated as google;
+use crate::providers::openai::convert::messages_to_chat_completion_messages;
 use crate::providers::openai::generated as openai;
 use crate::providers::openai::ChatCompletionRequestMessageExt;
 use crate::universal::{convert::TryFromLLM, Message};
@@ -126,7 +127,11 @@ pub fn chat_completions_messages_to_lingua(value: JsValue) -> Result<JsValue, Js
 /// Convert array of Lingua Messages to Chat Completions messages
 #[wasm_bindgen]
 pub fn lingua_to_chat_completions_messages(value: JsValue) -> Result<JsValue, JsValue> {
-    convert_from_lingua::<Vec<Message>, Vec<ChatCompletionRequestMessageExt>>(value)
+    let messages: Vec<Message> = serde_wasm_bindgen::from_value(value)
+        .map_err(|e| JsValue::from_str(&format!("Failed to parse input: {}", e)))?;
+    let chat_messages = messages_to_chat_completion_messages(messages)
+        .map_err(|e| JsValue::from_str(&format!("Conversion error: {:?}", e)))?;
+    serialize_to_js(&chat_messages, "result")
 }
 
 /// Convert array of Responses API messages to Lingua Messages

--- a/crates/lingua/tests/import_fixtures.rs
+++ b/crates/lingua/tests/import_fixtures.rs
@@ -13,6 +13,8 @@ struct ImportAssertionCase {
     expected_message_count: Option<usize>,
     expected_roles_in_order: Option<Vec<String>>,
     must_contain_text: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    must_not_contain_text: Option<Vec<String>>,
 }
 
 fn workspace_root() -> PathBuf {
@@ -152,6 +154,7 @@ fn infer_assertions_from_messages(messages: &[Message]) -> ImportAssertionCase {
         expected_message_count: Some(messages.len()),
         expected_roles_in_order: Some(roles),
         must_contain_text: Some(vec![]),
+        must_not_contain_text: None,
     }
 }
 
@@ -243,6 +246,7 @@ fn test_import_cases_from_shared_fixtures() {
                     expected_message_count: inferred.expected_message_count,
                     expected_roles_in_order: inferred.expected_roles_in_order,
                     must_contain_text: existing.must_contain_text.clone(),
+                    must_not_contain_text: existing.must_not_contain_text.clone(),
                 };
                 write_assertions_fixture(&assertions_path, &updated);
                 generated_count += 1;
@@ -292,6 +296,17 @@ fn test_import_cases_from_shared_fixtures() {
                     serialized_messages.contains(&required_text),
                     "missing required text '{}' for case '{}'",
                     required_text,
+                    case_name
+                );
+            }
+        }
+
+        if let Some(disallowed_texts) = assertions.must_not_contain_text {
+            for disallowed_text in disallowed_texts {
+                assert!(
+                    !serialized_messages.contains(&disallowed_text),
+                    "found disallowed text '{}' for case '{}'",
+                    disallowed_text,
                     case_name
                 );
             }

--- a/payloads/import-cases/README.md
+++ b/payloads/import-cases/README.md
@@ -59,7 +59,8 @@ Notes:
 {
   "expectedMessageCount": 2,
   "expectedRolesInOrder": ["user", "assistant"],
-  "mustContainText": []
+  "mustContainText": [],
+  "mustNotContainText": []
 }
 ```
 
@@ -68,6 +69,7 @@ Supported keys:
 - `expectedMessageCount` (number)
 - `expectedRolesInOrder` (string array)
 - `mustContainText` (string array)
+- `mustNotContainText` (string array)
 
 Notes:
 

--- a/payloads/import-cases/responses-tool-search-output-with-null-call-id.assertions.json
+++ b/payloads/import-cases/responses-tool-search-output-with-null-call-id.assertions.json
@@ -1,0 +1,16 @@
+{
+  "expectedMessageCount": 2,
+  "expectedRolesInOrder": [
+    "assistant",
+    "tool"
+  ],
+  "mustContainText": [
+    "tool_discovery_call",
+    "tool_discovery_result",
+    "tsc_discover_catalog",
+    "list_catalog_items"
+  ],
+  "mustNotContainText": [
+    "tso_discover_catalog"
+  ]
+}

--- a/payloads/import-cases/responses-tool-search-output-with-null-call-id.spans.json
+++ b/payloads/import-cases/responses-tool-search-output-with-null-call-id.spans.json
@@ -1,0 +1,49 @@
+[
+  {
+    "output": [
+      {
+        "arguments": {
+          "paths": ["catalog"]
+        },
+        "call_id": null,
+        "execution": "server",
+        "id": "tsc_discover_catalog",
+        "status": "completed",
+        "type": "tool_search_call"
+      },
+      {
+        "call_id": null,
+        "execution": "server",
+        "id": "tso_discover_catalog",
+        "status": "completed",
+        "tools": [
+          {
+            "description": "List and read catalog items.",
+            "name": "catalog",
+            "tools": [
+              {
+                "defer_loading": true,
+                "description": "List catalog items.",
+                "name": "list_catalog_items",
+                "parameters": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "limit": {
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "strict": false,
+                "type": "function"
+              }
+            ],
+            "type": "namespace"
+          }
+        ],
+        "type": "tool_search_output"
+      }
+    ]
+  }
+]


### PR DESCRIPTION

- Project Lingua tool discovery messages into valid Chat Completions-shaped messages.
- Convert `tool_discovery_call` to assistant `tool_calls[]`.
- Convert `tool_discovery_result` to `role: "tool"` messages with JSON string content and the matching `tool_call_id`.
- Update WASM and Python `lingua_to_chat_completions_messages` exports to use the specialized vector conversion path so grouped tool results expand correctly.
- Add an import fixture for Responses `tool_search_call` / `tool_search_output` where both items have `call_id: null`, preserving the prior call id for the result.
