### PR TITLE
Tolerate out-of-enum values on pass-through params in OpenAI request detection (GATE-6)

### DIFF
--- a/crates/lingua/src/providers/openai/adapter.rs
+++ b/crates/lingua/src/providers/openai/adapter.rs
@@ -28,7 +28,9 @@ use crate::providers::openai::params::{
 };
 use crate::providers::openai::responses_adapter::parse_responses_extras;
 use crate::providers::openai::tool_parsing::parse_openai_chat_tools_array;
-use crate::providers::openai::{try_parse_openai, try_parse_openai_legacy_prompt};
+use crate::providers::openai::{
+    detect_openai_shape, try_parse_openai, try_parse_openai_legacy_prompt,
+};
 use crate::serde_json::{self, Map, Value};
 use crate::universal::convert::TryFromLLM;
 use crate::universal::message::{
@@ -176,11 +178,17 @@ impl ProviderAdapter for OpenAIAdapter {
     }
 
     fn detect_request(&self, payload: &Value) -> bool {
-        try_parse_openai(payload).is_ok() || try_parse_openai_legacy_prompt(payload).is_ok()
+        try_parse_openai(payload).is_ok()
+            || try_parse_openai_legacy_prompt(payload).is_ok()
+            || detect_openai_shape(payload).is_ok()
     }
 
     fn detect_passthrough_request(&self, payload: &Value) -> bool {
-        try_parse_openai(payload).is_ok()
+        // Native OpenAI passthrough must also accept out-of-enum pass-through params —
+        // the value is forwarded verbatim and OpenAI is the authority on whether it is
+        // valid. The structural fallback still rejects legacy prompt-only bodies (no
+        // `messages`), which is what this override exists to keep out of passthrough.
+        try_parse_openai(payload).is_ok() || detect_openai_shape(payload).is_ok()
     }
 
     fn request_requires_json_response(&self, payload: &Value) -> Result<bool, TransformError> {
@@ -922,6 +930,48 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
         assert!(adapter.detect_request(&payload));
+    }
+
+    #[test]
+    fn test_openai_detect_request_tolerates_unknown_enum_values() {
+        // GATE-6 guard: every closed unit-variant enum on a top-level Chat Completions
+        // param is a latent "Unable to detect request source format" 400 when OpenAI
+        // ships a value newer than the vendored spec. Detection must tolerate them.
+        let adapter = OpenAIAdapter;
+        for (field, value) in [
+            ("service_tier", json!("some-future-tier")),
+            ("verbosity", json!("some-future-verbosity")),
+            ("prompt_cache_retention", json!("some-future-retention")),
+            ("modalities", json!(["some-future-modality"])),
+            ("reasoning_effort", json!("some-future-effort")),
+        ] {
+            let payload = json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+                field: value,
+            });
+            assert!(
+                adapter.detect_request(&payload),
+                "detect_request rejected unknown {field} value"
+            );
+            assert!(
+                adapter.detect_passthrough_request(&payload),
+                "detect_passthrough_request rejected unknown {field} value"
+            );
+        }
+    }
+
+    #[test]
+    fn test_openai_detect_passthrough_rejects_legacy_prompt() {
+        // The passthrough override exists to keep legacy prompt-only bodies out of
+        // zero-copy passthrough; the structural fallback must not reopen that.
+        let adapter = OpenAIAdapter;
+        let payload = json!({
+            "model": "gpt-3.5-turbo-instruct",
+            "prompt": "Hello"
+        });
+        assert!(adapter.detect_request(&payload));
+        assert!(!adapter.detect_passthrough_request(&payload));
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/detect.rs
+++ b/crates/lingua/src/providers/openai/detect.rs
@@ -6,7 +6,9 @@ OpenAI chat completion format by attempting to deserialize into
 the OpenAI struct types.
 */
 
-use crate::providers::openai::generated::{CreateChatCompletionRequestClass, CreateResponseClass};
+use crate::providers::openai::generated::{
+    ChatCompletionRequestMessage, CreateChatCompletionRequestClass, CreateResponseClass, InputParam,
+};
 use crate::providers::openai::params::OpenAIChatLegacyPromptParams;
 use crate::serde_json::{self, Value};
 use thiserror::Error;
@@ -82,6 +84,72 @@ pub fn try_parse_responses(payload: &Value) -> Result<CreateResponseClass, Detec
 
     serde_json::from_value(payload.clone())
         .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))
