### PR TITLE
Route gemma models to mantle in bedrock

### DIFF
--- a/crates/braintrust-llm-router/src/providers/bedrock.rs
+++ b/crates/braintrust-llm-router/src/providers/bedrock.rs
@@ -49,9 +49,11 @@ pub(crate) fn requires_bedrock_request_preparation(format: ProviderFormat) -> bo
 }
 
 // Some Bedrock models are served only on the `bedrock-mantle` host, not
-// `bedrock-runtime`: xAI/Grok (`xai.`) and Google Gemma 4 (`google.gemma`).
+// `bedrock-runtime`: xAI/Grok (`xai.`) and Google Gemma 4 (`google.gemma-4`).
+// Gemma 3 is excluded on purpose — it is served on `bedrock-runtime` and uses a
+// different mantle OpenAI path (`/v1` rather than `/openai/v1`).
 fn is_bedrock_mantle_only_model(model: &str) -> bool {
-    model.starts_with("xai.") || model.starts_with("google.gemma")
+    model.starts_with("xai.") || model.starts_with("google.gemma-4")
 }
 
 /// Prepare a Bedrock-targeted request by inlining client-provided remote image URLs.
@@ -717,6 +719,19 @@ mod tests {
                 "model {model} should route to the bedrock-mantle host"
             );
         }
+    }
+
+    #[test]
+    fn chat_completions_url_keeps_gemma_3_on_bedrock_runtime() {
+        let provider = provider();
+        let url = provider
+            .chat_completions_url("google.gemma-3-27b-it")
+            .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions",
+            "Gemma 3 is served on bedrock-runtime, not the mantle host"
+        );
     }
 
     #[test]

--- a/crates/braintrust-llm-router/src/providers/bedrock.rs
+++ b/crates/braintrust-llm-router/src/providers/bedrock.rs
@@ -48,10 +48,10 @@ pub(crate) fn requires_bedrock_request_preparation(format: ProviderFormat) -> bo
     )
 }
 
-// xAI/Grok on Bedrock is served only on the `bedrock-mantle` host, not
-// `bedrock-runtime`.
+// Some Bedrock models are served only on the `bedrock-mantle` host, not
+// `bedrock-runtime`: xAI/Grok (`xai.`) and Google Gemma 4 (`google.gemma`).
 fn is_bedrock_mantle_only_model(model: &str) -> bool {
-    model.starts_with("xai.")
+    model.starts_with("xai.") || model.starts_with("google.gemma")
 }
 
 /// Prepare a Bedrock-targeted request by inlining client-provided remote image URLs.
@@ -700,6 +700,23 @@ mod tests {
             url.as_str(),
             "https://bedrock-mantle.us-east-1.api.aws/openai/v1/chat/completions"
         );
+    }
+
+    #[test]
+    fn chat_completions_url_routes_gemma_models_to_mantle() {
+        let provider = provider();
+        for model in [
+            "google.gemma-4-e2b",
+            "google.gemma-4-31b",
+            "google.gemma-4-26b-a4b",
+        ] {
+            let url = provider.chat_completions_url(model).unwrap();
+            assert_eq!(
+                url.as_str(),
+                "https://bedrock-mantle.us-east-1.api.aws/openai/v1/chat/completions",
+                "model {model} should route to the bedrock-mantle host"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Bedrock introduced new gemma models that only route to mantle (https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-4-e2b.html), so we need to add them to our mantle-only list. 

If this starts becoming more of an issue we can add it to the model config 🤕 but for now this is fine I think

Manually validated that this invokes e2e, we already have e2e mantle testing so I think that is sufficient.