### PR TITLE
Fix Responses stream sequencing and reject malformed custom tool call events

### DIFF
--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -10,6 +10,7 @@ use crate::processing::transform::{
 #[cfg(feature = "openai")]
 use crate::providers::openai::responses_adapter::{
     responses_created_stream_event_from_universal,
+    responses_in_progress_stream_event_from_universal,
     responses_stream_events_from_universal_with_output_index_offset,
 };
 use crate::serde_json::Value;
@@ -1004,8 +1005,9 @@ fn expand_responses_session_chunks(
 
     let has_metadata =
         universal.model.is_some() || universal.id.is_some() || universal.usage.is_some();
-    let may_emit_created = has_metadata && !responses_message_started;
-    let event_sequence_number = *next_responses_sequence_number + u64::from(may_emit_created);
+    let should_emit_lifecycle_events = has_metadata && !responses_message_started;
+    let event_sequence_number =
+        *next_responses_sequence_number + if should_emit_lifecycle_events { 2 } else { 0 };
     let mut events = responses_stream_events_from_universal_with_output_index_offset(
         universal,
         output_index_state.text_output_index,
@@ -1035,15 +1037,14 @@ fn expand_responses_session_chunks(
     {
         responses_output_index_states.insert(choice_index, next_output_index_state);
     }
-    if has_metadata
-        && !responses_message_started
-        && !events.is_empty()
-        && events
-            .first()
-            .and_then(|event| event.get("type"))
-            .and_then(Value::as_str)
-            != Some("response.created")
-    {
+    if should_emit_lifecycle_events {
+        events.insert(
+            0,
+            responses_in_progress_stream_event_from_universal(
+                universal,
+                *next_responses_sequence_number + 1,
+            ),
+        );
         events.insert(
             0,
             responses_created_stream_event_from_universal(
@@ -1070,7 +1071,9 @@ fn expand_responses_session_chunks(
         .collect::<Result<Vec<_>, TransformError>>()?;
 
     if out.is_empty() {
-        Ok(chunks)
+        Ok(vec![StreamOutputChunk::data(Bytes::from_static(
+            KEEP_ALIVE_BYTES,
+        ))])
     } else {
         Ok(out)
     }
@@ -2547,6 +2550,80 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "openai")]
+    fn test_stream_session_chat_metadata_only_opening_is_sequenced_for_responses() {
+        let mut session = StreamTransformSession::new(ProviderFormat::Responses);
+        let metadata = to_bytes(&json!({
+            "id": "chatcmpl_123",
+            "object": "chat.completion.chunk",
+            "created": 123,
+            "model": "gpt-4.1",
+            "choices": [{
+                "index": 0,
+                "delta": { "role": "assistant", "content": "" },
+                "finish_reason": null
+            }]
+        }));
+        let content = to_bytes(&json!({
+            "id": "chatcmpl_123",
+            "object": "chat.completion.chunk",
+            "created": 123,
+            "model": "gpt-4.1",
+            "choices": [{
+                "index": 0,
+                "delta": { "content": "hello" },
+                "finish_reason": null
+            }]
+        }));
+        let empty = to_bytes(&json!({
+            "id": "chatcmpl_123",
+            "object": "chat.completion.chunk",
+            "created": 123,
+            "model": "gpt-4.1",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": null
+            }]
+        }));
+
+        let opening = session.push(metadata).unwrap();
+        assert_eq!(opening.len(), 2);
+        assert_eq!(opening[0].event_type.as_deref(), Some("response.created"));
+        let created: Value = crate::serde_json::from_slice(&opening[0].data).unwrap();
+        assert_eq!(
+            created.get("sequence_number").and_then(Value::as_u64),
+            Some(0)
+        );
+        assert_eq!(
+            opening[1].event_type.as_deref(),
+            Some("response.in_progress")
+        );
+        let in_progress: Value = crate::serde_json::from_slice(&opening[1].data).unwrap();
+        assert_eq!(
+            in_progress.get("sequence_number").and_then(Value::as_u64),
+            Some(1)
+        );
+
+        let keep_alive = session.push(empty).unwrap();
+        assert_eq!(keep_alive.len(), 1);
+        assert_eq!(keep_alive[0].data.as_ref(), KEEP_ALIVE_BYTES);
+        assert!(keep_alive[0].event_type.is_none());
+
+        let out = session.push(content).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].event_type.as_deref(),
+            Some("response.output_text.delta")
+        );
+        let text_delta: Value = crate::serde_json::from_slice(&out[0].data).unwrap();
+        assert_eq!(
+            text_delta.get("sequence_number").and_then(Value::as_u64),
+            Some(2)
+        );
+    }
+
+    #[test]
     #[cfg(all(feature = "google", feature = "openai"))]
     fn test_stream_session_google_mixed_thought_and_text_expands_to_responses_events() {
         let mut session = StreamTransformSession::new(ProviderFormat::Responses);
@@ -2584,6 +2661,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 Some("response.created"),
+                Some("response.in_progress"),
                 Some("response.reasoning_summary_text.delta"),
                 Some("response.output_text.delta"),
                 Some("response.completed")
@@ -2636,6 +2714,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 Some("response.created"),
+                Some("response.in_progress"),
                 Some("response.reasoning_summary_text.delta"),
                 Some("response.output_item.added"),
                 Some("response.function_call_arguments.delta")
@@ -2689,6 +2768,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 Some("response.created"),
+                Some("response.in_progress"),
                 Some("response.reasoning_summary_text.delta")
             ]
         );
@@ -2753,6 +2833,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 Some("response.created"),
+                Some("response.in_progress"),
                 Some("response.reasoning_summary_text.delta")
             ]
         );
@@ -2830,11 +2911,12 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 Some("response.created"),
+                Some("response.in_progress"),
                 Some("response.reasoning_summary_text.delta"),
                 Some("response.output_text.delta")
             ]
         );
-        let text_delta: OutputEvent = crate::serde_json::from_slice(&first[2].data).unwrap();
+        let text_delta: OutputEvent = crate::serde_json::from_slice(&first[3].data).unwrap();
         assert_eq!(text_delta.output_index, 1);
 
         let second = session.push(tool_call).unwrap();
@@ -2885,6 +2967,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 Some("response.created"),
+                Some("response.in_progress"),
                 Some("response.output_item.added"),
                 Some("response.custom_tool_call_input.delta"),
                 Some("response.completed")