+}
+
+/// Minimal structural view of a Chat Completions request.
+///
+/// Detection's job is format *discrimination*, not validation: it decides which adapter
+/// owns the payload, and its result is only ever consumed as a boolean. Deserializing the
+/// full `CreateChatCompletionRequestClass` couples that decision to every closed enum in
+/// the vendored OpenAI spec, so one out-of-enum value on a top-level pass-through
+/// parameter (`service_tier`, `verbosity`, `prompt_cache_retention`, ...) makes the
+/// gateway conclude it cannot identify the format at all — see GATE-6.
+///
+/// This view validates only what `OpenAIAdapter::request_to_universal` actually consumes:
+/// a `model` string and a well-formed `messages` array. Everything else is params, which
+/// `OpenAIChatParams` already handles permissively via `#[serde(flatten)] extras`.
+///
+/// Known residual: `ChatCompletionRequestMessage` itself contains closed enums (role,
+/// content-part types), so an out-of-enum value *inside* a message still fails detection.
+/// This fallback only decouples detection from top-level request parameters.
+#[derive(serde::Deserialize)]
+struct ChatCompletionsShape {
+    #[allow(dead_code)]
+    model: String,
+    messages: Vec<ChatCompletionRequestMessage>,
+}
+
+/// Structural (non-strict) Chat Completions detection.
+///
+/// Used only after `try_parse_openai` fails. Deliberately does NOT gate on enum-valued
+/// top-level pass-through parameters.
+pub fn detect_openai_shape(payload: &Value) -> Result<(), DetectionError> {
+    let shape: ChatCompletionsShape = serde_json::from_value(payload.clone())
+        .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))?;
+    if shape.messages.is_empty() {
+        return Err(DetectionError::DeserializationFailed(
+            "Not a Chat Completions payload: 'messages' is empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Minimal structural view of a Responses request. See `ChatCompletionsShape`; the same
+/// residual applies to closed enums inside `InputParam` items.
+#[derive(serde::Deserialize)]
+struct ResponsesShape {
+    #[allow(dead_code)]
+    input: InputParam,
+}
+
+/// Structural (non-strict) Responses detection. See `detect_openai_shape`.
+///
+/// Unlike the Chat Completions adapter, the Responses adapter is registered *first* in
+/// the adapter registry, so leniency here widens what the highest-priority adapter can
+/// claim. The `input`-present / `messages`-absent discriminator below is therefore kept
+/// verbatim from `try_parse_responses`, and the only relaxation relative to the strict
+/// parse is tolerating out-of-enum values on known top-level parameters — the strict
+/// parse already ignores unknown fields, so no new payload *shape* becomes claimable.
+pub fn detect_responses_shape(payload: &Value) -> Result<(), DetectionError> {
+    if payload.get("input").is_none() || payload.get("messages").is_some() {
+        return Err(DetectionError::DeserializationFailed(
+            "Not a Responses API payload: missing 'input' field or has 'messages' field"
+                .to_string(),
+        ));
+    }
+    let _shape: ResponsesShape = serde_json::from_value(payload.clone())
+        .map_err(|e| DetectionError::DeserializationFailed(e.to_string()))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -328,6 +396,131 @@ mod tests {
         assert!(result.is_ok());
         let parsed = result.unwrap();
         assert_eq!(parsed.model, "gpt-4");
+    }
+
+    #[test]
+    fn test_detect_openai_shape_accepts_out_of_enum_params() {
+        // GATE-6: unknown values on top-level pass-through params must not defeat
+        // format detection. These all fail the strict parse.
+        for (field, value) in [
+            ("service_tier", json!("fast")),
+            ("verbosity", json!("ultra")),
+            ("prompt_cache_retention", json!("7d")),
+            ("modalities", json!(["video"])),
+            ("reasoning_effort", json!("galactic")),
+        ] {
+            let payload = json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+                field: value,
+            });
+            assert!(
+                try_parse_openai(&payload).is_err(),
+                "expected strict parse to reject out-of-enum {field}; if it passes now, \
+                 the vendored spec caught up and this case no longer exercises the fallback"
+            );
+            assert!(
+                detect_openai_shape(&payload).is_ok(),
+                "structural detection rejected out-of-enum {field}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_openai_shape_rejects_non_chat_payloads() {
+        // Missing model
+        assert!(detect_openai_shape(&json!({
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .is_err());
+        // Missing messages (includes legacy prompt bodies — those stay owned by
+        // try_parse_openai_legacy_prompt)
+        assert!(detect_openai_shape(&json!({
+            "model": "gpt-4",
+            "prompt": "Hello"
+        }))
+        .is_err());
+        // Empty messages
+        assert!(detect_openai_shape(&json!({
+            "model": "gpt-4",
+            "messages": []
+        }))
+        .is_err());
+        // messages not an array
+        assert!(detect_openai_shape(&json!({
+            "model": "gpt-4",
+            "messages": "Hello"
+        }))
+        .is_err());
+        // Google-shaped payload
+        assert!(detect_openai_shape(&json!({
+            "contents": [{"role": "user", "parts": [{"text": "Hello"}]}]
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn test_detect_responses_shape_accepts_out_of_enum_params() {
+        for (field, value) in [
+            ("service_tier", json!("fast")),
+            ("prompt_cache_retention", json!("7d")),
+            ("truncation", json!("middle_out")),
+            ("include", json!(["not.a.real.include_value"])),
+        ] {
+            let payload = json!({
+                "model": "gpt-4",
+                "input": [{"role": "user", "content": "Hello"}],
+                field: value,
+            });
+            assert!(
+                try_parse_responses(&payload).is_err(),
+                "expected strict parse to reject out-of-enum {field}; if it passes now, \
+                 the vendored spec caught up and this case no longer exercises the fallback"
+            );
+            assert!(
+                detect_responses_shape(&payload).is_ok(),
+                "structural detection rejected out-of-enum {field}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_responses_shape_preserves_discriminator() {
+        // Chat payloads (messages present) must never be claimed by the Responses shape —
+        // the Responses adapter is first in the registry, so this guard carries the
+        // cross-adapter safety argument.
+        assert!(detect_responses_shape(&json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .is_err());
+        assert!(detect_responses_shape(&json!({
+            "model": "gpt-4",
+            "input": [{"role": "user", "content": "Hello"}],
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .is_err());
+        // Missing input
+        assert!(detect_responses_shape(&json!({"model": "gpt-4"})).is_err());
+    }
+
+    #[test]
+    fn test_try_parse_openai_strict_contract_unchanged() {
+        // The strict parse is still the validation surface (validation/openai.rs) —
+        // the structural fallback must not have loosened it.
+        let payload = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "service_tier": "fast"
+        });
+        assert!(try_parse_openai(&payload).is_err());
+
+        let in_enum = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "service_tier": "flex"
+        });
+        assert!(try_parse_openai(&in_enum).is_ok());
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/mod.rs
+++ b/crates/lingua/src/providers/openai/mod.rs
@@ -28,7 +28,8 @@ pub mod test_chat_completions;
 
 // Re-export detection functions
 pub use detect::{
-    try_parse_openai, try_parse_openai_legacy_prompt, try_parse_responses, DetectionError,
+    detect_openai_shape, detect_responses_shape, try_parse_openai, try_parse_openai_legacy_prompt,
+    try_parse_responses, DetectionError,
 };
 
 // Re-export capability functions

--- a/crates/lingua/src/providers/openai/responses_adapter.rs
+++ b/crates/lingua/src/providers/openai/responses_adapter.rs
@@ -32,7 +32,9 @@ use crate::providers::openai::params::{
     OpenAIReasoning, OpenAIResponsesExtrasView, OpenAIResponsesParams,
 };
 use crate::providers::openai::tool_parsing::parse_openai_responses_tools_array;
-use crate::providers::openai::{try_parse_responses, universal_to_responses_input};
+use crate::providers::openai::{
+    detect_responses_shape, try_parse_responses, universal_to_responses_input,
+};
 use crate::serde_json::{self, Map, Value};
 use crate::universal::convert::TryFromLLM;
 use crate::universal::message::{
@@ -615,7 +617,7 @@ impl ProviderAdapter for ResponsesAdapter {
     }
 
     fn detect_request(&self, payload: &Value) -> bool {
-        try_parse_responses(payload).is_ok()
+        try_parse_responses(payload).is_ok() || detect_responses_shape(payload).is_ok()
     }
 
     fn request_requires_json_response(&self, payload: &Value) -> Result<bool, TransformError> {
@@ -1730,6 +1732,36 @@ mod tests {
             "input": [{"role": "user", "content": "Hello"}]
         });
         assert!(adapter.detect_request(&payload));
+    }
+
+    #[test]
+    fn test_responses_detect_request_tolerates_unknown_enum_values() {
+        // GATE-6 guard: see the matching test on OpenAIAdapter. The Responses adapter is
+        // first in the registry, so also assert chat-shaped payloads stay unclaimed.
+        let adapter = ResponsesAdapter;
+        for (field, value) in [
+            ("service_tier", json!("some-future-tier")),
+            ("prompt_cache_retention", json!("some-future-retention")),
+            ("truncation", json!("some-future-truncation")),
+            ("include", json!(["some.future.include_value"])),
+        ] {
+            let payload = json!({
+                "model": "o1",
+                "input": [{"role": "user", "content": "Hello"}],
+                field: value,
+            });
+            assert!(
+                adapter.detect_request(&payload),
+                "detect_request rejected unknown {field} value"
+            );
+        }
+
+        let chat_payload = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "service_tier": "some-future-tier"
+        });
+        assert!(!adapter.detect_request(&chat_payload));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`POST /v1/proxy/chat/completions` with `service_tier: "fast"` returns a gateway 400 (`Unable to detect request source format`) even though the identical body succeeds against OpenAI directly. Reported in Pylon #19926 (Tavus); tracked as GATE-6.

Format detection is implemented as a strict full-body deserialization into the generated `CreateChatCompletionRequestClass` / `CreateResponseClass`, so a single out-of-enum value on an unrelated pass-through parameter makes the gateway conclude it cannot identify the request format at all. The parsed struct is discarded at every call site (`.is_ok()`), so this strictness bought nothing — and the conversion path already handles these fields permissively (`OpenAIChatParams.service_tier` is `Option<String>`, forwarded verbatim).

This is not specific to `service_tier`: every closed unit-variant enum on a top-level request param is a latent 400 (`verbosity`, `prompt_cache_retention`, `modalities`, `reasoning_effort`, `truncation`, `include` — all confirmed live against prod). It recurs every time OpenAI ships a value newer than our vendored spec snapshot.

## Fix

Add a structural fallback to detection, tried only after the strict parse fails:

- `detect_openai_shape` — requires a `model` string and a non-empty, well-formed `messages` array (the exact fields `request_to_universal` consumes). No gating on enum-valued top-level params.
- `detect_responses_shape` — preserves the `input`-present / `messages`-absent discriminator verbatim, then requires `input` to parse as `InputParam`.

Wired into `OpenAIAdapter::detect_request` / `detect_passthrough_request` (strict → legacy-prompt → shape) and `ResponsesAdapter::detect_request`. The strict parsers are untouched — `validation/openai.rs` keeps its contract, and the strict attempt still runs first so the common case is behaviorally identical. Same shape as the BT-5671 fix (`try_parse_openai_legacy_prompt`): make detection more permissive, don't loosen the generated types.

## Safety

- `OpenAIAdapter` is registered last in `ADAPTERS`, so its widened detection can only claim payloads nothing else matched.
- `ResponsesAdapter` is registered *first*, so leniency there is argued separately: the discriminator is unchanged, and since the strict parse already ignores unknown fields, the only new payloads admitted are ones with known fields carrying out-of-enum values — no new payload *shape* becomes claimable.
- The passthrough override still rejects legacy prompt-only bodies (the fallback requires `messages`), which is what that override exists to keep out of zero-copy passthrough. Response and stream detection remain strict.
- Error-shift risk: some malformed bodies that previously got `UnableToDetectRequestFormat` will now fail deeper with `ToUniversalFailed`. Both are 400s; the message is arguably more accurate.

## Known residuals (intentionally out of scope)

- `reasoning_effort` is only half-fixed: `OpenAIChatParams.reasoning_effort` is also a closed enum, so a new effort level now fails in conversion instead of detection. Widening it touches `build_reasoning_config` and cross-provider budget math.
- Closed enums *inside* messages/input items (role, content-part types) still gate detection. This PR decouples top-level params only; noted in the doc comments.
- Anthropic detection has the same strict-parse shape (`ServiceTierEnum`); same fix pattern applies if it surfaces.

## Testing

- New guard tests loop every known closed-enum top-level param on both adapters, asserting detection tolerates unknown values — and that the strict parse still rejects them, so a future spec refresh that absorbs a value flags the test case instead of silently passing. This is the test that would have caught GATE-6.
- Strict-contract pin: `try_parse_openai` still rejects `service_tier: "fast"` and accepts `"flex"`.
- Full suite: 1224 passed. Payload snapshots: 1745 passed, zero changes (detection claims no payload it previously declined). Fuzz regression suite passes. Clippy clean.
- Post-deploy: rerun the Pylon #19926 repro harness — `service_tier: "fast"` should return 200, and junk values should surface an OpenAI-originated error rather than a gateway 400.