### PR TITLE
Add cargo build metadata to lingua

### DIFF
--- a/crates/lingua/Cargo.toml
+++ b/crates/lingua/Cargo.toml
@@ -9,6 +9,10 @@ description = "Lingua - Universal message format for LLM APIs"
 keywords = ["llm", "ai", "openai", "anthropic", "api"]
 categories = ["api-bindings", "development-tools"]
 
+[package.metadata.braintrust.build-variants.all-providers]
+default-features = true
+features = ["bedrock"]
+
 [package.metadata.ts-rs]
 optional_option_fields = true
 


### PR DESCRIPTION
This metadata enables our monorepo build system to more-generically derive cargo feature sets for different variants of the build.