### PR TITLE
Preserve sibling tool calls in assistant imports

### DIFF
--- a/crates/lingua/src/processing/import.rs
+++ b/crates/lingua/src/processing/import.rs
@@ -354,6 +354,10 @@ struct LenientAssistantMessageCompat {
     content: Option<LenientAssistantContentCompat>,
     #[serde(default)]
     tool_calls: Vec<LenientOpenAiToolCallCompat>,
+    #[serde(default)]
+    reasoning: Option<Value>,
+    #[serde(default)]
+    reasoning_signature: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -582,7 +586,10 @@ fn parse_lenient_assistant_message_with_tool_calls(item: &Value) -> Option<Messa
     match parsed.role {
         AssistantRoleCompat::Assistant => {}
     }
-    if parsed.tool_calls.is_empty() {
+    if parsed.tool_calls.is_empty()
+        || parsed.reasoning.is_some()
+        || parsed.reasoning_signature.is_some()
+    {
         return None;
     }
 

--- a/crates/lingua/src/processing/import.rs
+++ b/crates/lingua/src/processing/import.rs
@@ -196,6 +196,11 @@ fn try_parse_mixed_role_messages_for_import(data: &Value) -> Option<Vec<Message>
     let mut messages = Vec::new();
 
     for item in items {
+        if let Some(message) = parse_lenient_assistant_message_with_tool_calls(item) {
+            messages.push(message);
+            continue;
+        }
+
         let mut parsed_messages = try_parsers_in_order(item, &provider_parsers).or_else(|| {
             let wrapped_item = Value::Array(vec![item.clone()]);
             try_parsers_in_order(&wrapped_item, &provider_parsers)
@@ -312,6 +317,12 @@ enum LenientAssistantContentPartCompat {
         #[serde(default)]
         encrypted_content: Option<String>,
     },
+    #[serde(rename = "thinking")]
+    Thinking {
+        thinking: String,
+        #[serde(default)]
+        signature: Option<String>,
+    },
     #[serde(rename = "tool_call", alias = "tool-call", alias = "toolCall")]
     ToolCall {
         #[serde(alias = "toolCallId")]
@@ -334,6 +345,40 @@ enum LenientAssistantContentPartCompat {
         #[serde(default)]
         output: Value,
     },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LenientAssistantMessageCompat {
+    role: AssistantRoleCompat,
+    #[serde(default)]
+    content: Option<LenientAssistantContentCompat>,
+    #[serde(default)]
+    tool_calls: Vec<LenientOpenAiToolCallCompat>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum AssistantRoleCompat {
+    Assistant,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum LenientAssistantContentCompat {
+    String(String),
+    Array(Vec<LenientAssistantContentPartCompat>),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LenientOpenAiToolCallCompat {
+    id: String,
+    function: LenientOpenAiFunctionCallCompat,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LenientOpenAiFunctionCallCompat {
+    name: String,
+    arguments: Value,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -449,7 +494,15 @@ fn parse_tool_call_arguments(value: Option<Value>) -> Option<ToolCallArguments> 
 }
 
 fn try_parse_lenient_assistant_content_part(item: &Value) -> Option<AssistantContentPart> {
-    match serde_json::from_value::<LenientAssistantContentPartCompat>(item.clone()).ok()? {
+    lenient_assistant_content_part_to_universal(
+        serde_json::from_value::<LenientAssistantContentPartCompat>(item.clone()).ok()?,
+    )
+}
+
+fn lenient_assistant_content_part_to_universal(
+    part: LenientAssistantContentPartCompat,
+) -> Option<AssistantContentPart> {
+    match part {
         LenientAssistantContentPartCompat::Text { text } => {
             Some(AssistantContentPart::Text(TextContentPart {
                 text,
@@ -464,6 +517,13 @@ fn try_parse_lenient_assistant_content_part(item: &Value) -> Option<AssistantCon
         } => Some(AssistantContentPart::Reasoning {
             text,
             encrypted_content,
+        }),
+        LenientAssistantContentPartCompat::Thinking {
+            thinking,
+            signature,
+        } => Some(AssistantContentPart::Reasoning {
+            text: thinking,
+            encrypted_content: signature,
         }),
         LenientAssistantContentPartCompat::ToolCall {
             tool_call_id,
@@ -490,6 +550,80 @@ fn try_parse_lenient_assistant_content_part(item: &Value) -> Option<AssistantCon
             provider_options: None,
         }),
     }
+}
+
+fn openai_tool_call_arguments(value: Value) -> ToolCallArguments {
+    match value {
+        Value::Object(map) => ToolCallArguments::Valid(map),
+        Value::String(text) => match serde_json::from_str::<Value>(&text) {
+            Ok(Value::Object(map)) => ToolCallArguments::Valid(map),
+            Ok(other) => ToolCallArguments::Invalid(other.to_string()),
+            Err(_) => ToolCallArguments::Invalid(text),
+        },
+        other => ToolCallArguments::Invalid(other.to_string()),
+    }
+}
+
+fn openai_tool_call_to_assistant_part(
+    tool_call: LenientOpenAiToolCallCompat,
+) -> AssistantContentPart {
+    AssistantContentPart::ToolCall {
+        tool_call_id: tool_call.id,
+        tool_name: tool_call.function.name,
+        arguments: openai_tool_call_arguments(tool_call.function.arguments),
+        encrypted_content: None,
+        provider_options: None,
+        provider_executed: None,
+    }
+}
+
+fn parse_lenient_assistant_message_with_tool_calls(item: &Value) -> Option<Message> {
+    let parsed = LenientAssistantMessageCompat::deserialize(item).ok()?;
+    match parsed.role {
+        AssistantRoleCompat::Assistant => {}
+    }
+    if parsed.tool_calls.is_empty() {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+    if let Some(content) = parsed.content {
+        match content {
+            LenientAssistantContentCompat::String(text) => {
+                if !text.is_empty() {
+                    parts.push(AssistantContentPart::Text(TextContentPart {
+                        text,
+                        encrypted_content: None,
+                        cache_control: None,
+                        provider_options: None,
+                    }));
+                }
+            }
+            LenientAssistantContentCompat::Array(content_parts) => {
+                parts.extend(
+                    content_parts
+                        .into_iter()
+                        .filter_map(lenient_assistant_content_part_to_universal),
+                );
+            }
+        }
+    }
+
+    parts.extend(
+        parsed
+            .tool_calls
+            .into_iter()
+            .map(openai_tool_call_to_assistant_part),
+    );
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    Some(Message::Assistant {
+        content: AssistantContent::Array(parts),
+        id: None,
+    })
 }
 
 fn try_parse_lenient_tool_content_part(item: &Value) -> Option<ToolContentPart> {

--- a/payloads/import-cases/role-message-openai-reasoning-with-sibling-tool-calls.assertions.json
+++ b/payloads/import-cases/role-message-openai-reasoning-with-sibling-tool-calls.assertions.json
@@ -1,0 +1,13 @@
+{
+  "expectedMessageCount": 1,
+  "expectedRolesInOrder": [
+    "assistant"
+  ],
+  "mustContainText": [
+    "Use the structured data tool before answering.",
+    "top_level_reasoning_signature_123",
+    "call_openai_reasoning_123",
+    "get_summary",
+    "anonymized metrics"
+  ]
+}

--- a/payloads/import-cases/role-message-openai-reasoning-with-sibling-tool-calls.spans.json
+++ b/payloads/import-cases/role-message-openai-reasoning-with-sibling-tool-calls.spans.json
@@ -1,0 +1,22 @@
+[
+  {
+    "output": [
+      {
+        "role": "assistant",
+        "content": "",
+        "reasoning": "Use the structured data tool before answering.",
+        "reasoning_signature": "top_level_reasoning_signature_123",
+        "tool_calls": [
+          {
+            "id": "call_openai_reasoning_123",
+            "type": "function",
+            "function": {
+              "name": "get_summary",
+              "arguments": "{\"topic\":\"anonymized metrics\"}"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/payloads/import-cases/role-message-thinking-with-sibling-tool-calls.assertions.json
+++ b/payloads/import-cases/role-message-thinking-with-sibling-tool-calls.assertions.json
@@ -1,0 +1,14 @@
+{
+  "expectedMessageCount": 1,
+  "expectedRolesInOrder": [
+    "assistant"
+  ],
+  "mustContainText": [
+    "Need to query structured data before answering.",
+    "reasoning_signature_123",
+    "call_structured_data_123",
+    "StructuredDataQueryTool",
+    "select count(*) from anonymized_table",
+    "\"limit\":10"
+  ]
+}

--- a/payloads/import-cases/role-message-thinking-with-sibling-tool-calls.spans.json
+++ b/payloads/import-cases/role-message-thinking-with-sibling-tool-calls.spans.json
@@ -1,0 +1,29 @@
+[
+  {
+    "output": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "Need to query structured data before answering.",
+            "signature": "reasoning_signature_123"
+          }
+        ],
+        "tool_calls": [
+          {
+            "id": "call_structured_data_123",
+            "type": "function",
+            "function": {
+              "name": "StructuredDataQueryTool",
+              "arguments": {
+                "query": "select count(*) from anonymized_table",
+                "limit": 10
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/scripts/show-import-thinking-tool-calls-issue.sh
+++ b/scripts/show-import-thinking-tool-calls-issue.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Show the assistant-thinking + sibling-tool-calls import behavior.
+#
+# On a broken importer, this prints an assistant message with reasoning only and
+# then fails because the sibling tool_call fields are absent. On a fixed importer,
+# it prints one assistant message containing both the reasoning part and tool_call
+# part.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_FILE="$REPO_ROOT/crates/lingua/tests/show_import_thinking_tool_calls_issue.rs"
+
+cleanup() {
+    rm -f "$TEST_FILE"
+}
+trap cleanup EXIT
+
+if [ -f "$TEST_FILE" ]; then
+    echo "Refusing to overwrite existing test file: $TEST_FILE" >&2
+    exit 1
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "cargo is required to run this script" >&2
+    exit 1
+fi
+
+CARGO_CMD=(cargo)
+if [ -n "${CARGO_TOOLCHAIN:-}" ]; then
+    CARGO_CMD=(cargo "+$CARGO_TOOLCHAIN")
+elif command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^1\.95\.0'; then
+    CARGO_CMD=(cargo +1.95.0)
+fi
+
+cat > "$TEST_FILE" <<'RS'
+use lingua::processing::{import_messages_from_spans, Span};
+use lingua::serde_json;
+
+#[test]
+fn show_import_thinking_tool_calls_issue() {
+    let spans_json = r#"
+[
+  {
+    "output": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "Need to query structured data before answering.",
+            "signature": "reasoning_signature_123"
+          }
+        ],
+        "tool_calls": [
+          {
+            "id": "call_structured_data_123",
+            "type": "function",
+            "function": {
+              "name": "StructuredDataQueryTool",
+              "arguments": {
+                "query": "select count(*) from anonymized_table",
+                "limit": 10
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]
+"#;
+
+    let spans: Vec<Span> = serde_json::from_str(spans_json).expect("fixture should parse");
+    let messages = import_messages_from_spans(spans);
+    let pretty = serde_json::to_string_pretty(&messages).expect("messages should serialize");
+
+    println!("\nImported Lingua messages:\n{}\n", pretty);
+
+    for expected in [
+        "Need to query structured data before answering.",
+        "reasoning_signature_123",
+        "call_structured_data_123",
+        "StructuredDataQueryTool",
+        "select count(*) from anonymized_table",
+        "\"limit\": 10",
+    ] {
+        assert!(
+            pretty.contains(expected),
+            "missing expected text: {expected}\n\nOn the broken importer, sibling tool_calls are dropped before the UI sees them.\n\nImported messages:\n{pretty}"
+        );
+    }
+}
+RS
+
+cd "$REPO_ROOT"
+echo "Running: ${CARGO_CMD[*]} test -p lingua --test show_import_thinking_tool_calls_issue -- --nocapture"
+"${CARGO_CMD[@]}" test -p lingua --test show_import_thinking_tool_calls_issue -- --nocapture


### PR DESCRIPTION
## Summary

Fixes Lingua import handling for assistant role messages that contain Anthropic-style `content[].type = "thinking"` blocks alongside sibling OpenAI-style `tool_calls`.

The importer now parses this mixed assistant shape at a typed compatibility boundary and preserves both the reasoning content and sibling tool calls in the resulting universal assistant message.

It also avoids preempting OpenAI/OpenRouter/vLLM-style messages with top-level `reasoning` or `reasoning_signature`, allowing the existing OpenAI provider parser to preserve those fields.

## Root cause

`try_parse_mixed_role_messages_for_import` offered role-message items to provider parsers before the lenient fallback. A provider parser could preserve `content[].thinking` while ignoring sibling `tool_calls`. The lenient assistant fallback only parsed `content`, so sibling tool calls were invisible there too.

## Tests

- `CASE_FILTER=role-message-thinking-with-sibling-tool-calls cargo +1.95.0 test -p lingua --test import_fixtures -- --nocapture`
- `CASE_FILTER=role-message-openai-reasoning-with-sibling-tool-calls cargo +1.95.0 test -p lingua --test import_fixtures -- --nocapture`
- `cargo +1.95.0 test -p lingua --test import_fixtures -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.95.0 make typed-boundary-check`
