### PR TITLE
Handle prompt safety warnings correctly in gemini responses

### DIFF
--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -2149,8 +2149,7 @@ mod tests {
     #[test]
     #[cfg(all(feature = "google", feature = "openai"))]
     fn test_transform_response_google_prompt_block_to_chat_completions() {
-        let input =
-            Bytes::from_static(br#"{"candidates":[],"promptFeedback":{"blockReason":"SAFETY"}}"#);
+        let input = Bytes::from_static(br#"{"promptFeedback":{"blockReason":"SAFETY"}}"#);
 
         let result = transform_response(input, ProviderFormat::ChatCompletions)
             .unwrap()

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -2147,6 +2147,23 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(feature = "google", feature = "openai"))]
+    fn test_transform_response_google_prompt_block_to_chat_completions() {
+        let input =
+            Bytes::from_static(br#"{"candidates":[],"promptFeedback":{"blockReason":"SAFETY"}}"#);
+
+        let result = transform_response(input, ProviderFormat::ChatCompletions)
+            .unwrap()
+            .result
+            .into_bytes();
+        let response: Value = crate::serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(response["choices"][0]["finish_reason"], "content_filter");
+        assert_eq!(response["choices"][0]["message"]["role"], "assistant");
+        assert!(response["choices"][0]["message"]["content"].is_null());
+    }
+
+    #[test]
     #[cfg(all(feature = "openai", feature = "anthropic"))]
     fn test_stream_detection_falls_back_to_full_response() {
         let payload = json!({

--- a/crates/lingua/src/processing/transform.rs
+++ b/crates/lingua/src/processing/transform.rs
@@ -2163,6 +2163,21 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(feature = "google", feature = "openai"))]
+    fn test_transform_stream_chunk_google_prompt_block_to_chat_completions() {
+        let input =
+            Bytes::from_static(br#"{"candidates":[],"promptFeedback":{"blockReason":"SAFETY"}}"#);
+
+        let result = transform_stream_chunk(input, ProviderFormat::ChatCompletions)
+            .unwrap()
+            .into_bytes();
+        let response: Value = crate::serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(response["choices"][0]["finish_reason"], "content_filter");
+        assert_eq!(response["choices"][0]["delta"]["role"], "assistant");
+    }
+
+    #[test]
     #[cfg(all(feature = "openai", feature = "anthropic"))]
     fn test_stream_detection_falls_back_to_full_response() {
         let payload = json!({

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -484,11 +484,12 @@ impl ProviderAdapter for GoogleAdapter {
     }
 
     fn detect_response(&self, payload: &Value) -> bool {
-        // Google response has candidates array (content may be missing for NO_IMAGE etc)
+        // Google may return an empty candidates array with promptFeedback when it blocks the
+        // prompt before generation.
         payload
             .get("candidates")
             .and_then(Value::as_array)
-            .is_some_and(|arr| !arr.is_empty())
+            .is_some()
     }
 
     fn response_to_universal(&self, payload: Value) -> Result<UniversalResponse, TransformError> {
@@ -523,6 +524,20 @@ impl ProviderAdapter for GoogleAdapter {
                 false
             }
         });
+
+        let prompt_was_blocked = response
+            .prompt_feedback
+            .as_ref()
+            .and_then(|feedback| feedback.block_reason.as_ref())
+            .is_some();
+
+        if prompt_was_blocked && messages.is_empty() {
+            messages.push(Message::Assistant {
+                content: AssistantContent::Array(vec![]),
+                id: None,
+            });
+            finish_reasons.push(FinishReason::ContentFilter);
+        }
 
         let finish_reason = if has_tool_calls {
             Some(FinishReason::ToolCalls)

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -484,12 +484,13 @@ impl ProviderAdapter for GoogleAdapter {
     }
 
     fn detect_response(&self, payload: &Value) -> bool {
-        // Google may return an empty candidates array with promptFeedback when it blocks the
-        // prompt before generation.
-        payload
-            .get("candidates")
-            .and_then(Value::as_array)
-            .is_some()
+        serde_json::from_value::<GenerateContentResponse>(payload.clone()).is_ok_and(|response| {
+            response.candidates.is_some()
+                || response
+                    .prompt_feedback
+                    .and_then(|feedback| feedback.block_reason)
+                    .is_some()
+        })
     }
 
     fn response_to_universal(&self, payload: Value) -> Result<UniversalResponse, TransformError> {

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -620,9 +620,13 @@ impl ProviderAdapter for GoogleAdapter {
     // =========================================================================
 
     fn detect_stream_response(&self, payload: &Value) -> bool {
-        // Google streaming uses the same format as non-streaming (candidates array)
-        // The response_to_universal detection already handles this
-        self.detect_response(payload)
+        serde_json::from_value::<GenerateContentResponse>(payload.clone()).is_ok_and(|response| {
+            response.candidates.is_some()
+                && response
+                    .prompt_feedback
+                    .and_then(|feedback| feedback.block_reason)
+                    .is_none()
+        })
     }
 
     fn stream_to_universal(

--- a/payloads/scripts/transforms/transforms-ai-sdk.test.ts
+++ b/payloads/scripts/transforms/transforms-ai-sdk.test.ts
@@ -100,7 +100,9 @@ for (const pair of STREAMING_RESPONSES_TO_ANTHROPIC_PAIRS) {
         pair.target,
         caseName
       );
-      const skipReason = getFixtureSkipReason(responsePath, { streaming: true });
+      const skipReason = getFixtureSkipReason(responsePath, {
+        streaming: true,
+      });
 
       if (skipReason) {
         registerSkippedFixtureTest(pairLabel, caseName, skipReason);


### PR DESCRIPTION
A user was seeing:
```
Internal(response transformation failed: Unable to detect response source format

Caused by:
    Unable to detect response source format)
```

for a gemini-2.5-flash request that likely triggered the content safety warning.

https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/GenerateContentResponse -- the `candidates` array will be empty when promptFeedback is populated