@@ -2894,10 +2977,11 @@ mod tests {
         assert_eq!(events[1]["sequence_number"], json!(1));
         assert_eq!(events[2]["sequence_number"], json!(2));
         assert_eq!(events[3]["sequence_number"], json!(3));
-        assert_eq!(events[1]["item"]["id"], json!("ctc_0"));
-        assert_eq!(events[2]["item_id"], json!("ctc_0"));
+        assert_eq!(events[4]["sequence_number"], json!(4));
+        assert_eq!(events[2]["item"]["id"], json!("ctc_0"));
+        assert_eq!(events[3]["item_id"], json!("ctc_0"));
         assert_eq!(
-            events[2]["delta"],
+            events[3]["delta"],
             json!("await tools.exec_command({cmd: true});")
         );
     }

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -65,6 +65,25 @@ struct ResponsesOutputIndexState {
     tool_output_index_offset: u32,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+struct ResponsesTerminalEvent {
+    #[serde(rename = "type")]
+    _event_type: String,
+    response: ResponsesTerminalResponse,
+    _sequence_number: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ResponsesTerminalResponse {
+    id: String,
+    object: String,
+    model: String,
+    status: String,
+    output: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    usage: Option<Value>,
+}
+
 /// Stateful stream transformation session.
 ///
 /// This wraps the stateless `transform_stream_chunk` API with target-provider
@@ -75,6 +94,7 @@ pub struct StreamTransformSession {
     allow_full_response_fallback: bool,
     buffered_delta: Option<StreamOutputChunk>,
     buffered_stop: Option<StreamOutputChunk>,
+    buffered_responses_terminal: Option<StreamOutputChunk>,
     // Whether the target Anthropic stream has an open message. Some source
     // providers emit repeated metadata chunks; only the first should become
     // Anthropic `message_start`.
@@ -113,6 +133,7 @@ impl StreamTransformSession {
             allow_full_response_fallback,
             buffered_delta: None,
             buffered_stop: None,
+            buffered_responses_terminal: None,
             anthropic_message_started: false,
             anthropic_tool_use_started: false,
             anthropic_open_content_block_index: None,
@@ -149,6 +170,25 @@ impl StreamTransformSession {
 
         let result = self.normalize_source_stream_result(&step)?;
 
+        if self.target_format == ProviderFormat::Responses
+            && self.buffered_responses_terminal.is_some()
+            && step
+                .universal
+                .as_ref()
+                .is_some_and(|chunk| chunk.choices.is_empty() && chunk.usage.is_some())
+        {
+            return self.flush_responses_terminal(
+                step.universal
+                    .as_ref()
+                    .and_then(|chunk| chunk.usage.as_ref()),
+            );
+        }
+
+        let mut prefix = if self.target_format == ProviderFormat::Responses {
+            self.flush_responses_terminal(None)?
+        } else {
+            Vec::new()
+        };
         let chunks = build_session_chunks(
             result,
             step.source_format,
@@ -162,6 +202,26 @@ impl StreamTransformSession {
                 next_responses_sequence_number: &mut self.next_responses_sequence_number,
             },
         )?;
+        if self.target_format == ProviderFormat::Responses {
+            let mut terminal = None;
+            let chunks = chunks
+                .into_iter()
+                .filter(|chunk| {
+                    if matches!(
+                        chunk.event_type.as_deref(),
+                        Some("response.completed") | Some("response.incomplete")
+                    ) {
+                        terminal = Some(chunk.clone());
+                        false
+                    } else {
+                        true
+                    }
+                })
+                .collect();
+            prefix.extend(self.process_chunks(chunks)?);
+            self.buffered_responses_terminal = terminal;
+            return Ok(prefix);
+        }
         self.process_chunks(chunks)
     }
 
@@ -315,7 +375,9 @@ impl StreamTransformSession {
     }
 
     pub fn finish(&mut self) -> Vec<StreamOutputChunk> {
-        self.flush_buffered()
+        let mut out = self.flush_responses_terminal(None).unwrap_or_default();
+        out.extend(self.flush_buffered());
+        out
     }
 
     pub fn push_sse(&mut self, input: Bytes) -> Result<Vec<Bytes>, TransformError> {
@@ -350,6 +412,28 @@ impl StreamTransformSession {
 
     pub fn done_marker_sse(&self) -> Option<Bytes> {
         sse_done_marker(self.target_format)
+    }
+
+    fn flush_responses_terminal(
+        &mut self,
+        usage: Option<&crate::universal::UniversalUsage>,
+    ) -> Result<Vec<StreamOutputChunk>, TransformError> {
+        let Some(terminal) = self.buffered_responses_terminal.take() else {
+            return Ok(Vec::new());
+        };
+        self.responses_message_started = false;
+        let Some(usage) = usage else {
+            return Ok(vec![terminal]);
+        };
+        let mut event = crate::serde_json::from_slice::<ResponsesTerminalEvent>(&terminal.data)
+            .map_err(|e| {
+                TransformError::DeserializationFailed(format!("Responses terminal event: {e}"))
+            })?;
+        event.response.usage = Some(usage.to_provider_value(ProviderFormat::Responses));
+        Ok(vec![StreamOutputChunk {
+            data: serialize_stream_value(&event)?,
+            event_type: terminal.event_type,
+        }])
     }
 
     fn process_chunks(

--- a/crates/lingua/src/processing/stream.rs
+++ b/crates/lingua/src/processing/stream.rs
@@ -320,6 +320,12 @@ impl StreamTransformSession {
 
     pub fn push_sse(&mut self, input: Bytes) -> Result<Vec<Bytes>, TransformError> {
         let chunks = self.push(input)?;
+        if chunks.is_empty()
+            && self.target_format == ProviderFormat::Responses
+            && self.responses_message_started
+        {
+            return Ok(vec![SSE_COMMENT_BYTES.clone()]);
+        }
         Ok(chunks
             .iter()
             .map(|chunk| self.format_output_chunk_as_sse(chunk))
@@ -1071,9 +1077,7 @@ fn expand_responses_session_chunks(
         .collect::<Result<Vec<_>, TransformError>>()?;
 
     if out.is_empty() {
-        Ok(vec![StreamOutputChunk::data(Bytes::from_static(
-            KEEP_ALIVE_BYTES,
-        ))])
+        Ok(vec![])
     } else {
         Ok(out)
     }
@@ -2589,38 +2593,18 @@ mod tests {
 
         let opening = session.push(metadata).unwrap();
         assert_eq!(opening.len(), 2);
-        assert_eq!(opening[0].event_type.as_deref(), Some("response.created"));
-        let created: Value = crate::serde_json::from_slice(&opening[0].data).unwrap();
+        for (index, chunk) in opening.iter().enumerate() {
+            let event: Value = crate::serde_json::from_slice(&chunk.data).unwrap();
+            assert_eq!(event["sequence_number"], json!(index));
+        }
+        assert!(session.push(empty.clone()).unwrap().is_empty());
         assert_eq!(
-            created.get("sequence_number").and_then(Value::as_u64),
-            Some(0)
+            session.push_sse(empty).unwrap(),
+            vec![SSE_COMMENT_BYTES.clone()]
         );
-        assert_eq!(
-            opening[1].event_type.as_deref(),
-            Some("response.in_progress")
-        );
-        let in_progress: Value = crate::serde_json::from_slice(&opening[1].data).unwrap();
-        assert_eq!(
-            in_progress.get("sequence_number").and_then(Value::as_u64),
-            Some(1)
-        );
-
-        let keep_alive = session.push(empty).unwrap();
-        assert_eq!(keep_alive.len(), 1);
-        assert_eq!(keep_alive[0].data.as_ref(), KEEP_ALIVE_BYTES);
-        assert!(keep_alive[0].event_type.is_none());
-
-        let out = session.push(content).unwrap();
-        assert_eq!(out.len(), 1);
-        assert_eq!(
-            out[0].event_type.as_deref(),
-            Some("response.output_text.delta")
-        );
-        let text_delta: Value = crate::serde_json::from_slice(&out[0].data).unwrap();
-        assert_eq!(
-            text_delta.get("sequence_number").and_then(Value::as_u64),
-            Some(2)
-        );
+        let text = session.push(content).unwrap();
+        let event: Value = crate::serde_json::from_slice(&text[0].data).unwrap();
+        assert_eq!(event["sequence_number"], json!(2));
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -205,6 +205,25 @@ pub(crate) fn responses_created_stream_event_from_universal(
     chunk: &UniversalStreamChunk,
     sequence_number: u64,
 ) -> Value {
+    crate::serde_json::json!({
+        "type": "response.created",
+        "response": responses_in_progress_from_universal(chunk),
+        "sequence_number": sequence_number
+    })
+}
+
+pub(crate) fn responses_in_progress_stream_event_from_universal(
+    chunk: &UniversalStreamChunk,
+    sequence_number: u64,
+) -> Value {
+    crate::serde_json::json!({
+        "type": "response.in_progress",
+        "response": responses_in_progress_from_universal(chunk),
+        "sequence_number": sequence_number
+    })
+}
+
+fn responses_in_progress_from_universal(chunk: &UniversalStreamChunk) -> Value {
     let id = chunk
         .id
         .clone()
@@ -226,11 +245,7 @@ pub(crate) fn responses_created_stream_event_from_universal(
         }
     }
 
-    crate::serde_json::json!({
-        "type": "response.created",
-        "response": response,
-        "sequence_number": sequence_number
-    })
+    response
 }
 
 fn responses_terminal_stream_event(chunk: &UniversalStreamChunk, sequence_number: u64) -> Value {
@@ -273,6 +288,7 @@ fn responses_terminal_stream_event(chunk: &UniversalStreamChunk, sequence_number
 struct ResponsesOutputItemAddedEvent {
     item: Option<ResponsesOutputItemAddedItem>,
     output_index: Option<u32>,
+    sequence_number: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -285,8 +301,10 @@ enum ResponsesOutputItemAddedItem {
     },
     #[serde(rename = "custom_tool_call")]
     CustomToolCall {
-        call_id: Option<String>,
-        name: Option<String>,
+        call_id: String,
+        name: String,
+        #[serde(rename = "input")]
+        _input: String,
     },
     #[serde(other)]
     #[default]
@@ -301,11 +319,7 @@ impl ResponsesOutputItemAddedItem {
                 name.as_deref().unwrap_or(""),
                 false,
             )),
-            Self::CustomToolCall { call_id, name } => Some((
-                call_id.as_deref().unwrap_or(""),
-                name.as_deref().unwrap_or(""),
-                true,
-            )),
+            Self::CustomToolCall { call_id, name, .. } => Some((call_id, name, true)),
             Self::Other => None,
         }
     }
@@ -324,7 +338,7 @@ struct ResponsesCustomToolCallInputDeltaEvent {
     #[serde(rename = "item_id")]
     _item_id: String,
     #[serde(rename = "sequence_number")]
-    _sequence_number: u32,
+    _sequence_number: u64,
 }
 
 fn responses_tool_call_start_chunk(
@@ -1191,13 +1205,33 @@ impl ProviderAdapter for ResponsesAdapter {
                 // Tool call start - extract call_id, name, and output_index
                 let parsed =
                     serde_json::from_value::<ResponsesOutputItemAddedEvent>(payload.clone())
-                        .unwrap_or_default();
+                        .map_err(|e| {
+                            TransformError::DeserializationFailed(format!(
+                                "Responses output item added event: {}",
+                                e
+                            ))
+                        })?;
                 if let Some((call_id, name, custom_tool_call)) = parsed
                     .item
                     .as_ref()
                     .and_then(ResponsesOutputItemAddedItem::tool_call_start)
                 {
-                    let output_index = parsed.output_index.unwrap_or(0);
+                    let output_index = if custom_tool_call {
+                        parsed.output_index.ok_or_else(|| {
+                            TransformError::DeserializationFailed(
+                                "Responses custom tool call output item added event: missing output_index"
+                                    .to_string(),
+                            )
+                        })?
+                    } else {
+                        parsed.output_index.unwrap_or(0)
+                    };
+                    if custom_tool_call && parsed.sequence_number.is_none() {
+                        return Err(TransformError::DeserializationFailed(
+                            "Responses custom tool call output item added event: missing sequence_number"
+                                .to_string(),
+                        ));
+                    }
 
                     // Preserve Responses output_index as a correlation key. Stateful
                     // stream transforms remap it to a tool-relative index before
@@ -2995,7 +3029,8 @@ mod tests {
                 "input": "",
                 "name": "exec"
             },
-            "output_index": 7
+            "output_index": 7,
+            "sequence_number": 7
         });
         let start_chunk = adapter
             .stream_to_universal(custom_tool_start.clone())
@@ -3044,7 +3079,7 @@ mod tests {
             "type": "response.custom_tool_call_input.delta",
             "delta": "await tools.exec_command({cmd: \"true\"});",
             "item_id": "ctc_exec",
-            "sequence_number": 8,
+            "sequence_number": u64::from(u32::MAX) + 1,
             "output_index": 7
         });
         let delta_chunk = adapter
@@ -3102,6 +3137,68 @@ mod tests {
         assert!(err
             .to_string()
             .contains("Responses custom tool call input delta event"));
+    }
+
+    #[test]
+    fn test_responses_stream_custom_tool_call_start_rejects_missing_required_fields() {
+        let adapter = ResponsesAdapter;
+        for payload in [
+            json!({
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "custom_tool_call",
+                    "name": "exec",
+                    "input": ""
+                },
+                "output_index": 7,
+                "sequence_number": 1
+            }),
+            json!({
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "custom_tool_call",
+                    "call_id": "call_exec",
+                    "input": ""
+                },
+                "output_index": 7,
+                "sequence_number": 1
+            }),
+            json!({
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "custom_tool_call",
+                    "call_id": "call_exec",
+                    "name": "exec"
+                },
+                "output_index": 7,
+                "sequence_number": 1
+            }),
+            json!({
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "custom_tool_call",
+                    "call_id": "call_exec",
+                    "name": "exec",
+                    "input": ""
+                },
+                "sequence_number": 1
+            }),
+            json!({
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "custom_tool_call",
+                    "call_id": "call_exec",
+                    "name": "exec",
+                    "input": ""
+                },
+                "output_index": 7
+            }),
+        ] {
+            let err = adapter
+                .stream_to_universal(payload)
+                .expect_err("malformed custom tool start should fail");
+            assert!(matches!(err, TransformError::DeserializationFailed(_)));
+        }
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -303,6 +303,7 @@ enum ResponsesOutputItemAddedItem {
     CustomToolCall {
         call_id: String,
         name: String,
+        // Required by the Responses schema; input deltas carry its streamed content.
         #[serde(rename = "input")]
         _input: String,
     },

--- a/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms-streaming.test.ts.snap
@@ -9849,570 +9849,567 @@ data: {"candidates":[{"content":{"parts":[{"text":""}],"role":"model"},"finishRe
 
 exports[`streaming: responses → anthropic > complexReasoningRequest > streaming 1`] = `
 "event: response.created
-data: {"response":{"id":"msg_01E9HYVD5q13m6p2wwxQYUAX","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":109,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":110}},"type":"response.created"}
+data: {"response":{"id":"msg_01E9HYVD5q13m6p2wwxQYUAX","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":109,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":110}},"sequence_number":0,"type":"response.created"}
 
 event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"response":{"id":"msg_01E9HYVD5q13m6p2wwxQYUAX","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":109,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":110}},"sequence_number":1,"type":"response.in_progress"}
+
+:
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"Let","output_index":0,"sequence_number":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"Let","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" me think about this step by step. We have a digital clock that shows times from 00:00 to 23:59, which means there are 24 hours × 60 minutes = 1440","output_index":0,"sequence_number":1,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" me think about this step by step. We have a digital clock that shows times from 00:00 to 23:59, which means there are 24 hours × 60 minutes = 1440","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" different times displayed.\\n\\nEach time has 4 digits in the format HH:MM.","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" different times displayed.\\n\\nEach time has 4 digits in the format HH:MM.","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"\\n\\nLet me count how often each digit (0-9) appears.\\n\\nFor the hours (00-23):\\n- First digit (","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"\\n\\nLet me count how often each digit (0-9) appears.\\n\\nFor the hours (00-23):\\n- First digit (","output_index":0,"sequence_number":5,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"tens of hours): \\n  - 0 appears in: 00-09 (10 times)\\n  - 1 appears in: 10","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"tens of hours): \\n  - 0 appears in: 00-09 (10 times)\\n  - 1 appears in: 10","output_index":0,"sequence_number":6,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"-19 (10 times)\\n  - 2 appears in: 20-23 (4 times)\\n  - Total appearances per complete day","output_index":0,"sequence_number":5,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"-19 (10 times)\\n  - 2 appears in: 20-23 (4 times)\\n  - Total appearances per complete day","output_index":0,"sequence_number":7,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":": 10+10+4 = 24 times\\n\\n- Second digit (units of hours):\\n  - 0 appears in: 00, 10, 20 (3 times)\\n  -","output_index":0,"sequence_number":6,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":": 10+10+4 = 24 times\\n\\n- Second digit (units of hours):\\n  - 0 appears in: 00, 10, 20 (3 times)\\n  -","output_index":0,"sequence_number":8,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" 1 appears in: 01, 11, 21 (3 times)\\n  - 2 appears in: 02, 12, 22 (3 times)\\n  - 3 appears in: 03, 13, 23 (3","output_index":0,"sequence_number":7,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" 1 appears in: 01, 11, 21 (3 times)\\n  - 2 appears in: 02, 12, 22 (3 times)\\n  - 3 appears in: 03, 13, 23 (3","output_index":0,"sequence_number":9,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" times)\\n  - 4 appears in: 04, 14 (2 times)\\n  - 5 appears in: 05, 15 (2 times)\\n  - 6 appears in: 06, 16 ","output_index":0,"sequence_number":8,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" times)\\n  - 4 appears in: 04, 14 (2 times)\\n  - 5 appears in: 05, 15 (2 times)\\n  - 6 appears in: 06, 16 ","output_index":0,"sequence_number":10,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"(2 times)\\n  - 7 appears in: 07, 17 (2 times)\\n  - 8 appears in: 08, 18 (2 times)\\n  - 9 appears in: 09, 19 (2 times","output_index":0,"sequence_number":9,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"(2 times)\\n  - 7 appears in: 07, 17 (2 times)\\n  - 8 appears in: 08, 18 (2 times)\\n  - 9 appears in: 09, 19 (2 times","output_index":0,"sequence_number":11,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":")\\n\\nFor the minutes (00-59):\\n- First digit (tens of minutes):\\n  - 0 appears in: 00-09 (10 times)\\n  - 1 appears in: 10-19","output_index":0,"sequence_number":10,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":")\\n\\nFor the minutes (00-59):\\n- First digit (tens of minutes):\\n  - 0 appears in: 00-09 (10 times)\\n  - 1 appears in: 10-19","output_index":0,"sequence_number":12,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" (10 times)\\n","output_index":0,"sequence_number":11,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" (10 times)\\n","output_index":0,"sequence_number":13,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"  - 2 appears in:","output_index":0,"sequence_number":12,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"  - 2 appears in:","output_index":0,"sequence_number":14,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" 20-29 (10 times)\\n  - 3 appears in: 30-39 (10 times)\\n  - 4 appears in: 40-49 (10 times)\\n  - 5 appears in: 50-59 (10","output_index":0,"sequence_number":13,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" 20-29 (10 times)\\n  - 3 appears in: 30-39 (10 times)\\n  - 4 appears in: 40-49 (10 times)\\n  - 5 appears in: 50-59 (10","output_index":0,"sequence_number":15,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" times)\\n  - Each digit 0-5 shows up 10 times in this position\\n\\n- Second digit (units of minutes):\\n  - All","output_index":0,"sequence_number":14,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" times)\\n  - Each digit 0-5 shows up 10 times in this position\\n\\n- Second digit (units of minutes):\\n  - All","output_index":0,"sequence_number":16,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" digits 0-9 cycle through 6 times across the minute range, appearing once","output_index":0,"sequence_number":15,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" digits 0-9 cycle through 6 times across the minute range, appearing once","output_index":0,"sequence_number":17,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" in each group of 10 minutes\\n\\nNow I need to combine these frequencies. Since there are 1440 total times in a day, I","output_index":0,"sequence_number":16,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" in each group of 10 minutes\\n\\nNow I need to combine these frequencies. Since there are 1440 total times in a day, I","output_index":0,"sequence_number":18,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"'ll multiply the hourly digit frequencies by 60 (the number of minutes)","output_index":0,"sequence_number":17,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"'ll multiply the hourly digit frequencies by 60 (the number of minutes)","output_index":0,"sequence_number":19,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" and the minute digit frequencies by 24 (the number of hours).","output_index":0,"sequence_number":18,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" and the minute digit frequencies by 24 (the number of hours).","output_index":0,"sequence_number":20,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"\\n\\nFor","output_index":0,"sequence_number":19,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"\\n\\nFor","output_index":0,"sequence_number":21,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" the tens place of hours: 0 appears in hours 00-09 (10 hours ×","output_index":0,"sequence_number":20,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" the tens place of hours: 0 appears in hours 00-09 (10 hours ×","output_index":0,"sequence_number":22,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" 60 minutes = 600 occurrences), 1 appears in hours 10-19 (10 × 60 = 600), and ","output_index":0,"sequence_number":21,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" 60 minutes = 600 occurrences), 1 appears in hours 10-19 (10 × 60 = 600), and ","output_index":0,"sequence_number":23,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"2 appears in hours 20-23 (4 × 60 = 240). For the units place of hours: 0 shows up in hours 00, 10,","output_index":0,"sequence_number":22,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"2 appears in hours 20-23 (4 × 60 = 240). For the units place of hours: 0 shows up in hours 00, 10,","output_index":0,"sequence_number":24,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" 20 (3 × 60 = 180 times), 1 appears in hours 01, 11, 21 (3 × ","output_index":0,"sequence_number":23,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" 20 (3 × 60 = 180 times), 1 appears in hours 01, 11, 21 (3 × ","output_index":0,"sequence_number":25,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"60 = 180 times), and this pattern continues for each digit.","output_index":0,"sequence_number":24,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"60 = 180 times), and this pattern continues for each digit.","output_index":0,"sequence_number":26,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" ","output_index":0,"sequence_number":25,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" ","output_index":0,"sequence_number":27,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"08, 18, each shows 60 times = 2 × 60 = 120 times\\n- 9: appears in hours 09, 19, each shows 60 times = 2 × 60 = 120 times","output_index":0,"sequence_number":26,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"08, 18, each shows 60 times = 2 × 60 = 120 times\\n- 9: appears in hours 09, 19, each shows 60 times = 2 × 60 = 120 times","output_index":0,"sequence_number":28,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"\\n\\nFor the tens place in minutes, each digit 0-4","output_index":0,"sequence_number":27,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"\\n\\nFor the tens place in minutes, each digit 0-4","output_index":0,"sequence_number":29,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" appears across a 10-minute span throughout all 24 hours, giving","output_index":0,"sequence_number":28,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" appears across a 10-minute span throughout all 24 hours, giving","output_index":0,"sequence_number":30,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" 10 × 24 = 240 occurrences per digit. This covers","output_index":0,"sequence_number":29,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" 10 × 24 = 240 occurrences per digit. This covers","output_index":0,"sequence_number":31,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" minutes 00-09, 10-19, 20-29, 30-39, and 40-49 respectively.","output_index":0,"sequence_number":30,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" minutes 00-09, 10-19, 20-29, 30-39, and 40-49 respectively.","output_index":0,"sequence_number":32,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"\\n\\nIn","output_index":0,"sequence_number":31,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"\\n\\nIn","output_index":0,"sequence_number":33,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" the units place of minutes, all digits 0-9 cycle through 6 times each hour (appearing in x0, x1, x","output_index":0,"sequence_number":32,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" the units place of minutes, all digits 0-9 cycle through 6 times each hour (appearing in x0, x1, x","output_index":0,"sequence_number":34,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"2... x9), so 6 × 24 = 144 times daily.\\n\\nTall","output_index":0,"sequence_number":33,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"2... x9), so 6 × 24 = 144 times daily.\\n\\nTall","output_index":0,"sequence_number":35,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"ying up digit 0: it appears 600 times in the","output_index":0,"sequence_number":34,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"ying up digit 0: it appears 600 times in the","output_index":0,"sequence_number":36,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" first position, 180 in the second, 240 in the third, and 144 in the fourth, totaling 1164 occurrences.","output_index":0,"sequence_number":35,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" first position, 180 in the second, 240 in the third, and 144 in the fourth, totaling 1164 occurrences.","output_index":0,"sequence_number":37,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"\\n\\nDigit","output_index":0,"sequence_number":36,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"\\n\\nDigit","output_index":0,"sequence_number":38,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" 1 matches this same distribution—1164 total","output_index":0,"sequence_number":37,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" 1 matches this same distribution—1164 total","output_index":0,"sequence_number":39,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":". Digit 2 appears less frequently in the first position (only 240 times, since","output_index":0,"sequence_number":38,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":". Digit 2 appears less frequently in the first position (only 240 times, since","output_index":0,"sequence_number":40,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" it only shows up in 20:xx","output_index":0,"sequence_number":39,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" it only shows up in 20:xx","output_index":0,"sequence_number":41,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"-23:xx), bringing its total to 804. Digits 3 ","output_index":0,"sequence_number":40,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"-23:xx), bringing its total to 804. Digits 3 ","output_index":0,"sequence_number":42,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"through 5 don't appear in the first position at all, with digit 3","output_index":0,"sequence_number":41,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"through 5 don't appear in the first position at all, with digit 3","output_index":0,"sequence_number":43,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" reaching 564 total and digits 4 and 5 each totaling 504. Digit 6 appears 0 times in the third","output_index":0,"sequence_number":42,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" reaching 564 total and digits 4 and 5 each totaling 504. Digit 6 appears 0 times in the third","output_index":0,"sequence_number":44,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" position since minutes only go up to 59.","output_index":0,"sequence_number":43,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" position since minutes only go up to 59.","output_index":0,"sequence_number":45,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"\\n\\nDigits","output_index":0,"sequence_number":44,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"\\n\\nDigits","output_index":0,"sequence_number":46,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" 7, 8, and 9 follow the same pattern as digits 4 and 5—","output_index":0,"sequence_number":45,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" 7, 8, and 9 follow the same pattern as digits 4 and 5—","output_index":0,"sequence_number":47,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"they never appear in the first position or third position, giving each a total of 264 occ","output_index":0,"sequence_number":46,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"they never appear in the first position or third position, giving each a total of 264 occ","output_index":0,"sequence_number":48,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"urrences. Adding everything up: 1164 + 1164 + 804 + 564 + 504 + 504 + 264 + 264 + 264 +","output_index":0,"sequence_number":47,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"urrences. Adding everything up: 1164 + 1164 + 804 + 564 + 504 + 504 + 264 + 264 + 264 +","output_index":0,"sequence_number":49,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" 264 = 5760. Since there are 1440 minutes in a day, this checks out.","output_index":0,"sequence_number":48,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" 264 = 5760. Since there are 1440 minutes in a day, this checks out.","output_index":0,"sequence_number":50,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"\\n\\nThe digits","output_index":0,"sequence_number":49,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"\\n\\nThe digits","output_index":0,"sequence_number":51,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" 0 and 1 dominate with 1164 appearances each (about 20.21%), while 6 through 9 are","output_index":0,"sequence_number":50,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" 0 and 1 dominate with 1164 appearances each (about 20.21%), while 6 through 9 are","output_index":0,"sequence_number":52,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" the least frequent at 264 each (roughly 4.58%). For digit 1 specifically","output_index":0,"sequence_number":51,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" the least frequent at 264 each (roughly 4.58%). For digit 1 specifically","output_index":0,"sequence_number":53,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" in the first position, the hours 10-19 contribute 600 occurrences across all ","output_index":0,"sequence_number":52,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" in the first position, the hours 10-19 contribute 600 occurrences across all ","output_index":0,"sequence_number":54,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"60 minutes of each hour.","output_index":0,"sequence_number":53,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"60 minutes of each hour.","output_index":0,"sequence_number":55,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+
+:
+
+:
+
+:
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"content_index":0,"delta":"# Digital Clock Digit Frequency Analysis\\n\\nLooking at all times from **","output_index":1,"sequence_number":56,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"# Digital Clock Digit Frequency Analysis\\n\\nLooking at all times from **","output_index":1,"sequence_number":54,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"00:00 to 23:59** (1,440 different times), let me count each digit's","output_index":1,"sequence_number":57,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"00:00 to 23:59** (1,440 different times), let me count each digit's","output_index":1,"sequence_number":55,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" appearances:\\n\\n## Breakdown by Position\\n\\n**Position 1 (tens of hours):**\\n- 0: 600","output_index":1,"sequence_number":58,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" appearances:\\n\\n## Breakdown by Position\\n\\n**Position 1 (tens of hours):**\\n- 0: 600","output_index":1,"sequence_number":56,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" times (hours 00-09)\\n- 1: 600 times (hours 10-19)\\n- 2: 240 times (hours 20-23)\\n\\n**Position 2 (units of hours):**\\n- 0-","output_index":1,"sequence_number":59,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" times (hours 00-09)\\n- 1: 600 times (hours 10-19)\\n- 2: 240 times (hours 20-23)\\n\\n**Position 2 (units of hours):**\\n- 0-","output_index":1,"sequence_number":57,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"3: 180 times each (appear in 3 hours)\\n- 4-9: 120 times each (appear in","output_index":1,"sequence_number":60,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"3: 180 times each (appear in 3 hours)\\n- 4-9: 120 times each (appear in","output_index":1,"sequence_number":58,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 2 hours)\\n\\n**Position 3 (tens of minutes):**\\n- 0-5: 240 times each (10 minutes × 24 hours)\\n\\n**Position 4 (units of","output_index":1,"sequence_number":61,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 2 hours)\\n\\n**Position 3 (tens of minutes):**\\n- 0-5: 240 times each (10 minutes × 24 hours)\\n\\n**Position 4 (units of","output_index":1,"sequence_number":59,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" minutes):**\\n- 0-9: 144 times each (6 times per hour × 24 hours)\\n\\n## Total Count\\n\\n- **0: 1,164 times**","output_index":1,"sequence_number":62,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" minutes):**\\n- 0-9: 144 times each (6 times per hour × 24 hours)\\n\\n## Total Count\\n\\n- **0: 1,164 times**","output_index":1,"sequence_number":60,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"\\n- **1: 1,164 times**\\n- 2: 804 times\\n- 3: 564 times\\n- 4: 504 times\\n- 5: 504 times\\n- 6: 264 times\\n- 7: ","output_index":1,"sequence_number":63,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"\\n- **1: 1,164 times**\\n- 2: 804 times\\n- 3: 564 times\\n- 4: 504 times\\n- 5: 504 times\\n- 6: 264 times\\n- 7: ","output_index":1,"sequence_number":61,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"264 times\\n- 8: 264 times\\n- 9: 264 times\\n\\n## Results\\n\\n**Most Common:** **0 and 1** (tied)\\n- 1,164 out","output_index":1,"sequence_number":64,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"264 times\\n- 8: 264 times\\n- 9: 264 times\\n\\n## Results\\n\\n**Most Common:** **0 and 1** (tied)\\n- 1,164 out","output_index":1,"sequence_number":62,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" of 5,760 total digits\\n- **20.21%** each\\n\\n**Rarest:** **6, 7, 8, and 9** (tied)\\n-","output_index":1,"sequence_number":65,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" of 5,760 total digits\\n- **20.21%** each\\n\\n**Rarest:** **6, 7, 8, and 9** (tied)\\n-","output_index":1,"sequence_number":63,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 264 out of 5,760 total digits  \\n- **4.58%** each\\n\\nThe digits 0 and 1 dominate because","output_index":1,"sequence_number":66,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 264 out of 5,760 total digits  \\n- **4.58%** each\\n\\nThe digits 0 and 1 dominate because","output_index":1,"sequence_number":64,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" they appear frequently in the hour positions, while 6-9 never appear in the tens","output_index":1,"sequence_number":67,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" they appear frequently in the hour positions, while 6-9 never appear in the tens","output_index":1,"sequence_number":65,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" places.","output_index":1,"sequence_number":68,"type":"response.output_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":" places.","output_index":1,"sequence_number":66,"type":"response.output_text.delta"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+:
 
 event: response.completed
-data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":109,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":2786,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":2895}},"sequence_number":67,"type":"response.completed"}
+data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":109,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":2786,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":2895}},"sequence_number":69,"type":"response.completed"}
 
 "
 `;
 
 exports[`streaming: responses → anthropic > multimodalRequest > streaming 1`] = `
 "event: response.created
-data: {"response":{"id":"msg_015qJrapjhE1vrnqbNoGsknc","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":278,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":279}},"type":"response.created"}
+data: {"response":{"id":"msg_015qJrapjhE1vrnqbNoGsknc","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":278,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":279}},"sequence_number":0,"type":"response.created"}
 
 event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"response":{"id":"msg_015qJrapjhE1vrnqbNoGsknc","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":278,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":279}},"sequence_number":1,"type":"response.in_progress"}
+
+:
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"#","output_index":0,"sequence_number":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"#","output_index":0,"sequence_number":2,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" Image Description\\n\\nThis is an adorable photograph of","output_index":0,"sequence_number":1,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" Image Description\\n\\nThis is an adorable photograph of","output_index":0,"sequence_number":3,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" a **young tabby kitten** lying on a light","output_index":0,"sequence_number":2,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" a **young tabby kitten** lying on a light","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" wooden floor. Here are the key details:\\n\\n## The","output_index":0,"sequence_number":3,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" wooden floor. Here are the key details:\\n\\n## The","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" Kitten\\n- **Pose**: The kitten is lying on its side with","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" Kitten\\n- **Pose**: The kitten is lying on its side with","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" its head tilted, looking directly at the camera with an endearing, curious expression\\n- **Coloring**: Gray","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" its head tilted, looking directly at the camera with an endearing, curious expression\\n- **Coloring**: Gray","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"/brown tabby pattern with distinctive stripes\\n- **Eyes**: Large, bright yellow","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"/brown tabby pattern with distinctive stripes\\n- **Eyes**: Large, bright yellow","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"-green eyes that are very expressive and prominent\\n- **Features**: Pink nose, white whis","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"-green eyes that are very expressive and prominent\\n- **Features**: Pink nose, white whis","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"kers, and fluffy fur with the characteristic \\"M\\" marking on the","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"kers, and fluffy fur with the characteristic \\"M\\" marking on the","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" forehead typical of tabby cats\\n- **Paws**: One front paw is extended forward on","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" forehead typical of tabby cats\\n- **Paws**: One front paw is extended forward on","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" the floor\\n\\n## Background\\n- Clean, minimalist setting with a white wall\\n- Light wooden flo","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" the floor\\n\\n## Background\\n- Clean, minimalist setting with a white wall\\n- Light wooden flo","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"oring (appears to be laminate or hardwood)\\n- Blurred background suggesting an","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"oring (appears to be laminate or hardwood)\\n- Blurred background suggesting an","output_index":0,"sequence_number":13,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" indoor home environment\\n- Some indistinct furniture or objects visible but","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" indoor home environment\\n- Some indistinct furniture or objects visible but","output_index":0,"sequence_number":14,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" out of focus\\n\\nThe image captures a sweet, playful moment with excellent focus on the kitten's face","output_index":0,"sequence_number":13,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" out of focus\\n\\nThe image captures a sweet, playful moment with excellent focus on the kitten's face","output_index":0,"sequence_number":15,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" and creates a warm, inviting feeling typical of pet photography.","output_index":0,"sequence_number":14,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" and creates a warm, inviting feeling typical of pet photography.","output_index":0,"sequence_number":16,"type":"response.output_text.delta"}
 
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+:
 
 event: response.completed
-data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":278,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":245,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":523}},"sequence_number":15,"type":"response.completed"}
+data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":278,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":245,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":523}},"sequence_number":17,"type":"response.completed"}
 
 "
 `;
 
 exports[`streaming: responses → anthropic > parallelToolCallsRequest > streaming 1`] = `
 "event: response.created
-data: {"response":{"id":"msg_013yAMgJeZPRWy9KKkhPkh43","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":757,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":758}},"type":"response.created"}
+data: {"response":{"id":"msg_013yAMgJeZPRWy9KKkhPkh43","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":757,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":758}},"sequence_number":0,"type":"response.created"}
 
 event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"response":{"id":"msg_013yAMgJeZPRWy9KKkhPkh43","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":757,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":758}},"sequence_number":1,"type":"response.in_progress"}
+
+:
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"The","output_index":0,"sequence_number":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"The","output_index":0,"sequence_number":2,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" current weather is:\\n\\n**San Francisco, CA**: 65°F and sunny\\n\\n**New York, NY**: 45°F and cloudy","output_index":0,"sequence_number":1,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" current weather is:\\n\\n**San Francisco, CA**: 65°F and sunny\\n\\n**New York, NY**: 45°F and cloudy","output_index":0,"sequence_number":3,"type":"response.output_text.delta"}
 
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+:
 
 event: response.completed
-data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":757,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":35,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":792}},"sequence_number":2,"type":"response.completed"}
+data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":757,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":35,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":792}},"sequence_number":4,"type":"response.completed"}
 
 "
 `;
 
 exports[`streaming: responses → anthropic > reasoningRequest > streaming 1`] = `
 "event: response.created
-data: {"response":{"id":"msg_01XrumAP48awLewmcSBbzCPg","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":74,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":75}},"type":"response.created"}
+data: {"response":{"id":"msg_01XrumAP48awLewmcSBbzCPg","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":74,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":75}},"sequence_number":0,"type":"response.created"}
 
 event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"response":{"id":"msg_01XrumAP48awLewmcSBbzCPg","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":74,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":75}},"sequence_number":1,"type":"response.in_progress"}
+
+:
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"To","output_index":0,"sequence_number":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"To","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" find the average speed, I need to calculate the total distance traveled and divide it by the total time.\\n\\nStep 1: Calculate distance for the first part\\n-","output_index":0,"sequence_number":1,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" find the average speed, I need to calculate the total distance traveled and divide it by the total time.\\n\\nStep 1: Calculate distance for the first part\\n-","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" Speed = 60 mph\\n- Time = 2 hours\\n- Distance = Speed × Time = 60 × 2 = 120 miles\\n\\nStep 2: Calculate distance for the second part\\n- Speed = 80 mph\\n- Time =","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" Speed = 60 mph\\n- Time = 2 hours\\n- Distance = Speed × Time = 60 × 2 = 120 miles\\n\\nStep 2: Calculate distance for the second part\\n- Speed = 80 mph\\n- Time =","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" 1 hour\\n- Distance = Speed × Time = 80 × 1 = 80 miles\\n\\nStep 3: Calculate total distance\\n- Total distance = 120 + 80 = 200 miles\\n\\nStep 4: Calculate total time\\n- Total time = ","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" 1 hour\\n- Distance = Speed × Time = 80 × 1 = 80 miles\\n\\nStep 3: Calculate total distance\\n- Total distance = 120 + 80 = 200 miles\\n\\nStep 4: Calculate total time\\n- Total time = ","output_index":0,"sequence_number":5,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"2 + 1 = 3 hours\\n\\nStep 5: Calculate average speed\\n- Average speed = Total distance ÷ Total time\\n- Average speed = 200 ÷ 3 = 66.67 mph (","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"2 + 1 = 3 hours\\n\\nStep 5: Calculate average speed\\n- Average speed = Total distance ÷ Total time\\n- Average speed = 200 ÷ 3 = 66.67 mph (","output_index":0,"sequence_number":6,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"rounded to 2 decimal places)","output_index":0,"sequence_number":5,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"rounded to 2 decimal places)","output_index":0,"sequence_number":7,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+
+:
+
+:
+
+:
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"content_index":0,"delta":"# Solving for Average Speed\\n\\n## Step 1: Calculate distance for first segment","output_index":1,"sequence_number":8,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"# Solving for Average Speed\\n\\n## Step 1: Calculate distance for first segment","output_index":1,"sequence_number":6,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"\\n- Speed: 60 mph\\n- Time: 2 hours\\n- **Distance = 60 × 2 = 120 miles**\\n\\n## Step 2: Calculate distance for second segment\\n- Speed: 80 mph","output_index":1,"sequence_number":9,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"\\n- Speed: 60 mph\\n- Time: 2 hours\\n- **Distance = 60 × 2 = 120 miles**\\n\\n## Step 2: Calculate distance for second segment\\n- Speed: 80 mph","output_index":1,"sequence_number":7,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"\\n- Time: 1 hour\\n- **Distance = 80 × 1 = 80 miles**\\n\\n## Step 3: Find total distance\\n**Total distance = 120 + 80 = 200 miles**\\n\\n## Step 4: Find","output_index":1,"sequence_number":10,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"\\n- Time: 1 hour\\n- **Distance = 80 × 1 = 80 miles**\\n\\n## Step 3: Find total distance\\n**Total distance = 120 + 80 = 200 miles**\\n\\n## Step 4: Find","output_index":1,"sequence_number":8,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" total time\\n**Total time = 2 + 1 = 3 hours**\\n\\n## Step 5: Calculate average speed\\n**Average speed = Total distance ÷ Total time**\\n\\n**Average speed = 200 ÷ 3 = ","output_index":1,"sequence_number":11,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" total time\\n**Total time = 2 + 1 = 3 hours**\\n\\n## Step 5: Calculate average speed\\n**Average speed = Total distance ÷ Total time**\\n\\n**Average speed = 200 ÷ 3 = ","output_index":1,"sequence_number":9,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"66.67 mph**\\n\\n### Answer: The average speed is **66.67 mph** (or 66⅔ mph)","output_index":1,"sequence_number":12,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"66.67 mph**\\n\\n### Answer: The average speed is **66.67 mph** (or 66⅔ mph)","output_index":1,"sequence_number":10,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"\\n\\n---\\n\\n**Note:** Average speed is based on total distance and total time, not the average of the two speeds","output_index":1,"sequence_number":13,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"\\n\\n---\\n\\n**Note:** Average speed is based on total distance and total time, not the average of the two speeds","output_index":1,"sequence_number":11,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" (which would be 70 mph). This is why we must calculate the actual distances","output_index":1,"sequence_number":14,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" (which would be 70 mph). This is why we must calculate the actual distances","output_index":1,"sequence_number":12,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" traveled.","output_index":1,"sequence_number":15,"type":"response.output_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":" traveled.","output_index":1,"sequence_number":13,"type":"response.output_text.delta"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+:
 
 event: response.completed
-data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":74,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":494,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":568}},"sequence_number":14,"type":"response.completed"}
+data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":74,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":494,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":568}},"sequence_number":16,"type":"response.completed"}
 
 "
 `;
 
 exports[`streaming: responses → anthropic > reasoningWithOutput > streaming 1`] = `
 "event: response.created
-data: {"response":{"id":"msg_01FfNLZRubc8dQWzS5ErsqzT","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":42,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":43}},"type":"response.created"}
+data: {"response":{"id":"msg_01FfNLZRubc8dQWzS5ErsqzT","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":42,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":43}},"sequence_number":0,"type":"response.created"}
 
 event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"response":{"id":"msg_01FfNLZRubc8dQWzS5ErsqzT","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":42,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":43}},"sequence_number":1,"type":"response.in_progress"}
+
+:
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"This","output_index":0,"sequence_number":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"This","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" is a straightforward question about the color of the sky. The sky appears blue during the day under normal conditions. This is due","output_index":0,"sequence_number":1,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" is a straightforward question about the color of the sky. The sky appears blue during the day under normal conditions. This is due","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" to a phenomenon called Rayleigh scattering, where molecules in Earth's atmosphere scatter blue light from the sun more than other colors.\\n\\nHowever, I should note that the sky","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" to a phenomenon called Rayleigh scattering, where molecules in Earth's atmosphere scatter blue light from the sun more than other colors.\\n\\nHowever, I should note that the sky","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" can appear different colors at different times:\\n- Blue during a clear","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" can appear different colors at different times:\\n- Blue during a clear","output_index":0,"sequence_number":5,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" day\\n- Red, orange, pink during sunrise/sunset\\n- Gray or white when clou","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" day\\n- Red, orange, pink during sunrise/sunset\\n- Gray or white when clou","output_index":0,"sequence_number":6,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"dy\\n- Dark/black at night\\n- Other variations depending on conditions\\n\\nI'll","output_index":0,"sequence_number":5,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"dy\\n- Dark/black at night\\n- Other variations depending on conditions\\n\\nI'll","output_index":0,"sequence_number":7,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" give a simple, accurate answer that addresses the most common scenario.","output_index":0,"sequence_number":6,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" give a simple, accurate answer that addresses the most common scenario.","output_index":0,"sequence_number":8,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+
+:
+
+:
+
+:
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"content_index":0,"delta":"The sky is","output_index":1,"sequence_number":9,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"The sky is","output_index":1,"sequence_number":7,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" typically **blue** during the day when the weather is clear. \\n\\nThis happens because of how","output_index":1,"sequence_number":10,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" typically **blue** during the day when the weather is clear. \\n\\nThis happens because of how","output_index":1,"sequence_number":8,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" sunlight interacts with Earth's atmosphere - blue light is scattered more than other colors. However, the sky can appear different colors at different times:\\n\\n- **Red","output_index":1,"sequence_number":11,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" sunlight interacts with Earth's atmosphere - blue light is scattered more than other colors. However, the sky can appear different colors at different times:\\n\\n- **Red","output_index":1,"sequence_number":9,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":", orange, or pink** during sunrise and sunset\\n- **Gray or white** when cloudy\\n- **Dark blue to black** at night\\n- **Yellow","output_index":1,"sequence_number":12,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":", orange, or pink** during sunrise and sunset\\n- **Gray or white** when cloudy\\n- **Dark blue to black** at night\\n- **Yellow","output_index":1,"sequence_number":10,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" or orange** in areas with pollution or dust\\n\\nSo while we generally think of the sky as blue, its","output_index":1,"sequence_number":13,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" or orange** in areas with pollution or dust\\n\\nSo while we generally think of the sky as blue, its","output_index":1,"sequence_number":11,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" color actually varies quite a bit!","output_index":1,"sequence_number":14,"type":"response.output_text.delta"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":" color actually varies quite a bit!","output_index":1,"sequence_number":12,"type":"response.output_text.delta"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+:
 
 event: response.completed
-data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":42,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":260,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":302}},"sequence_number":13,"type":"response.completed"}
+data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":42,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":260,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":302}},"sequence_number":15,"type":"response.completed"}
 
 "
 `;
 
 exports[`streaming: responses → anthropic > simpleRequest > streaming 1`] = `
 "event: response.created
-data: {"response":{"id":"msg_01QuhHd1Xv5ZLfCUKDd7HSkL","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":43,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":44}},"type":"response.created"}
+data: {"response":{"id":"msg_01QuhHd1Xv5ZLfCUKDd7HSkL","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":43,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":44}},"sequence_number":0,"type":"response.created"}
 
 event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"response":{"id":"msg_01QuhHd1Xv5ZLfCUKDd7HSkL","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":43,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":44}},"sequence_number":1,"type":"response.in_progress"}
+
+:
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"This","output_index":0,"sequence_number":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"This","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":" is a straightforward factual question. The capital of France is Paris.","output_index":0,"sequence_number":1,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":" is a straightforward factual question. The capital of France is Paris.","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+
+:
+
+:
+
+:
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"","output_index":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"The capital of France is Paris.","output_index":1,"sequence_number":4,"type":"response.output_text.delta"}
 
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
-
-event: response.output_text.delta
-data: {"content_index":0,"delta":"The capital of France is Paris.","output_index":1,"sequence_number":2,"type":"response.output_text.delta"}
-
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+:
 
 event: response.completed
-data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":43,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":34,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":77}},"sequence_number":3,"type":"response.completed"}
+data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":43,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":34,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":77}},"sequence_number":5,"type":"response.completed"}
 
 "
 `;
 
 exports[`streaming: responses → anthropic > simpleRequestTruncated > streaming 1`] = `
 "event: response.created
-data: {"response":{"id":"msg_018E3CeuvKq25UkKdqfxRqpR","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":16,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":17}},"type":"response.created"}
+data: {"response":{"id":"msg_018E3CeuvKq25UkKdqfxRqpR","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":16,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":17}},"sequence_number":0,"type":"response.created"}
 
 event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"response":{"id":"msg_018E3CeuvKq25UkKdqfxRqpR","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":16,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":17}},"sequence_number":1,"type":"response.in_progress"}
+
+:
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"#","output_index":0,"sequence_number":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"#","output_index":0,"sequence_number":2,"type":"response.output_text.delta"}
 
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+:
 
 event: response.incomplete
-data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":16,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":17}},"sequence_number":1,"type":"response.incomplete"}
+data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":16,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":17}},"sequence_number":3,"type":"response.incomplete"}
 
 "
 `;
 
 exports[`streaming: responses → anthropic > systemMessageArrayContent > streaming 1`] = `
 "event: response.created
-data: {"response":{"id":"msg_01XZRZMwbv9rhv1Y9UA33m33","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":33,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":38}},"type":"response.created"}
+data: {"response":{"id":"msg_01XZRZMwbv9rhv1Y9UA33m33","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":33,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":38}},"sequence_number":0,"type":"response.created"}
 
 event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"response":{"id":"msg_01XZRZMwbv9rhv1Y9UA33m33","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":33,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":38}},"sequence_number":1,"type":"response.in_progress"}
+
+:
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"I'll help you find","output_index":0,"sequence_number":0,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"I'll help you find","output_index":0,"sequence_number":2,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" recent errors from the project logs. Let me query the data source for you.\\n\\n\`\`\`sql\\nSELECT ","output_index":0,"sequence_number":1,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" recent errors from the project logs. Let me query the data source for you.\\n\\n\`\`\`sql\\nSELECT ","output_index":0,"sequence_number":3,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"\\n  timestamp,\\n  error_message,\\n  error_code,\\n  severity,\\n  source\\nFROM \`abc","output_index":0,"sequence_number":2,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"\\n  timestamp,\\n  error_message,\\n  error_code,\\n  severity,\\n  source\\nFROM \`abc","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"-123.project_logs.logs\`\\nWHERE \\n  severity = 'ERROR'\\n  AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP","output_index":0,"sequence_number":3,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"-123.project_logs.logs\`\\nWHERE \\n  severity = 'ERROR'\\n  AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"(), INTERVAL 24 HOUR)\\nORDER BY timestamp DESC\\nLIMIT 100\\n\`\`\`\\n\\nThis query will:\\n- Filter for entries","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"(), INTERVAL 24 HOUR)\\nORDER BY timestamp DESC\\nLIMIT 100\\n\`\`\`\\n\\nThis query will:\\n- Filter for entries","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" with ERROR severity\\n- Look at the last 24 hours of logs\\n- Show the most recent errors first\\n- Limit to","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" with ERROR severity\\n- Look at the last 24 hours of logs\\n- Show the most recent errors first\\n- Limit to","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 100 results to keep it manageable\\n\\nCould you let me know if you'd like me to:\\n1.","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 100 results to keep it manageable\\n\\nCould you let me know if you'd like me to:\\n1.","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" Adjust the time window (e.g., last hour, last week)\\n2. Filter by specific","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" Adjust the time window (e.g., last hour, last week)\\n2. Filter by specific","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" error codes or sources\\n3. Group the errors to see which","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" error codes or sources\\n3. Group the errors to see which","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" are most common\\n4. Include additional fields from the logs","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" are most common\\n4. Include additional fields from the logs","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
 
-event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+:
 
 event: response.completed
-data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":33,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":224,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":257}},"sequence_number":10,"type":"response.completed"}
+data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":33,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":224,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":257}},"sequence_number":12,"type":"response.completed"}
 
 "
 `;
 
 exports[`streaming: responses → anthropic > toolCallRequest > streaming 1`] = `
 "event: response.created
-data: {"response":{"id":"msg_01QNRL9LEKaG2LpJHo7hLuW3","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":677,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":685}},"type":"response.created"}
-
-event: response.output_item.added
-data: {"item":{"arguments":"","call_id":"toolu_01UoCBs6hrWsp9CLkLyFkX1u","name":"get_weather","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":0,"type":"response.output_item.added"}
-
-event: response.function_call_arguments.delta
-data: {"delta":"","output_index":0,"type":"response.function_call_arguments.delta"}
-
-event: response.function_call_arguments.delta
-data: {"delta":"{\\"locatio","output_index":0,"sequence_number":1,"type":"response.function_call_arguments.delta"}
-
-event: response.function_call_arguments.delta
-data: {"delta":"n\\": \\"","output_index":0,"sequence_number":2,"type":"response.function_call_arguments.delta"}
-
-event: response.function_call_arguments.delta
-data: {"delta":"San Fr","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
-
-event: response.function_call_arguments.delta
-data: {"delta":"ancisco, CA\\"}","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+data: {"response":{"id":"msg_01QNRL9LEKaG2LpJHo7hLuW3","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":677,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":685}},"sequence_number":0,"type":"response.created"}
 
 event: response.in_progress
-data: {"sequence_number":0,"type":"response.in_progress"}
+data: {"response":{"id":"msg_01QNRL9LEKaG2LpJHo7hLuW3","model":"claude-sonnet-4-5-20250929","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":677,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":685}},"sequence_number":1,"type":"response.in_progress"}
+
+event: response.output_item.added
+data: {"item":{"arguments":"","call_id":"toolu_01UoCBs6hrWsp9CLkLyFkX1u","name":"get_weather","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+:
+
+event: response.function_call_arguments.delta
+data: {"delta":"{\\"locatio","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+event: response.function_call_arguments.delta
+data: {"delta":"n\\": \\"","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+event: response.function_call_arguments.delta
+data: {"delta":"San Fr","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+event: response.function_call_arguments.delta
+data: {"delta":"ancisco, CA\\"}","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+:
 
 event: response.completed
-data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":677,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":41,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":718}},"sequence_number":5,"type":"response.completed"}
+data: {"response":{"id":"resp_transformed","model":"transformed","object":"response","output":[],"status":"completed","usage":{"input_tokens":677,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":41,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":718}},"sequence_number":7,"type":"response.completed"}
 
 "
 `;
@@ -10421,179 +10418,182 @@ exports[`streaming: responses → google > complexReasoningRequest > streaming 1
 "event: response.created
 data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":65,"output_tokens_details":{"reasoning_tokens":65},"total_tokens":140}},"sequence_number":0,"type":"response.created"}
 
-event: response.reasoning_summary_text.delta
-data: {"delta":"**Defining the Objective**\\n\\nOkay, I'm working on the problem of identifying the most and least frequent digits on a digital clock over a 24-hour period. I've begun to analyze the parameters, and I'm focusing on breaking down the time range (00:00 to 23:59) to count the digit appearances methodically. This approach is key to an effective solution.\\n\\n\\n","output_index":0,"sequence_number":1,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+event: response.in_progress
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":65,"output_tokens_details":{"reasoning_tokens":65},"total_tokens":140}},"sequence_number":1,"type":"response.in_progress"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Analyzing Digit Frequencies**\\n\\nI'm now diving deep into the specifics of digit counting, broken down by position. I'm focusing on the units digit of the minutes (M2). The total number of digits displayed is 5760 (1440 * 4). I've got to determine which numbers appear most and least. I'm breaking down how often each digit (0-9) appears in each position to find the solution. I am trying to determine a method to make this problem more efficient.\\n\\n\\n","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Defining the Objective**\\n\\nOkay, I'm working on the problem of identifying the most and least frequent digits on a digital clock over a 24-hour period. I've begun to analyze the parameters, and I'm focusing on breaking down the time range (00:00 to 23:59) to count the digit appearances methodically. This approach is key to an effective solution.\\n\\n\\n","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Calculating Digit Frequencies**\\n\\nI'm now determining the frequency of each digit in the minutes' tens place (M1). I have calculated that for M2, each digit (0-9) appears 144 times. I'm focusing on the position analysis to determine the occurrences of each digit. M1 cycles from 0-5 for every 10 minutes. I am analyzing the implications across the entire 24-hour period (00:00 to 23:59). My current focus is to efficiently determine the patterns.\\n\\n\\n","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Analyzing Digit Frequencies**\\n\\nI'm now diving deep into the specifics of digit counting, broken down by position. I'm focusing on the units digit of the minutes (M2). The total number of digits displayed is 5760 (1440 * 4). I've got to determine which numbers appear most and least. I'm breaking down how often each digit (0-9) appears in each position to find the solution. I am trying to determine a method to make this problem more efficient.\\n\\n\\n","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Calculating Frequency Analysis**\\n\\nI've completed the initial frequency calculations for each digit position. Specifically, for M2, each digit appears 144 times, and for M1, digits 0-5 each occur 240 times, and 6-9 appear 0 times. My next step is to finalize the H1 and H2 digit occurrences, addressing the complexity of the hour constraints. I'll summarize these totals into the final tally.\\n\\n\\n","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Calculating Digit Frequencies**\\n\\nI'm now determining the frequency of each digit in the minutes' tens place (M1). I have calculated that for M2, each digit (0-9) appears 144 times. I'm focusing on the position analysis to determine the occurrences of each digit. M1 cycles from 0-5 for every 10 minutes. I am analyzing the implications across the entire 24-hour period (00:00 to 23:59). My current focus is to efficiently determine the patterns.\\n\\n\\n","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Finalizing Calculations**\\n\\nI'm now finalizing the calculations for the tens (H1) and units (H2) of the hours. I've corrected an error in H2 calculations and now have a firm grasp on the frequency distribution. I'm focusing on consolidating all of the totals across the H1, H2, M1, and M2 positions for a complete, accurate count. The final step is determining the most and least frequent digits.\\n\\n\\n","output_index":0,"sequence_number":5,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Calculating Frequency Analysis**\\n\\nI've completed the initial frequency calculations for each digit position. Specifically, for M2, each digit appears 144 times, and for M1, digits 0-5 each occur 240 times, and 6-9 appear 0 times. My next step is to finalize the H1 and H2 digit occurrences, addressing the complexity of the hour constraints. I'll summarize these totals into the final tally.\\n\\n\\n","output_index":0,"sequence_number":5,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Calculating Total Counts**\\n\\nI'm now consolidating the frequency counts for all digit positions. Specifically, I've totaled each digit's occurrences in H1, H2, M1, and M2, accounting for all time constraints. From this analysis, I will determine the most and least frequent digits displayed over the entire 24-hour cycle. The final step is to verify the results.\\n\\n\\n","output_index":0,"sequence_number":6,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Finalizing Calculations**\\n\\nI'm now finalizing the calculations for the tens (H1) and units (H2) of the hours. I've corrected an error in H2 calculations and now have a firm grasp on the frequency distribution. I'm focusing on consolidating all of the totals across the H1, H2, M1, and M2 positions for a complete, accurate count. The final step is determining the most and least frequent digits.\\n\\n\\n","output_index":0,"sequence_number":6,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Refining Calculation Accuracy**\\n\\nI'm now implementing the calculation refinements based on the detailed analysis. I've re-examined the H2 position, accounting for the varying hour constraints, and updated the frequency totals for digits 0-9. I'm focusing on validating these counts to ensure an accurate base for finding the most and least frequent digits.\\n\\n\\n","output_index":0,"sequence_number":7,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Calculating Total Counts**\\n\\nI'm now consolidating the frequency counts for all digit positions. Specifically, I've totaled each digit's occurrences in H1, H2, M1, and M2, accounting for all time constraints. From this analysis, I will determine the most and least frequent digits displayed over the entire 24-hour cycle. The final step is to verify the results.\\n\\n\\n","output_index":0,"sequence_number":7,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Refining Calculation Accuracy**\\n\\nI'm now implementing calculation refinements based on the updated analysis of each digit position. I have re-evaluated the H2 position, accounting for the unique hour constraints, and have updated the frequency totals for digits 0-9. I'm focusing on validation of these counts.\\n\\n\\n","output_index":0,"sequence_number":8,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Refining Calculation Accuracy**\\n\\nI'm now implementing the calculation refinements based on the detailed analysis. I've re-examined the H2 position, accounting for the varying hour constraints, and updated the frequency totals for digits 0-9. I'm focusing on validating these counts to ensure an accurate base for finding the most and least frequent digits.\\n\\n\\n","output_index":0,"sequence_number":8,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Refining Calculations**\\n\\nI'm now refining the accuracy of the counts, re-evaluating each digit's occurrences in the hours and minutes. I am now double-checking the H1 and H2 hour calculations, particularly the impact of the hour constraints (0-23). I've found a more reliable and efficient approach.\\n\\n\\n","output_index":0,"sequence_number":9,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Refining Calculation Accuracy**\\n\\nI'm now implementing calculation refinements based on the updated analysis of each digit position. I have re-evaluated the H2 position, accounting for the unique hour constraints, and have updated the frequency totals for digits 0-9. I'm focusing on validation of these counts.\\n\\n\\n","output_index":0,"sequence_number":9,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Refining Hour Calculation**\\n\\nI'm now implementing calculation refinements based on the detailed analysis. I've re-evaluated the H2 position, accounting for the unique hour constraints, and have updated the frequency totals for digits 0-9. I'm focusing on validating these counts to ensure an accurate base for finding the most and least frequent digits.\\n\\n\\n","output_index":0,"sequence_number":10,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Refining Calculations**\\n\\nI'm now refining the accuracy of the counts, re-evaluating each digit's occurrences in the hours and minutes. I am now double-checking the H1 and H2 hour calculations, particularly the impact of the hour constraints (0-23). I've found a more reliable and efficient approach.\\n\\n\\n","output_index":0,"sequence_number":10,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Refining Hour Calculation**\\n\\nI'm now implementing calculation refinements based on the detailed analysis. I've re-evaluated the H2 position, accounting for the unique hour constraints, and have updated the frequency totals for digits 0-9. I'm focusing on validating these counts to ensure an accurate base for finding the most and least frequent digits.\\n\\n\\n","output_index":0,"sequence_number":11,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"Let's break down the problem by counting the occurrences of each digit (0-9) across all possible times from 0","output_index":1,"sequence_number":11,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"Let's break down the problem by counting the occurrences of each digit (0-9) across all possible times from 0","output_index":1,"sequence_number":12,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"0:00 to 23:59.\\n\\nFirst, let's determine the total number of digits displayed.\\n*   There are 24 hours (00 to 23).\\n*   There are","output_index":1,"sequence_number":12,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"0:00 to 23:59.\\n\\nFirst, let's determine the total number of digits displayed.\\n*   There are 24 hours (00 to 23).\\n*   There are","output_index":1,"sequence_number":13,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 60 minutes in each hour (00 to 59).\\n*   Total number of times displayed = 24 hours * 60 minutes = 1440 times.\\n*   Each time (e.","output_index":1,"sequence_number":13,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 60 minutes in each hour (00 to 59).\\n*   Total number of times displayed = 24 hours * 60 minutes = 1440 times.\\n*   Each time (e.","output_index":1,"sequence_number":14,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"g., 01:23) consists of 4 digits.\\n*   Total number of digits displayed = 1440 times * 4 digits/time = 5760 digits.\\n\\nNow, let's","output_index":1,"sequence_number":14,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"g., 01:23) consists of 4 digits.\\n*   Total number of digits displayed = 1440 times * 4 digits/time = 5760 digits.\\n\\nNow, let's","output_index":1,"sequence_number":15,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" count the occurrences of each digit (0-9) by considering their positions:\\n\\n1.  **M2 (Units of Minutes - Rightmost digit):**\\n    *   This digit cycles through 0, 1, 2","output_index":1,"sequence_number":15,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" count the occurrences of each digit (0-9) by considering their positions:\\n\\n1.  **M2 (Units of Minutes - Rightmost digit):**\\n    *   This digit cycles through 0, 1, 2","output_index":1,"sequence_number":16,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":", ..., 9, 0, 1, ...\\n    *   In a 60-minute cycle (00-59), each digit (0-9) appears 6 times (e.g., ","output_index":1,"sequence_number":16,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":", ..., 9, 0, 1, ...\\n    *   In a 60-minute cycle (00-59), each digit (0-9) appears 6 times (e.g., ","output_index":1,"sequence_number":17,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"0 appears in :00, :10, :20, :30, :40, :50).\\n    *   This pattern repeats for all 24 hours.\\n    *   So, each","output_index":1,"sequence_number":17,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"0 appears in :00, :10, :20, :30, :40, :50).\\n    *   This pattern repeats for all 24 hours.\\n    *   So, each","output_index":1,"sequence_number":18,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" digit 0-9 appears: 6 occurrences/hour * 24 hours = **144 times** in the M2 position.\\n\\n2.  **M1 (Tens of Minutes - Second digit from right):**\\n    ","output_index":1,"sequence_number":18,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" digit 0-9 appears: 6 occurrences/hour * 24 hours = **144 times** in the M2 position.\\n\\n2.  **M1 (Tens of Minutes - Second digit from right):**\\n    ","output_index":1,"sequence_number":19,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"*   This digit cycles through 0, 1, 2, 3, 4, 5.\\n    *   In a 60-minute cycle (00-59):\\n        *   0 appears 1","output_index":1,"sequence_number":19,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"*   This digit cycles through 0, 1, 2, 3, 4, 5.\\n    *   In a 60-minute cycle (00-59):\\n        *   0 appears 1","output_index":1,"sequence_number":20,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"0 times (00-09)\\n        *   1 appears 10 times (10-19)\\n        *   2 appears 10 times (20-29)\\n        *   3","output_index":1,"sequence_number":20,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"0 times (00-09)\\n        *   1 appears 10 times (10-19)\\n        *   2 appears 10 times (20-29)\\n        *   3","output_index":1,"sequence_number":21,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" appears 10 times (30-39)\\n        *   4 appears 10 times (40-49)\\n        *   5 appears 10 times (50-59)\\n    ","output_index":1,"sequence_number":21,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" appears 10 times (30-39)\\n        *   4 appears 10 times (40-49)\\n        *   5 appears 10 times (50-59)\\n    ","output_index":1,"sequence_number":22,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"*   Digits 6, 7, 8, 9 never appear in this position.\\n    *   This pattern repeats for all 24 hours.\\n    *   So, each digit 0-5 appears: 10","output_index":1,"sequence_number":22,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"*   Digits 6, 7, 8, 9 never appear in this position.\\n    *   This pattern repeats for all 24 hours.\\n    *   So, each digit 0-5 appears: 10","output_index":1,"sequence_number":23,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" occurrences/hour * 24 hours = **240 times** in the M1 position.\\n\\n3.  **H2 (Units of Hours - Second digit from left):**\\n    *   This digit's range","output_index":1,"sequence_number":23,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" occurrences/hour * 24 hours = **240 times** in the M1 position.\\n\\n3.  **H2 (Units of Hours - Second digit from left):**\\n    *   This digit's range","output_index":1,"sequence_number":24,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" depends on the H1 digit.\\n    *   For hours 00-19 (H1 is 0 or 1): The H2 digit cycles 0, 1, ..., 9. Each digit appears once for","output_index":1,"sequence_number":24,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" depends on the H1 digit.\\n    *   For hours 00-19 (H1 is 0 or 1): The H2 digit cycles 0, 1, ..., 9. Each digit appears once for","output_index":1,"sequence_number":25,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" each hour (e.g., in 01:XX, the '1' appears 60 times). There are 20 such hours (00-19).\\n        *   So, for digits 0-9","output_index":1,"sequence_number":25,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" each hour (e.g., in 01:XX, the '1' appears 60 times). There are 20 such hours (00-19).\\n        *   So, for digits 0-9","output_index":1,"sequence_number":26,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":": 1 occurrence/hour * 60 minutes/hour * 20 hours = **1200 times**. *This is incorrect. The 1 occurrence/hour already means it is present in that hour for 60 minutes","output_index":1,"sequence_number":26,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":": 1 occurrence/hour * 60 minutes/hour * 20 hours = **1200 times**. *This is incorrect. The 1 occurrence/hour already means it is present in that hour for 60 minutes","output_index":1,"sequence_number":27,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":".*\\n        *   Let's rephrase: In hours 00-09 (10 hours), each digit 0-9 appears in the H2 position for 60 minutes. So, 10 hours * ","output_index":1,"sequence_number":27,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":".*\\n        *   Let's rephrase: In hours 00-09 (10 hours), each digit 0-9 appears in the H2 position for 60 minutes. So, 10 hours * ","output_index":1,"sequence_number":28,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"60 minutes = 600 occurrences for H2=0 (e.g. 00:XX), H2=1 (01:XX), ..., H2=9 (09:XX).\\n        *   Similarly","output_index":1,"sequence_number":28,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"60 minutes = 600 occurrences for H2=0 (e.g. 00:XX), H2=1 (01:XX), ..., H2=9 (09:XX).\\n        *   Similarly","output_index":1,"sequence_number":29,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":", in hours 10-19 (10 hours), each digit 0-9 appears in the H2 position for 60 minutes. So, another 10 hours * 60 minutes = 600 occurrences.","output_index":1,"sequence_number":29,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":", in hours 10-19 (10 hours), each digit 0-9 appears in the H2 position for 60 minutes. So, another 10 hours * 60 minutes = 600 occurrences.","output_index":1,"sequence_number":30,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"\\n        *   No, this counts the hours wrong.\\n        *   Let's think of it as: How many times does the number 'X' appear in H2 *for each minute*?\\n        *   H2","output_index":1,"sequence_number":30,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"\\n        *   No, this counts the hours wrong.\\n        *   Let's think of it as: How many times does the number 'X' appear in H2 *for each minute*?\\n        *   H2","output_index":1,"sequence_number":31,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" takes values from 0-9 in the hours 00-09 (e.g., for 01:MM, H2 is 1). So, for each of these 10 hours (00,","output_index":1,"sequence_number":31,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" takes values from 0-9 in the hours 00-09 (e.g., for 01:MM, H2 is 1). So, for each of these 10 hours (00,","output_index":1,"sequence_number":32,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 01, ..., 09), the H2 digit is constant for 60 minutes. So, digits 0-9 each appear 60 times. (e.g., '0' is H2 in ","output_index":1,"sequence_number":32,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 01, ..., 09), the H2 digit is constant for 60 minutes. So, digits 0-9 each appear 60 times. (e.g., '0' is H2 in ","output_index":1,"sequence_number":33,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"00:XX - 60 times; '1' is H2 in 01:XX - 60 times).\\n        *   Similarly, for hours 10-19 (e.g., for","output_index":1,"sequence_number":33,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"00:XX - 60 times; '1' is H2 in 01:XX - 60 times).\\n        *   Similarly, for hours 10-19 (e.g., for","output_index":1,"sequence_number":34,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 11:MM, H2 is 1). Each digit 0-9 appears 60 times. (e.g., '0' is H2 in 10:XX - 60 times; '","output_index":1,"sequence_number":34,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 11:MM, H2 is 1). Each digit 0-9 appears 60 times. (e.g., '0' is H2 in 10:XX - 60 times; '","output_index":1,"sequence_number":35,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"1' is H2 in 11:XX - 60 times).\\n        *   So, for digits 0-9 from hours 00-19: 60 (from 0X:MM","output_index":1,"sequence_number":35,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"1' is H2 in 11:XX - 60 times).\\n        *   So, for digits 0-9 from hours 00-19: 60 (from 0X:MM","output_index":1,"sequence_number":36,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":") + 60 (from 1X:MM) = **120 times each**.\\n    *   For hours 20-23 (H1 is 2): The H2 digit cycles 0,","output_index":1,"sequence_number":36,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":") + 60 (from 1X:MM) = **120 times each**.\\n    *   For hours 20-23 (H1 is 2): The H2 digit cycles 0,","output_index":1,"sequence_number":37,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 1, 2, 3. Each digit appears once for each hour for 60 minutes.\\n        *   0 appears in 20:XX (60 times).\\n        *   1 appears in 21:XX","output_index":1,"sequence_number":37,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 1, 2, 3. Each digit appears once for each hour for 60 minutes.\\n        *   0 appears in 20:XX (60 times).\\n        *   1 appears in 21:XX","output_index":1,"sequence_number":38,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" (60 times).\\n        *   2 appears in 22:XX (60 times).\\n        *   3 appears in 23:XX (60 times).\\n        *   Digits 4-9","output_index":1,"sequence_number":38,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" (60 times).\\n        *   2 appears in 22:XX (60 times).\\n        *   3 appears in 23:XX (60 times).\\n        *   Digits 4-9","output_index":1,"sequence_number":39,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" never appear in this range.\\n    *   Total for H2:\\n        *   Digits 0-3: 120 (from 00-19) + 60 (from 20-23)","output_index":1,"sequence_number":39,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" never appear in this range.\\n    *   Total for H2:\\n        *   Digits 0-3: 120 (from 00-19) + 60 (from 20-23)","output_index":1,"sequence_number":40,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" = **180 times each**.\\n        *   Digits 4-9: 120 (from 00-19) + 0 (from 20-23) = **120","output_index":1,"sequence_number":40,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" = **180 times each**.\\n        *   Digits 4-9: 120 (from 00-19) + 0 (from 20-23) = **120","output_index":1,"sequence_number":41,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" times each**.\\n\\n4.  **H1 (Tens of Hours - Leftmost digit):**\\n    *   This digit can be 0, 1, or 2.\\n    *   Digit 0 appears for hours 00","output_index":1,"sequence_number":41,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" times each**.\\n\\n4.  **H1 (Tens of Hours - Leftmost digit):**\\n    *   This digit can be 0, 1, or 2.\\n    *   Digit 0 appears for hours 00","output_index":1,"sequence_number":42,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"-09 (10 hours). For each hour, it's displayed for 60 minutes.\\n        *   10 hours * 60 minutes/hour = **600 times**.\\n    *   Digit 1 appears","output_index":1,"sequence_number":42,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"-09 (10 hours). For each hour, it's displayed for 60 minutes.\\n        *   10 hours * 60 minutes/hour = **600 times**.\\n    *   Digit 1 appears","output_index":1,"sequence_number":43,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" for hours 10-19 (10 hours). For each hour, it's displayed for 60 minutes.\\n        *   10 hours * 60 minutes/hour = **600 times**.","output_index":1,"sequence_number":43,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" for hours 10-19 (10 hours). For each hour, it's displayed for 60 minutes.\\n        *   10 hours * 60 minutes/hour = **600 times**.","output_index":1,"sequence_number":44,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"\\n    *   Digit 2 appears for hours 20-23 (4 hours). For each hour, it's displayed for 60 minutes.\\n        *   4 hours * 60 minutes/hour =","output_index":1,"sequence_number":44,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"\\n    *   Digit 2 appears for hours 20-23 (4 hours). For each hour, it's displayed for 60 minutes.\\n        *   4 hours * 60 minutes/hour =","output_index":1,"sequence_number":45,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" **240 times**.\\n    *   Digits 3-9 never appear in this position.\\n\\n**Summary of Counts for Each Digit:**\\n\\n| Digit | M2 (Units of Min) | M1 (Tens of Min) | H","output_index":1,"sequence_number":45,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" **240 times**.\\n    *   Digits 3-9 never appear in this position.\\n\\n**Summary of Counts for Each Digit:**\\n\\n| Digit | M2 (Units of Min) | M1 (Tens of Min) | H","output_index":1,"sequence_number":46,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"2 (Units of Hr) | H1 (Tens of Hr) | Total Count |\\n| :---- | :---------------- | :--------------- | :--------------- | :-------------- | :---------- |\\n| **0** | 144","output_index":1,"sequence_number":46,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"2 (Units of Hr) | H1 (Tens of Hr) | Total Count |\\n| :---- | :---------------- | :--------------- | :--------------- | :-------------- | :---------- |\\n| **0** | 144","output_index":1,"sequence_number":47,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"               | 240              | 180              | 600             | **1164**    |\\n| **1** | 144               | 240              | 180              ","output_index":1,"sequence_number":47,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"               | 240              | 180              | 600             | **1164**    |\\n| **1** | 144               | 240              | 180              ","output_index":1,"sequence_number":48,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"| 600             | **1164**    |\\n| **2** | 144               | 240              | 180              | 240             | **80","output_index":1,"sequence_number":48,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"| 600             | **1164**    |\\n| **2** | 144               | 240              | 180              | 240             | **80","output_index":1,"sequence_number":49,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"4**     |\\n| **3** | 144               | 240              | 180              | 0               | **564**     |\\n| **4** | 14","output_index":1,"sequence_number":49,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"4**     |\\n| **3** | 144               | 240              | 180              | 0               | **564**     |\\n| **4** | 14","output_index":1,"sequence_number":50,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"4               | 240              | 120              | 0               | **504**     |\\n| **5** | 144               | 240              | 120","output_index":1,"sequence_number":50,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"4               | 240              | 120              | 0               | **504**     |\\n| **5** | 144               | 240              | 120","output_index":1,"sequence_number":51,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"              | 0               | **504**     |\\n| **6** | 144               | 0                | 120              | 0               | **264**     |\\n|","output_index":1,"sequence_number":51,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"              | 0               | **504**     |\\n| **6** | 144               | 0                | 120              | 0               | **264**     |\\n|","output_index":1,"sequence_number":52,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" **7** | 144               | 0                | 120              | 0               | **264**     |\\n| **8** | 144               | 0                | ","output_index":1,"sequence_number":52,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" **7** | 144               | 0                | 120              | 0               | **264**     |\\n| **8** | 144               | 0                | ","output_index":1,"sequence_number":53,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"120              | 0               | **264**     |\\n| **9** | 144               | 0                | 120              | 0               | **264**     ","output_index":1,"sequence_number":53,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"120              | 0               | **264**     |\\n| **9** | 144               | 0                | 120              | 0               | **264**     ","output_index":1,"sequence_number":54,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"|\\n| **Total** | | | | | **5760** |\\n\\nThe sum of the counts (5760) matches our total number of digits.\\n\\n**Most Common Digit(s):**\\nDigits","output_index":1,"sequence_number":54,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"|\\n| **Total** | | | | | **5760** |\\n\\nThe sum of the counts (5760) matches our total number of digits.\\n\\n**Most Common Digit(s):**\\nDigits","output_index":1,"sequence_number":55,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" **0** and **1** are the most common, both appearing **1164** times.\\nPercentage: (1164 / 5760) * 100% $\\\\approx$ **20.2","output_index":1,"sequence_number":55,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" **0** and **1** are the most common, both appearing **1164** times.\\nPercentage: (1164 / 5760) * 100% $\\\\approx$ **20.2","output_index":1,"sequence_number":56,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"1%**\\n\\n**Rarest Digit(s):**\\nDigits **6, 7, 8,** and **9** are the rarest, all appearing **264** times.\\nPercentage: (264","output_index":1,"sequence_number":56,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"1%**\\n\\n**Rarest Digit(s):**\\nDigits **6, 7, 8,** and **9** are the rarest, all appearing **264** times.\\nPercentage: (264","output_index":1,"sequence_number":57,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" / 5760) * 100% $\\\\approx$ **4.58%**","output_index":1,"sequence_number":57,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" / 5760) * 100% $\\\\approx$ **4.58%**","output_index":1,"sequence_number":58,"type":"response.output_text.delta"}
 
 event: response.completed
-data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":5889,"output_tokens_details":{"reasoning_tokens":3662},"total_tokens":5964}},"sequence_number":58,"type":"response.completed"}
+data: {"response":{"id":"iW_VaY_sJ4OV_uMPkvTv-Aw","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":75,"input_tokens_details":{"cached_tokens":0},"output_tokens":5889,"output_tokens_details":{"reasoning_tokens":3662},"total_tokens":5964}},"sequence_number":59,"type":"response.completed"}
 
 "
 `;
@@ -10602,11 +10602,14 @@ exports[`streaming: responses → google > multimodalRequest > streaming 1`] = `
 "event: response.created
 data: {"response":{"id":"iW_VaZ3aDdSa_uMPpsqI4Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":267,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":287},"total_tokens":563}},"sequence_number":0,"type":"response.created"}
 
+event: response.in_progress
+data: {"response":{"id":"iW_VaZ3aDdSa_uMPpsqI4Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":267,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":287},"total_tokens":563}},"sequence_number":1,"type":"response.in_progress"}
+
 event: response.output_text.delta
-data: {"content_index":0,"delta":"In this image, I see a beautiful **","output_index":0,"sequence_number":1,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"In this image, I see a beautiful **","output_index":0,"sequence_number":2,"type":"response.output_text.delta"}
 
 event: response.incomplete
-data: {"response":{"id":"iW_VaZ3aDdSa_uMPpsqI4Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":267,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":287},"total_tokens":563}},"sequence_number":2,"type":"response.incomplete"}
+data: {"response":{"id":"iW_VaZ3aDdSa_uMPpsqI4Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":267,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":287},"total_tokens":563}},"sequence_number":3,"type":"response.incomplete"}
 
 "
 `;
@@ -10615,14 +10618,17 @@ exports[`streaming: responses → google > parallelToolCallsRequest > streaming 
 "event: response.created
 data: {"response":{"id":"US8oarqkA-zQ_uMPs83E8A4","model":"gemini-3.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":151,"input_tokens_details":{"cached_tokens":0},"output_tokens":117,"output_tokens_details":{"reasoning_tokens":93},"total_tokens":268}},"sequence_number":0,"type":"response.created"}
 
-event: response.output_text.delta
-data: {"content_index":0,"delta":"In San Francisco, it is currently 65°F and sunny. In New York, it is 45","output_index":0,"sequence_number":1,"type":"response.output_text.delta"}
+event: response.in_progress
+data: {"response":{"id":"US8oarqkA-zQ_uMPs83E8A4","model":"gemini-3.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":151,"input_tokens_details":{"cached_tokens":0},"output_tokens":117,"output_tokens_details":{"reasoning_tokens":93},"total_tokens":268}},"sequence_number":1,"type":"response.in_progress"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"°F and cloudy.","output_index":0,"sequence_number":2,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"In San Francisco, it is currently 65°F and sunny. In New York, it is 45","output_index":0,"sequence_number":2,"type":"response.output_text.delta"}
+
+event: response.output_text.delta
+data: {"content_index":0,"delta":"°F and cloudy.","output_index":0,"sequence_number":3,"type":"response.output_text.delta"}
 
 event: response.completed
-data: {"response":{"id":"US8oarqkA-zQ_uMPs83E8A4","model":"gemini-3.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":151,"input_tokens_details":{"cached_tokens":0},"output_tokens":122,"output_tokens_details":{"reasoning_tokens":93},"total_tokens":273}},"sequence_number":3,"type":"response.completed"}
+data: {"response":{"id":"US8oarqkA-zQ_uMPs83E8A4","model":"gemini-3.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":151,"input_tokens_details":{"cached_tokens":0},"output_tokens":122,"output_tokens_details":{"reasoning_tokens":93},"total_tokens":273}},"sequence_number":4,"type":"response.completed"}
 
 "
 `;
@@ -10631,41 +10637,44 @@ exports[`streaming: responses → google > reasoningRequest > streaming 1`] = `
 "event: response.created
 data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":67,"output_tokens_details":{"reasoning_tokens":67},"total_tokens":104}},"sequence_number":0,"type":"response.created"}
 
-event: response.reasoning_summary_text.delta
-data: {"delta":"**Defining the Goal**\\n\\nI've zeroed in on the core of the problem: determining the train's average speed. The formula is key: Total Distance divided by Total Time. I'm building my approach around this foundational understanding.\\n\\n\\n","output_index":0,"sequence_number":1,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+event: response.in_progress
+data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":67,"output_tokens_details":{"reasoning_tokens":67},"total_tokens":104}},"sequence_number":1,"type":"response.in_progress"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Calculating the Distance**\\n\\nI'm now calculating the distances for each leg of the journey. I'm using the Distance = Speed x Time formula, breaking down the trip into stage one and stage two. I've worked out the distance for each stage and summed those up, and the total distance traveled is 200 miles! Next, I am calculating the total time of the journey.\\n\\n\\n","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Defining the Goal**\\n\\nI've zeroed in on the core of the problem: determining the train's average speed. The formula is key: Total Distance divided by Total Time. I'm building my approach around this foundational understanding.\\n\\n\\n","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Finalizing the Calculation**\\n\\nI've completed all calculations. The process went smoothly, step-by-step. I've calculated the total distance at 200 miles and the total time at 3 hours. Dividing to get the average speed, I get 66.67 mph (or exactly 66 and 2/3 mph). Now I'm structuring the answer for presentation, following all of the steps I used.\\n\\n\\n","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Calculating the Distance**\\n\\nI'm now calculating the distances for each leg of the journey. I'm using the Distance = Speed x Time formula, breaking down the trip into stage one and stage two. I've worked out the distance for each stage and summed those up, and the total distance traveled is 200 miles! Next, I am calculating the total time of the journey.\\n\\n\\n","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Finalizing the Calculation**\\n\\nI've completed all calculations. The process went smoothly, step-by-step. I've calculated the total distance at 200 miles and the total time at 3 hours. Dividing to get the average speed, I get 66.67 mph (or exactly 66 and 2/3 mph). Now I'm structuring the answer for presentation, following all of the steps I used.\\n\\n\\n","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"Here's how to calculate the average speed step-by-step","output_index":1,"sequence_number":4,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"Here's how to calculate the average speed step-by-step","output_index":1,"sequence_number":5,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":":\\n\\n**1. Understand the Formula for Average Speed:**\\nAverage Speed = Total Distance / Total Time\\n\\n**2. Calculate the Distance for the First Part of the Journey:**\\n*   Speed = 60 mph\\n*   ","output_index":1,"sequence_number":5,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":":\\n\\n**1. Understand the Formula for Average Speed:**\\nAverage Speed = Total Distance / Total Time\\n\\n**2. Calculate the Distance for the First Part of the Journey:**\\n*   Speed = 60 mph\\n*   ","output_index":1,"sequence_number":6,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"Time = 2 hours\\n*   Distance₁ = Speed × Time = 60 mph × 2 hours = 120 miles\\n\\n**3. Calculate the Distance for the Second Part of the Journey:**\\n*   Speed = ","output_index":1,"sequence_number":6,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"Time = 2 hours\\n*   Distance₁ = Speed × Time = 60 mph × 2 hours = 120 miles\\n\\n**3. Calculate the Distance for the Second Part of the Journey:**\\n*   Speed = ","output_index":1,"sequence_number":7,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"80 mph\\n*   Time = 1 hour\\n*   Distance₂ = Speed × Time = 80 mph × 1 hour = 80 miles\\n\\n**4. Calculate the Total Distance Traveled:**\\n*   ","output_index":1,"sequence_number":7,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"80 mph\\n*   Time = 1 hour\\n*   Distance₂ = Speed × Time = 80 mph × 1 hour = 80 miles\\n\\n**4. Calculate the Total Distance Traveled:**\\n*   ","output_index":1,"sequence_number":8,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"Total Distance = Distance₁ + Distance₂ = 120 miles + 80 miles = 200 miles\\n\\n**5. Calculate the Total Time Taken:**\\n*   Total Time = Time₁ + Time₂ = ","output_index":1,"sequence_number":8,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"Total Distance = Distance₁ + Distance₂ = 120 miles + 80 miles = 200 miles\\n\\n**5. Calculate the Total Time Taken:**\\n*   Total Time = Time₁ + Time₂ = ","output_index":1,"sequence_number":9,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"2 hours + 1 hour = 3 hours\\n\\n**6. Calculate the Average Speed:**\\n*   Average Speed = Total Distance / Total Time\\n*   Average Speed = 200 miles / 3 hours\\n*   Average Speed =","output_index":1,"sequence_number":9,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"2 hours + 1 hour = 3 hours\\n\\n**6. Calculate the Average Speed:**\\n*   Average Speed = Total Distance / Total Time\\n*   Average Speed = 200 miles / 3 hours\\n*   Average Speed =","output_index":1,"sequence_number":10,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" 66.666... mph\\n\\n**7. Round to a practical number:**\\n*   Average Speed ≈ 66.67 mph\\n\\n**Answer:** The average speed of the train is approximately **66.","output_index":1,"sequence_number":10,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" 66.666... mph\\n\\n**7. Round to a practical number:**\\n*   Average Speed ≈ 66.67 mph\\n\\n**Answer:** The average speed of the train is approximately **66.","output_index":1,"sequence_number":11,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"67 mph**.","output_index":1,"sequence_number":11,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"67 mph**.","output_index":1,"sequence_number":12,"type":"response.output_text.delta"}
 
 event: response.completed
-data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":895,"output_tokens_details":{"reasoning_tokens":592},"total_tokens":932}},"sequence_number":12,"type":"response.completed"}
+data: {"response":{"id":"iG_VaeWWI6uM_PUPpP7C2Qw","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":895,"output_tokens_details":{"reasoning_tokens":592},"total_tokens":932}},"sequence_number":13,"type":"response.completed"}
 
 "
 `;
@@ -10674,17 +10683,20 @@ exports[`streaming: responses → google > reasoningRequestTruncated > streaming
 "event: response.created
 data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":68,"output_tokens_details":{"reasoning_tokens":68},"total_tokens":105}},"sequence_number":0,"type":"response.created"}
 
-event: response.reasoning_summary_text.delta
-data: {"delta":"**Calculating Average Speed**\\n\\nOkay, I'm working on calculating the average speed. I've broken down the problem to use the average speed formula: (Total Distance) / (Total Time). My next step is figuring out how to determine the total distance and total time, given the information in the problem. I need to make sure I don't miss any steps!\\n\\n\\n","output_index":0,"sequence_number":1,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+event: response.in_progress
+data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":68,"output_tokens_details":{"reasoning_tokens":68},"total_tokens":105}},"sequence_number":1,"type":"response.in_progress"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Defining Problem Stages**\\n\\nI'm now focusing on how the train's journey can be broken into stages. I've realized the travel is in at least two parts. I'm recalling the formula for average speed: (Total Distance) / (Total Time). I believe this is critical to tackling the problem methodically.\\n\\n\\n","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Calculating Average Speed**\\n\\nOkay, I'm working on calculating the average speed. I've broken down the problem to use the average speed formula: (Total Distance) / (Total Time). My next step is figuring out how to determine the total distance and total time, given the information in the problem. I need to make sure I don't miss any steps!\\n\\n\\n","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Defining Problem Stages**\\n\\nI'm now focusing on how the train's journey can be broken into stages. I've realized the travel is in at least two parts. I'm recalling the formula for average speed: (Total Distance) / (Total Time). I believe this is critical to tackling the problem methodically.\\n\\n\\n","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"Let's break","output_index":1,"sequence_number":3,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"Let's break","output_index":1,"sequence_number":4,"type":"response.output_text.delta"}
 
 event: response.incomplete
-data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":94,"output_tokens_details":{"reasoning_tokens":92},"total_tokens":131}},"sequence_number":4,"type":"response.incomplete"}
+data: {"response":{"id":"iG_VabCjI7rv_uMPnN-N6Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":37,"input_tokens_details":{"cached_tokens":0},"output_tokens":94,"output_tokens_details":{"reasoning_tokens":92},"total_tokens":131}},"sequence_number":5,"type":"response.incomplete"}
 
 "
 `;
@@ -10693,38 +10705,41 @@ exports[`streaming: responses → google > reasoningWithOutput > streaming 1`] =
 "event: response.created
 data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":65,"output_tokens_details":{"reasoning_tokens":65},"total_tokens":72}},"sequence_number":0,"type":"response.created"}
 
-event: response.reasoning_summary_text.delta
-data: {"delta":"**Reviewing Basic Principles**\\n\\nI've started by breaking down the user's question. Now I'm recalling relevant background knowledge, specifically focusing on how light scattering affects sky color. I'm focusing on the contrast between daytime and sunrise/sunset.\\n\\n\\n","output_index":0,"sequence_number":1,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+event: response.in_progress
+data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":65,"output_tokens_details":{"reasoning_tokens":65},"total_tokens":72}},"sequence_number":1,"type":"response.in_progress"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Defining the Standard Answer**\\n\\nNow I'm focusing on the core answer: \\"The sky is blue.\\" I'm also ensuring that I can explain *why* it's blue, using Rayleigh scattering as the key. I'm building out a list of other possible sky colors, so I can add them for completeness. I'm focusing on the importance of clarity.\\n\\n\\n","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Reviewing Basic Principles**\\n\\nI've started by breaking down the user's question. Now I'm recalling relevant background knowledge, specifically focusing on how light scattering affects sky color. I'm focusing on the contrast between daytime and sunrise/sunset.\\n\\n\\n","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Refining My Explanation**\\n\\nI'm now zeroing in on a polished response. I'm focusing on crafting a succinct explanation that balances clarity with completeness, accounting for Rayleigh scattering as the key. I'm prioritizing the inclusion of varied sky colors in different situations to provide a more nuanced answer.\\n\\n\\n","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Defining the Standard Answer**\\n\\nNow I'm focusing on the core answer: \\"The sky is blue.\\" I'm also ensuring that I can explain *why* it's blue, using Rayleigh scattering as the key. I'm building out a list of other possible sky colors, so I can add them for completeness. I'm focusing on the importance of clarity.\\n\\n\\n","output_index":0,"sequence_number":3,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Crafting the Final Response**\\n\\nI'm now satisfied with the explanation and focusing on polishing the response. I've re-read it, to clarify that the user receives an easy to understand answer, which is also correct. I'm prioritizing accuracy and conciseness, ready to finalize the statement.\\n\\n\\n","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Refining My Explanation**\\n\\nI'm now zeroing in on a polished response. I'm focusing on crafting a succinct explanation that balances clarity with completeness, accounting for Rayleigh scattering as the key. I'm prioritizing the inclusion of varied sky colors in different situations to provide a more nuanced answer.\\n\\n\\n","output_index":0,"sequence_number":4,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+
+event: response.reasoning_summary_text.delta
+data: {"delta":"**Crafting the Final Response**\\n\\nI'm now satisfied with the explanation and focusing on polishing the response. I've re-read it, to clarify that the user receives an easy to understand answer, which is also correct. I'm prioritizing accuracy and conciseness, ready to finalize the statement.\\n\\n\\n","output_index":0,"sequence_number":5,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"The sky is most commonly **blue** during the day.\\n\\nThis is due to a phenomenon called **Rayleigh scattering**. Shorter wavelengths of light (like blue and violet) are scattered","output_index":1,"sequence_number":5,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"The sky is most commonly **blue** during the day.\\n\\nThis is due to a phenomenon called **Rayleigh scattering**. Shorter wavelengths of light (like blue and violet) are scattered","output_index":1,"sequence_number":6,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" more efficiently by the tiny nitrogen and oxygen molecules in Earth's atmosphere than longer wavelengths (like red and yellow). Because blue light is scattered in all directions, it appears to come from all parts of the sky, making it look blue.\\n\\nHowever,","output_index":1,"sequence_number":6,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" more efficiently by the tiny nitrogen and oxygen molecules in Earth's atmosphere than longer wavelengths (like red and yellow). Because blue light is scattered in all directions, it appears to come from all parts of the sky, making it look blue.\\n\\nHowever,","output_index":1,"sequence_number":7,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" the color of the sky can change dramatically depending on various factors:\\n\\n*   **Sunrise and Sunset:** It often appears **red, orange, pink, or purple**. At these times, the sunlight travels through much more atmosphere, scattering away most of the","output_index":1,"sequence_number":7,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" the color of the sky can change dramatically depending on various factors:\\n\\n*   **Sunrise and Sunset:** It often appears **red, orange, pink, or purple**. At these times, the sunlight travels through much more atmosphere, scattering away most of the","output_index":1,"sequence_number":8,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" blue light and leaving the longer-wavelength reds and oranges to reach our eyes directly.\\n*   **Overcast or Stormy Weather:** It can appear **grey or white** due to thick clouds reflecting and absorbing light.\\n*   **Night:**","output_index":1,"sequence_number":8,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" blue light and leaving the longer-wavelength reds and oranges to reach our eyes directly.\\n*   **Overcast or Stormy Weather:** It can appear **grey or white** due to thick clouds reflecting and absorbing light.\\n*   **Night:**","output_index":1,"sequence_number":9,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" It appears **black** (with stars), as that side of Earth is facing away from the sun, and there's no sunlight to scatter in the atmosphere.\\n*   **Pollution or Dust:** Can give it a hazy,","output_index":1,"sequence_number":9,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" It appears **black** (with stars), as that side of Earth is facing away from the sun, and there's no sunlight to scatter in the atmosphere.\\n*   **Pollution or Dust:** Can give it a hazy,","output_index":1,"sequence_number":10,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" brownish, or yellowish tint.\\n\\nSo, while **blue** is the most common answer for a clear daytime sky, it's certainly not its only color!","output_index":1,"sequence_number":10,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" brownish, or yellowish tint.\\n\\nSo, while **blue** is the most common answer for a clear daytime sky, it's certainly not its only color!","output_index":1,"sequence_number":11,"type":"response.output_text.delta"}
 
 event: response.completed
-data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":983,"output_tokens_details":{"reasoning_tokens":714},"total_tokens":990}},"sequence_number":11,"type":"response.completed"}
+data: {"response":{"id":"iW_VaZfANa-b_uMPhLD1kQo","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens":983,"output_tokens_details":{"reasoning_tokens":714},"total_tokens":990}},"sequence_number":12,"type":"response.completed"}
 
 "
 `;
@@ -10733,17 +10748,20 @@ exports[`streaming: responses → google > simpleRequest > streaming 1`] = `
 "event: response.created
 data: {"response":{"id":"iG_VacqLI7aX_uMP96rw0Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":8,"input_tokens_details":{"cached_tokens":0},"output_tokens":17,"output_tokens_details":{"reasoning_tokens":17},"total_tokens":25}},"sequence_number":0,"type":"response.created"}
 
+event: response.in_progress
+data: {"response":{"id":"iG_VacqLI7aX_uMP96rw0Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":8,"input_tokens_details":{"cached_tokens":0},"output_tokens":17,"output_tokens_details":{"reasoning_tokens":17},"total_tokens":25}},"sequence_number":1,"type":"response.in_progress"}
+
 event: response.reasoning_summary_text.delta
-data: {"delta":"**Answering the Query**\\n\\nOkay, I'm focusing on providing a direct and accurate response to the user's question. My primary concern is delivering the correct information clearly. I'm aiming for a concise and factual answer that meets the user's needs.\\n\\n\\n","output_index":0,"sequence_number":1,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
+data: {"delta":"**Answering the Query**\\n\\nOkay, I'm focusing on providing a direct and accurate response to the user's question. My primary concern is delivering the correct information clearly. I'm aiming for a concise and factual answer that meets the user's needs.\\n\\n\\n","output_index":0,"sequence_number":2,"summary_index":0,"type":"response.reasoning_summary_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":"The","output_index":1,"sequence_number":2,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"The","output_index":1,"sequence_number":3,"type":"response.output_text.delta"}
 
 event: response.output_text.delta
-data: {"content_index":0,"delta":" capital of France is **Paris**.","output_index":1,"sequence_number":3,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":" capital of France is **Paris**.","output_index":1,"sequence_number":4,"type":"response.output_text.delta"}
 
 event: response.completed
-data: {"response":{"id":"iG_VacqLI7aX_uMP96rw0Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":8,"input_tokens_details":{"cached_tokens":0},"output_tokens":24,"output_tokens_details":{"reasoning_tokens":17},"total_tokens":32}},"sequence_number":4,"type":"response.completed"}
+data: {"response":{"id":"iG_VacqLI7aX_uMP96rw0Q8","model":"gemini-2.5-flash","object":"response","output":[],"status":"completed","usage":{"input_tokens":8,"input_tokens_details":{"cached_tokens":0},"output_tokens":24,"output_tokens_details":{"reasoning_tokens":17},"total_tokens":32}},"sequence_number":5,"type":"response.completed"}
 
 "
 `;
@@ -10752,8 +10770,11 @@ exports[`streaming: responses → google > simpleRequestTruncated > streaming 1`
 "event: response.created
 data: {"response":{"id":"iG_VaZqcI_GW_uMPtubRiQE","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":10}},"sequence_number":0,"type":"response.created"}
 
+event: response.in_progress
+data: {"response":{"id":"iG_VaZqcI_GW_uMPtubRiQE","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":10}},"sequence_number":1,"type":"response.in_progress"}
+
 event: response.incomplete
-data: {"response":{"id":"iG_VaZqcI_GW_uMPtubRiQE","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":10}},"sequence_number":1,"type":"response.incomplete"}
+data: {"response":{"id":"iG_VaZqcI_GW_uMPtubRiQE","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":10}},"sequence_number":2,"type":"response.incomplete"}
 
 "
 `;
@@ -10762,11 +10783,14 @@ exports[`streaming: responses → google > systemMessageArrayContent > streaming
 "event: response.created
 data: {"response":{"id":"i2_VafqnDsbu_uMPxqqZkQ0","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":29,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":284},"total_tokens":325}},"sequence_number":0,"type":"response.created"}
 
+event: response.in_progress
+data: {"response":{"id":"i2_VafqnDsbu_uMPxqqZkQ0","model":"gemini-2.5-flash","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":29,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":284},"total_tokens":325}},"sequence_number":1,"type":"response.in_progress"}
+
 event: response.output_text.delta
-data: {"content_index":0,"delta":"To find recent errors in the \`project_logs\` (","output_index":0,"sequence_number":1,"type":"response.output_text.delta"}
+data: {"content_index":0,"delta":"To find recent errors in the \`project_logs\` (","output_index":0,"sequence_number":2,"type":"response.output_text.delta"}
 
 event: response.incomplete
-data: {"response":{"id":"i2_VafqnDsbu_uMPxqqZkQ0","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":29,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":284},"total_tokens":325}},"sequence_number":2,"type":"response.incomplete"}
+data: {"response":{"id":"i2_VafqnDsbu_uMPxqqZkQ0","model":"gemini-2.5-flash","object":"response","output":[],"status":"incomplete","usage":{"input_tokens":29,"input_tokens_details":{"cached_tokens":0},"output_tokens":296,"output_tokens_details":{"reasoning_tokens":284},"total_tokens":325}},"sequence_number":3,"type":"response.incomplete"}
 
 "
 `;
@@ -10775,14 +10799,17 @@ exports[`streaming: responses → google > toolCallRequest > streaming 1`] = `
 "event: response.created
 data: {"response":{"id":"YVv7aeCnCK30jMcPgsyniAw","model":"gemini-3-flash-preview","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":73,"input_tokens_details":{"cached_tokens":0},"output_tokens":19,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":92}},"sequence_number":0,"type":"response.created"}
 
+event: response.in_progress
+data: {"response":{"id":"YVv7aeCnCK30jMcPgsyniAw","model":"gemini-3-flash-preview","object":"response","output":[],"status":"in_progress","usage":{"input_tokens":73,"input_tokens_details":{"cached_tokens":0},"output_tokens":19,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":92}},"sequence_number":1,"type":"response.in_progress"}
+
 event: response.output_item.added
-data: {"item":{"arguments":"","call_id":"etjq4utn","name":"get_weather","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":1,"type":"response.output_item.added"}
+data: {"item":{"arguments":"","call_id":"etjq4utn","name":"get_weather","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
 
 event: response.function_call_arguments.delta
-data: {"delta":"{\\"location\\":\\"San Francisco, CA\\"}","output_index":0,"sequence_number":2,"type":"response.function_call_arguments.delta"}
+data: {"delta":"{\\"location\\":\\"San Francisco, CA\\"}","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
 
 event: response.completed
-data: {"response":{"id":"YVv7aeCnCK30jMcPgsyniAw","model":"gemini-3-flash-preview","object":"response","output":[],"status":"completed","usage":{"input_tokens":73,"input_tokens_details":{"cached_tokens":0},"output_tokens":19,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":92}},"sequence_number":3,"type":"response.completed"}
+data: {"response":{"id":"YVv7aeCnCK30jMcPgsyniAw","model":"gemini-3-flash-preview","object":"response","output":[],"status":"completed","usage":{"input_tokens":73,"input_tokens_details":{"cached_tokens":0},"output_tokens":19,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":92}},"sequence_number":4,"type":"response.completed"}
 
 "
 `;


### PR DESCRIPTION
followup fixes

Fix Responses stream sequencing and custom tool-call validation

  - Emit ordered Responses lifecycle events for transformed streams.
  - Keep empty transformed chunks out of non-SSE output; emit SSE heartbeats only while the response is active.
  - Preserve custom tool-call stream fields and reject malformed custom-tool starts.
  - Parse custom-tool sequence numbers as u64.
  - Add stream/parser regression coverage and update streaming snapshots