### PR TITLE
Use type-only tsup.config.js

### DIFF
--- a/bindings/typescript-types/tsup.config.ts
+++ b/bindings/typescript-types/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { type Options } from "tsup";
 
-export default defineConfig({
+export default {
   entry: {
     index: "src/index.ts",
   },
@@ -10,4 +10,4 @@ export default defineConfig({
   splitting: false,
   sourcemap: false,
   clean: true,
-});
+} satisfies Options;

--- a/bindings/typescript/tsup.config.ts
+++ b/bindings/typescript/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { type Options } from "tsup";
 
-export default defineConfig([
+export default [
   {
     entry: {
       index: "src/index.ts",
@@ -23,4 +23,4 @@ export default defineConfig([
     sourcemap: true,
     clean: false,
   },
-]);
+] satisfies Options[];


### PR DESCRIPTION
This allows build tools to analyze vastly fewer files because they don't need to look through all the node module dependencies.