### PR TITLE
Fix URL-backed audio and video file inputs for Gemini and Vertex prompt invocation

### DIFF
--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -1429,6 +1429,14 @@
       ]
     },
     {
+      "testCase": "chatCompletionsUrlBackedAudioFileParam",
+      "source": "ChatCompletions",
+      "target": "Bedrock",
+      "errors": [
+        { "pattern": "Lingua file content to Bedrock Converse file input", "reason": "Bedrock Converse does not support Lingua file input" }
+      ]
+    },
+    {
       "testCase": "chatCompletionsUrlBackedVideoFileParam",
       "source": "ChatCompletions",
       "target": "Google",
@@ -1450,6 +1458,14 @@
       "target": "Anthropic",
       "errors": [
         { "pattern": "URL-backed file with MIME type video/mp4 to Anthropic document input", "reason": "Anthropic document input does not support URL-backed video files" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsUrlBackedVideoFileParam",
+      "source": "ChatCompletions",
+      "target": "Bedrock",
+      "errors": [
+        { "pattern": "Lingua file content to Bedrock Converse file input", "reason": "Bedrock Converse does not support Lingua file input" }
       ]
     }
   ]

--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -1403,6 +1403,54 @@
         { "pattern": "messages[*].content[*].arguments.type", "reason": "Google function-call arguments cannot retain the custom argument kind" },
         { "pattern": "messages[*].content[*].arguments.value", "reason": "Google function-call arguments cannot preserve free-form custom tool input" }
       ]
+    },
+    {
+      "testCase": "chatCompletionsUrlBackedAudioFileParam",
+      "source": "ChatCompletions",
+      "target": "Google",
+      "fields": [
+        { "pattern": "messages[*].content[*].filename", "reason": "Google fileData has no filename field; it preserves the remote URI and inferred audio MIME type" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsUrlBackedAudioFileParam",
+      "source": "ChatCompletions",
+      "target": "Responses",
+      "errors": [
+        { "pattern": "Lingua file content with MIME type audio/mp3 to OpenAI Responses input_file", "reason": "OpenAI Responses input_file does not support audio files" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsUrlBackedAudioFileParam",
+      "source": "ChatCompletions",
+      "target": "Anthropic",
+      "errors": [
+        { "pattern": "URL-backed file with MIME type audio/mp3 to Anthropic document input", "reason": "Anthropic document input does not support URL-backed audio files" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsUrlBackedVideoFileParam",
+      "source": "ChatCompletions",
+      "target": "Google",
+      "fields": [
+        { "pattern": "messages[*].content[*].filename", "reason": "Google fileData has no filename field; it preserves the remote URI and inferred video MIME type" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsUrlBackedVideoFileParam",
+      "source": "ChatCompletions",
+      "target": "Responses",
+      "errors": [
+        { "pattern": "Lingua file content with MIME type video/mp4 to OpenAI Responses input_file", "reason": "OpenAI Responses input_file does not support video files" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsUrlBackedVideoFileParam",
+      "source": "ChatCompletions",
+      "target": "Anthropic",
+      "errors": [
+        { "pattern": "URL-backed file with MIME type video/mp4 to Anthropic document input", "reason": "Anthropic document input does not support URL-backed video files" }
+      ]
     }
   ]
 }

--- a/crates/lingua/src/providers/anthropic/convert.rs
+++ b/crates/lingua/src/providers/anthropic/convert.rs
@@ -873,6 +873,38 @@ impl TryFromLLM<Message> for generated::InputMessage {
                 let anthropic_content = match content {
                     UserContent::String(text) => generated::MessageContent::PurpleString(text),
                     UserContent::Array(parts) => {
+                        for part in &parts {
+                            let UserContentPart::File {
+                                data: Value::String(data),
+                                media_type,
+                                ..
+                            } = part
+                            else {
+                                continue;
+                            };
+
+                            let is_url = data.starts_with("http://") || data.starts_with("https://");
+
+                            if is_url
+                                && !matches!(&**media_type, "application/pdf" | "text/plain")
+                            {
+                                return Err(ConvertError::UnsupportedMapping {
+                                    from: format!(
+                                        "URL-backed file with MIME type {}",
+                                        media_type
+                                    ),
+                                    to: "Anthropic document input",
+                                });
+                            }
+
+                            if media_type.starts_with("audio/") || media_type.starts_with("video/") {
+                                return Err(ConvertError::UnsupportedMapping {
+                                    from: format!("Lingua file content with MIME type {}", media_type),
+                                    to: "Anthropic document input",
+                                });
+                            }
+                        }
+
                         let blocks = parts
                             .into_iter()
                             .filter_map(|part| match part {
@@ -3416,6 +3448,38 @@ mod tests {
         } else {
             panic!("Expected InputContentBlockArray");
         }
+    }
+
+    #[test]
+    fn test_url_backed_audio_file_errors_for_anthropic() {
+        let message = Message::User {
+            content: UserContent::Array(vec![UserContentPart::File {
+                data: serde_json::Value::String("https://example.com/sample.mp3".to_string()),
+                filename: Some("sample.mp3".to_string()),
+                media_type: "audio/mp3".to_string(),
+                provider_options: None,
+            }]),
+        };
+
+        let error = <generated::InputMessage as TryFromLLM<Message>>::try_from(message)
+            .expect_err("Anthropic does not support URL-backed audio documents");
+        assert!(matches!(error, ConvertError::UnsupportedMapping { .. }));
+    }
+
+    #[test]
+    fn test_base64_audio_file_errors_for_anthropic() {
+        let message = Message::User {
+            content: UserContent::Array(vec![UserContentPart::File {
+                data: serde_json::Value::String("c2FtcGxlIGF1ZGlv".to_string()),
+                filename: Some("sample.mp3".to_string()),
+                media_type: "audio/mp3".to_string(),
+                provider_options: None,
+            }]),
+        };
+
+        let error = <generated::InputMessage as TryFromLLM<Message>>::try_from(message)
+            .expect_err("Anthropic does not support audio documents");
+        assert!(matches!(error, ConvertError::UnsupportedMapping { .. }));
     }
 
     #[test]

--- a/crates/lingua/src/providers/bedrock/convert.rs
+++ b/crates/lingua/src/providers/bedrock/convert.rs
@@ -180,39 +180,51 @@ impl TryFromLLM<Message> for BedrockMessage {
             Message::User { content } => {
                 let blocks = match content {
                     UserContent::String(s) => vec![BedrockContentBlock::Text { text: s }],
-                    UserContent::Array(parts) => parts
-                        .into_iter()
-                        .filter_map(|p| match p {
-                            UserContentPart::Text(t) => {
-                                Some(BedrockContentBlock::Text { text: t.text })
-                            }
-                            UserContentPart::Image {
-                                image, media_type, ..
-                            } => {
-                                if let Value::String(data) = image {
-                                    let format = media_type
-                                        .as_deref()
-                                        .and_then(|mt| mt.strip_prefix("image/"))
-                                        .map(|f| match f {
-                                            "png" => BedrockImageFormat::Png,
-                                            "gif" => BedrockImageFormat::Gif,
-                                            "webp" => BedrockImageFormat::Webp,
-                                            _ => BedrockImageFormat::Jpeg,
-                                        })
-                                        .unwrap_or(BedrockImageFormat::Jpeg);
-                                    Some(BedrockContentBlock::Image {
-                                        image: BedrockImageBlock {
-                                            format,
-                                            source: BedrockImageSource { bytes: data },
-                                        },
-                                    })
-                                } else {
-                                    None
+                    UserContent::Array(parts) => {
+                        if parts
+                            .iter()
+                            .any(|part| matches!(part, UserContentPart::File { .. }))
+                        {
+                            return Err(ConvertError::UnsupportedMapping {
+                                from: "Lingua file content".to_string(),
+                                to: "Bedrock Converse file input",
+                            });
+                        }
+
+                        parts
+                            .into_iter()
+                            .filter_map(|p| match p {
+                                UserContentPart::Text(t) => {
+                                    Some(BedrockContentBlock::Text { text: t.text })
                                 }
-                            }
-                            _ => None,
-                        })
-                        .collect(),
+                                UserContentPart::Image {
+                                    image, media_type, ..
+                                } => {
+                                    if let Value::String(data) = image {
+                                        let format = media_type
+                                            .as_deref()
+                                            .and_then(|mt| mt.strip_prefix("image/"))
+                                            .map(|f| match f {
+                                                "png" => BedrockImageFormat::Png,
+                                                "gif" => BedrockImageFormat::Gif,
+                                                "webp" => BedrockImageFormat::Webp,
+                                                _ => BedrockImageFormat::Jpeg,
+                                            })
+                                            .unwrap_or(BedrockImageFormat::Jpeg);
+                                        Some(BedrockContentBlock::Image {
+                                            image: BedrockImageBlock {
+                                                format,
+                                                source: BedrockImageSource { bytes: data },
+                                            },
+                                        })
+                                    } else {
+                                        None
+                                    }
+                                }
+                                _ => None,
+                            })
+                            .collect()
+                    }
                 };
                 (BedrockConversationRole::User, blocks)
             }
@@ -733,6 +745,22 @@ mod tests {
             BedrockContentBlock::Text { text } => assert_eq!(text, "Hello"),
             _ => panic!("Expected text block"),
         }
+    }
+
+    #[test]
+    fn test_message_to_bedrock_rejects_file_content() {
+        let message = Message::User {
+            content: UserContent::Array(vec![UserContentPart::File {
+                data: Value::String("https://example.com/sample.mp3".to_string()),
+                filename: Some("sample.mp3".to_string()),
+                media_type: "audio/mp3".to_string(),
+                provider_options: None,
+            }]),
+        };
+
+        let error = <BedrockMessage as TryFromLLM<Message>>::try_from(message)
+            .expect_err("Bedrock must not silently drop file content");
+        assert!(matches!(error, ConvertError::UnsupportedMapping { .. }));
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/convert.rs
+++ b/crates/lingua/src/providers/google/convert.rs
@@ -30,7 +30,7 @@ use crate::universal::request::{
 };
 use crate::universal::response::{FinishReason, UniversalUsage};
 use crate::universal::tools::{BuiltinToolProvider, UniversalTool, UniversalToolType};
-use crate::util::media::{parse_base64_data_url, parse_file_metadata_from_url};
+use crate::util::media::{infer_mime_type_from_reference, parse_base64_data_url};
 
 /// Prefix for synthetic tool call IDs generated when Google omits them.
 pub(super) const SYNTHETIC_CALL_ID_PREFIX: &str = "call_";
@@ -56,71 +56,7 @@ fn text_part(text: String) -> GooglePart {
 }
 
 fn mime_type_from_url(url: &str) -> String {
-    if let Some(metadata) = parse_file_metadata_from_url(url) {
-        if let Some(content_type) = metadata.content_type {
-            return content_type;
-        }
-
-        if let Some((_, extension)) = metadata.filename.rsplit_once('.') {
-            let mime_type = if extension.eq_ignore_ascii_case("jpg")
-                || extension.eq_ignore_ascii_case("jpeg")
-            {
-                Some("image/jpeg")
-            } else if extension.eq_ignore_ascii_case("png") {
-                Some("image/png")
-            } else if extension.eq_ignore_ascii_case("webp") {
-                Some("image/webp")
-            } else if extension.eq_ignore_ascii_case("heic") {
-                Some("image/heic")
-            } else if extension.eq_ignore_ascii_case("heif") {
-                Some("image/heif")
-            } else if extension.eq_ignore_ascii_case("pdf") {
-                Some("application/pdf")
-            } else if extension.eq_ignore_ascii_case("txt") {
-                Some("text/plain")
-            } else if extension.eq_ignore_ascii_case("flv") {
-                Some("video/x-flv")
-            } else if extension.eq_ignore_ascii_case("mov") {
-                Some("video/quicktime")
-            } else if extension.eq_ignore_ascii_case("mpeg") {
-                Some("video/mpeg")
-            } else if extension.eq_ignore_ascii_case("mpegs") {
-                Some("video/mpegs")
-            } else if extension.eq_ignore_ascii_case("mpg") {
-                Some("video/mpg")
-            } else if extension.eq_ignore_ascii_case("wmv") {
-                Some("video/wmv")
-            } else if extension.eq_ignore_ascii_case("3gp")
-                || extension.eq_ignore_ascii_case("3gpp")
-            {
-                Some("video/3gpp")
-            } else if extension.eq_ignore_ascii_case("aac") {
-                Some("audio/x-aac")
-            } else if extension.eq_ignore_ascii_case("flac") {
-                Some("audio/flac")
-            } else if extension.eq_ignore_ascii_case("mp3") {
-                Some("audio/mp3")
-            } else if extension.eq_ignore_ascii_case("m4a") {
-                Some("audio/m4a")
-            } else if extension.eq_ignore_ascii_case("mpga") {
-                Some("audio/mpga")
-            } else if extension.eq_ignore_ascii_case("ogg") {
-                Some("audio/ogg")
-            } else if extension.eq_ignore_ascii_case("pcm") {
-                Some("audio/pcm")
-            } else if extension.eq_ignore_ascii_case("wav") {
-                Some("audio/wav")
-            } else {
-                None
-            };
-
-            if let Some(mime_type) = mime_type {
-                return mime_type.to_string();
-            }
-        }
-    }
-
-    DEFAULT_MIME_TYPE.to_string()
+    infer_mime_type_from_reference(None, Some(url)).unwrap_or_else(|| DEFAULT_MIME_TYPE.to_string())
 }
 
 fn value_to_map(value: &Value) -> Option<Map<String, Value>> {
@@ -518,6 +454,7 @@ impl TryFromLLM<Message> for GoogleContent {
                                 }
                                 UserContentPart::File {
                                     data: Value::String(data),
+                                    filename,
                                     media_type,
                                     ..
                                 } => {
@@ -532,10 +469,22 @@ impl TryFromLLM<Message> for GoogleContent {
                                     } else if data.starts_with("http://")
                                         || data.starts_with("https://")
                                     {
+                                        let mime_type = if media_type == "application/octet-stream" {
+                                            infer_mime_type_from_reference(
+                                                filename.as_deref(),
+                                                Some(&data),
+                                            )
+                                        } else {
+                                            Some(media_type)
+                                        }
+                                        .ok_or_else(|| ConvertError::UnsupportedMapping {
+                                            from: "URL-backed file with an unknown MIME type".to_string(),
+                                            to: "Google fileData (provide a recognized filename or MIME-bearing data URL)",
+                                        })?;
                                         converted.push(GooglePart {
                                             file_data: Some(GoogleFileData {
                                                 file_uri: Some(data),
-                                                mime_type: Some(media_type),
+                                                mime_type: Some(mime_type),
                                             }),
                                             ..Default::default()
                                         });
@@ -1490,6 +1439,59 @@ mod tests {
         );
         assert_eq!(file_data.mime_type.as_deref(), Some("application/pdf"));
         assert!(parts[0].inline_data.is_none());
+    }
+
+    #[test]
+    fn test_url_backed_file_infers_audio_and_video_mime_types() {
+        let message = Message::User {
+            content: UserContent::Array(vec![
+                UserContentPart::File {
+                    data: Value::String("https://example.com/audio".to_string()),
+                    filename: Some("sample-3s.mp3".to_string()),
+                    media_type: "application/octet-stream".to_string(),
+                    provider_options: None,
+                },
+                UserContentPart::File {
+                    data: Value::String("https://example.com/video/sample-5s.mp4".to_string()),
+                    filename: None,
+                    media_type: "application/octet-stream".to_string(),
+                    provider_options: None,
+                },
+            ]),
+        };
+
+        let content = <GoogleContent as TryFromLLM<Message>>::try_from(message).unwrap();
+        let parts = content.parts.unwrap();
+        assert_eq!(
+            parts[0]
+                .file_data
+                .as_ref()
+                .and_then(|file_data| file_data.mime_type.as_deref()),
+            Some("audio/mp3")
+        );
+        assert_eq!(
+            parts[1]
+                .file_data
+                .as_ref()
+                .and_then(|file_data| file_data.mime_type.as_deref()),
+            Some("video/mp4")
+        );
+    }
+
+    #[test]
+    fn test_url_backed_file_with_unknown_mime_type_errors() {
+        let message = Message::User {
+            content: UserContent::Array(vec![UserContentPart::File {
+                data: Value::String("https://example.com/file".to_string()),
+                filename: None,
+                media_type: "application/octet-stream".to_string(),
+                provider_options: None,
+            }]),
+        };
+
+        let error = <GoogleContent as TryFromLLM<Message>>::try_from(message)
+            .expect_err("unknown URL-backed files should fail before the provider request");
+        assert!(matches!(error, ConvertError::UnsupportedMapping { .. }));
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -14,7 +14,7 @@ use crate::universal::{
     ToolDiscoveryResultContentPart, ToolDiscoveryResultItem, ToolResultContentPart, UserContent,
     UserContentPart,
 };
-use crate::util::media::parse_base64_data_url;
+use crate::util::media::{infer_mime_type_from_reference, parse_base64_data_url};
 use base64::Engine;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
@@ -931,21 +931,8 @@ pub(crate) fn responses_output_values_from_universal_context(
 }
 
 fn openai_media_type_from_reference(filename: Option<&str>, file_url: Option<&str>) -> String {
-    let extension = filename
-        .and_then(|name| name.rsplit('.').next().map(str::to_string))
-        .or_else(|| {
-            file_url
-                .and_then(|url| url.rsplit('/').next())
-                .and_then(|segment| segment.split('?').next())
-                .and_then(|name| name.rsplit('.').next())
-                .map(str::to_string)
-        });
-
-    match extension.as_deref() {
-        Some("txt") => "text/plain".to_string(),
-        Some("pdf") => "application/pdf".to_string(),
-        _ => "application/octet-stream".to_string(),
-    }
+    infer_mime_type_from_reference(filename, file_url)
+        .unwrap_or_else(|| "application/octet-stream".to_string())
 }
 
 fn openai_file_payload_from_data(
@@ -994,7 +981,12 @@ fn universal_file_payload_from_openai(
         });
     }
 
-    let media_type = openai_media_type_from_reference(filename.as_deref(), file_url.as_deref());
+    let reference_url = file_url.as_deref().or_else(|| {
+        file_data
+            .as_deref()
+            .filter(|data| data.starts_with("http://") || data.starts_with("https://"))
+    });
+    let media_type = openai_media_type_from_reference(filename.as_deref(), reference_url);
 
     if let Some(file_url) = file_url {
         return Ok((
@@ -1873,25 +1865,33 @@ impl TryFromLLM<UserContentPart> for openai::InputContent {
                 filename,
                 media_type,
                 provider_options,
-            } => match openai_file_payload_from_data(data, &media_type)? {
-                OpenAIFilePayload::FileUrl(file_url) => openai::InputContent {
-                    input_content_type: openai::InputItemContentListType::InputFile,
-                    file_url: Some(file_url),
-                    filename,
-                    ..Default::default()
-                },
-                OpenAIFilePayload::FileData(file_data) => {
-                    let filename =
-                        openai_filename_for_file(filename, &media_type, &provider_options);
+            } => {
+                if media_type.starts_with("audio/") || media_type.starts_with("video/") {
+                    return Err(ConvertError::UnsupportedMapping {
+                        from: format!("Lingua file content with MIME type {}", media_type),
+                        to: "OpenAI Responses input_file",
+                    });
+                }
 
-                    openai::InputContent {
+                match openai_file_payload_from_data(data, &media_type)? {
+                    OpenAIFilePayload::FileUrl(file_url) => openai::InputContent {
                         input_content_type: openai::InputItemContentListType::InputFile,
-                        file_data: Some(file_data),
-                        filename,
+                        file_url: Some(file_url),
                         ..Default::default()
+                    },
+                    OpenAIFilePayload::FileData(file_data) => {
+                        let filename =
+                            openai_filename_for_file(filename, &media_type, &provider_options);
+
+                        openai::InputContent {
+                            input_content_type: openai::InputItemContentListType::InputFile,
+                            file_data: Some(file_data),
+                            filename,
+                            ..Default::default()
+                        }
                     }
                 }
-            },
+            }
         })
     }
 }
@@ -6560,6 +6560,39 @@ mod tests {
     }
 
     #[test]
+    fn user_url_backed_file_omits_supplied_filename_for_responses() {
+        let input = UserContentPart::File {
+            data: serde_json::Value::String("https://example.com/sample.pdf".to_string()),
+            filename: Some("sample.pdf".to_string()),
+            media_type: "application/pdf".to_string(),
+            provider_options: None,
+        };
+
+        let converted = <openai::InputContent as TryFromLLM<UserContentPart>>::try_from(input)
+            .expect("file should convert");
+
+        assert_eq!(
+            converted.file_url.as_deref(),
+            Some("https://example.com/sample.pdf")
+        );
+        assert!(converted.filename.is_none());
+    }
+
+    #[test]
+    fn user_audio_file_errors_for_responses() {
+        let input = UserContentPart::File {
+            data: serde_json::Value::String("https://example.com/sample.mp3".to_string()),
+            filename: Some("sample.mp3".to_string()),
+            media_type: "audio/mp3".to_string(),
+            provider_options: None,
+        };
+
+        let error = <openai::InputContent as TryFromLLM<UserContentPart>>::try_from(input)
+            .expect_err("Responses input_file does not support audio files");
+        assert!(matches!(error, ConvertError::UnsupportedMapping { .. }));
+    }
+
+    #[test]
     fn user_file_errors_for_non_string_data() {
         let input = UserContentPart::File {
             data: json!({ "not": "supported" }),
@@ -6962,6 +6995,35 @@ mod tests {
                 assert_eq!(data, serde_json::Value::String("Sample text.".to_string()));
                 assert_eq!(filename.as_deref(), Some("Doc.txt"));
                 assert_eq!(media_type, "text/plain");
+            }
+            other => panic!("expected file content, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn chat_completions_url_backed_file_infers_audio_mime_type_from_filename() {
+        let input = openai::ChatCompletionRequestMessageContentPart {
+            text: None,
+            content_part_type: openai::PurpleType::File,
+            prompt_cache_breakpoint: None,
+            image_url: None,
+            input_audio: None,
+            file: Some(openai::File {
+                file_data: Some("https://example.com/media".to_string()),
+                file_id: None,
+                filename: Some("sample-3s.mp3".to_string()),
+            }),
+            refusal: None,
+        };
+
+        let converted = <UserContentPart as TryFromLLM<
+            openai::ChatCompletionRequestMessageContentPart,
+        >>::try_from(input)
+        .expect("file should import");
+
+        match converted {
+            UserContentPart::File { media_type, .. } => {
+                assert_eq!(media_type, "audio/mp3");
             }
             other => panic!("expected file content, got {:?}", other),
         }

--- a/crates/lingua/src/util/media.rs
+++ b/crates/lingua/src/util/media.rs
@@ -106,6 +106,81 @@ pub struct FileMetadata {
     pub content_type: Option<String>,
 }
 
+/// Infer a MIME type from a filename or HTTP(S) URL reference.
+///
+/// A content type encoded in a signed URL takes precedence over filename and
+/// path-extension inference.
+pub fn infer_mime_type_from_reference(filename: Option<&str>, url: Option<&str>) -> Option<String> {
+    let url_metadata = url.and_then(parse_file_metadata_from_url);
+
+    if let Some(content_type) = url_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.content_type.clone())
+    {
+        return Some(content_type);
+    }
+
+    let name = filename.or_else(|| {
+        url_metadata
+            .as_ref()
+            .map(|metadata| metadata.filename.as_str())
+    })?;
+    let extension = name.rsplit_once('.')?.1;
+
+    let mime_type =
+        if extension.eq_ignore_ascii_case("jpg") || extension.eq_ignore_ascii_case("jpeg") {
+            "image/jpeg"
+        } else if extension.eq_ignore_ascii_case("png") {
+            "image/png"
+        } else if extension.eq_ignore_ascii_case("webp") {
+            "image/webp"
+        } else if extension.eq_ignore_ascii_case("heic") {
+            "image/heic"
+        } else if extension.eq_ignore_ascii_case("heif") {
+            "image/heif"
+        } else if extension.eq_ignore_ascii_case("pdf") {
+            "application/pdf"
+        } else if extension.eq_ignore_ascii_case("txt") {
+            "text/plain"
+        } else if extension.eq_ignore_ascii_case("flv") {
+            "video/x-flv"
+        } else if extension.eq_ignore_ascii_case("mov") {
+            "video/quicktime"
+        } else if extension.eq_ignore_ascii_case("mp4") {
+            "video/mp4"
+        } else if extension.eq_ignore_ascii_case("mpeg") {
+            "video/mpeg"
+        } else if extension.eq_ignore_ascii_case("mpegs") {
+            "video/mpegs"
+        } else if extension.eq_ignore_ascii_case("mpg") {
+            "video/mpg"
+        } else if extension.eq_ignore_ascii_case("wmv") {
+            "video/wmv"
+        } else if extension.eq_ignore_ascii_case("3gp") || extension.eq_ignore_ascii_case("3gpp") {
+            "video/3gpp"
+        } else if extension.eq_ignore_ascii_case("aac") {
+            "audio/x-aac"
+        } else if extension.eq_ignore_ascii_case("flac") {
+            "audio/flac"
+        } else if extension.eq_ignore_ascii_case("mp3") {
+            "audio/mp3"
+        } else if extension.eq_ignore_ascii_case("m4a") {
+            "audio/m4a"
+        } else if extension.eq_ignore_ascii_case("mpga") {
+            "audio/mpga"
+        } else if extension.eq_ignore_ascii_case("ogg") {
+            "audio/ogg"
+        } else if extension.eq_ignore_ascii_case("pcm") {
+            "audio/pcm"
+        } else if extension.eq_ignore_ascii_case("wav") {
+            "audio/wav"
+        } else {
+            return None;
+        };
+
+    Some(mime_type.to_string())
+}
+
 /// Parse file metadata from a URL.
 ///
 /// This handles:
@@ -807,5 +882,33 @@ mod tests {
         assert!(parse_file_metadata_from_url("not a url").is_none());
         assert!(parse_file_metadata_from_url("ftp://example.com/file").is_none());
         assert!(parse_file_metadata_from_url("https://example.com/").is_none());
+    }
+
+    #[test]
+    fn test_infer_mime_type_from_reference_uses_filename_and_url() {
+        assert_eq!(
+            infer_mime_type_from_reference(Some("sample-3s.MP3"), Some("https://example.com/file")),
+            Some("audio/mp3".to_string())
+        );
+        assert_eq!(
+            infer_mime_type_from_reference(
+                None,
+                Some("https://example.com/video/sample-5s.mp4?signature=abc")
+            ),
+            Some("video/mp4".to_string())
+        );
+    }
+
+    #[test]
+    fn test_infer_mime_type_from_reference_uses_signed_url_content_type() {
+        assert_eq!(
+            infer_mime_type_from_reference(
+                Some("sample.mp3"),
+                Some(
+                    "https://example.com/file?X-Amz-Expires=60&response-content-type=audio%2Fmpeg"
+                )
+            ),
+            Some("audio/mpeg".to_string())
+        );
     }
 }

--- a/crates/lingua/src/util/media.rs
+++ b/crates/lingua/src/util/media.rs
@@ -120,65 +120,69 @@ pub fn infer_mime_type_from_reference(filename: Option<&str>, url: Option<&str>)
         return Some(content_type);
     }
 
-    let name = filename.or_else(|| {
-        url_metadata
-            .as_ref()
-            .map(|metadata| metadata.filename.as_str())
-    })?;
+    let url_filename = url_metadata
+        .as_ref()
+        .map(|metadata| metadata.filename.as_str());
+
+    filename
+        .into_iter()
+        .chain(url_filename)
+        .find_map(mime_type_from_filename)
+        .map(str::to_string)
+}
+
+fn mime_type_from_filename(name: &str) -> Option<&'static str> {
     let extension = name.rsplit_once('.')?.1;
 
-    let mime_type =
-        if extension.eq_ignore_ascii_case("jpg") || extension.eq_ignore_ascii_case("jpeg") {
-            "image/jpeg"
-        } else if extension.eq_ignore_ascii_case("png") {
-            "image/png"
-        } else if extension.eq_ignore_ascii_case("webp") {
-            "image/webp"
-        } else if extension.eq_ignore_ascii_case("heic") {
-            "image/heic"
-        } else if extension.eq_ignore_ascii_case("heif") {
-            "image/heif"
-        } else if extension.eq_ignore_ascii_case("pdf") {
-            "application/pdf"
-        } else if extension.eq_ignore_ascii_case("txt") {
-            "text/plain"
-        } else if extension.eq_ignore_ascii_case("flv") {
-            "video/x-flv"
-        } else if extension.eq_ignore_ascii_case("mov") {
-            "video/quicktime"
-        } else if extension.eq_ignore_ascii_case("mp4") {
-            "video/mp4"
-        } else if extension.eq_ignore_ascii_case("mpeg") {
-            "video/mpeg"
-        } else if extension.eq_ignore_ascii_case("mpegs") {
-            "video/mpegs"
-        } else if extension.eq_ignore_ascii_case("mpg") {
-            "video/mpg"
-        } else if extension.eq_ignore_ascii_case("wmv") {
-            "video/wmv"
-        } else if extension.eq_ignore_ascii_case("3gp") || extension.eq_ignore_ascii_case("3gpp") {
-            "video/3gpp"
-        } else if extension.eq_ignore_ascii_case("aac") {
-            "audio/x-aac"
-        } else if extension.eq_ignore_ascii_case("flac") {
-            "audio/flac"
-        } else if extension.eq_ignore_ascii_case("mp3") {
-            "audio/mp3"
-        } else if extension.eq_ignore_ascii_case("m4a") {
-            "audio/m4a"
-        } else if extension.eq_ignore_ascii_case("mpga") {
-            "audio/mpga"
-        } else if extension.eq_ignore_ascii_case("ogg") {
-            "audio/ogg"
-        } else if extension.eq_ignore_ascii_case("pcm") {
-            "audio/pcm"
-        } else if extension.eq_ignore_ascii_case("wav") {
-            "audio/wav"
-        } else {
-            return None;
-        };
-
-    Some(mime_type.to_string())
+    if extension.eq_ignore_ascii_case("jpg") || extension.eq_ignore_ascii_case("jpeg") {
+        Some("image/jpeg")
+    } else if extension.eq_ignore_ascii_case("png") {
+        Some("image/png")
+    } else if extension.eq_ignore_ascii_case("webp") {
+        Some("image/webp")
+    } else if extension.eq_ignore_ascii_case("heic") {
+        Some("image/heic")
+    } else if extension.eq_ignore_ascii_case("heif") {
+        Some("image/heif")
+    } else if extension.eq_ignore_ascii_case("pdf") {
+        Some("application/pdf")
+    } else if extension.eq_ignore_ascii_case("txt") {
+        Some("text/plain")
+    } else if extension.eq_ignore_ascii_case("flv") {
+        Some("video/x-flv")
+    } else if extension.eq_ignore_ascii_case("mov") {
+        Some("video/quicktime")
+    } else if extension.eq_ignore_ascii_case("mp4") {
+        Some("video/mp4")
+    } else if extension.eq_ignore_ascii_case("mpeg") {
+        Some("video/mpeg")
+    } else if extension.eq_ignore_ascii_case("mpegs") {
+        Some("video/mpegs")
+    } else if extension.eq_ignore_ascii_case("mpg") {
+        Some("video/mpg")
+    } else if extension.eq_ignore_ascii_case("wmv") {
+        Some("video/wmv")
+    } else if extension.eq_ignore_ascii_case("3gp") || extension.eq_ignore_ascii_case("3gpp") {
+        Some("video/3gpp")
+    } else if extension.eq_ignore_ascii_case("aac") {
+        Some("audio/x-aac")
+    } else if extension.eq_ignore_ascii_case("flac") {
+        Some("audio/flac")
+    } else if extension.eq_ignore_ascii_case("mp3") {
+        Some("audio/mp3")
+    } else if extension.eq_ignore_ascii_case("m4a") {
+        Some("audio/m4a")
+    } else if extension.eq_ignore_ascii_case("mpga") {
+        Some("audio/mpga")
+    } else if extension.eq_ignore_ascii_case("ogg") {
+        Some("audio/ogg")
+    } else if extension.eq_ignore_ascii_case("pcm") {
+        Some("audio/pcm")
+    } else if extension.eq_ignore_ascii_case("wav") {
+        Some("audio/wav")
+    } else {
+        None
+    }
 }
 
 /// Parse file metadata from a URL.
@@ -896,6 +900,13 @@ mod tests {
                 Some("https://example.com/video/sample-5s.mp4?signature=abc")
             ),
             Some("video/mp4".to_string())
+        );
+        assert_eq!(
+            infer_mime_type_from_reference(
+                Some("audio"),
+                Some("https://example.com/audio/sample-3s.mp3")
+            ),
+            Some("audio/mp3".to_string())
         );
     }
 

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -571,6 +571,63 @@ export const paramsCases: TestCaseCollection = {
     bedrock: null,
   },
 
+  chatCompletionsUrlBackedAudioFileParam: {
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Transcribe this audio clip.",
+            },
+            {
+              type: "file",
+              file: {
+                filename: "sample-3s.mp3",
+                file_data: "https://samplelib.com/mp3/sample-3s.mp3",
+              },
+            },
+          ],
+        },
+      ],
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
+  chatCompletionsUrlBackedVideoFileParam: {
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Describe this video clip.",
+            },
+            {
+              type: "file",
+              file: {
+                filename: "sample-5s.mp4",
+                file_data:
+                  "https://samplelib.com/lib/preview/mp4/sample-5s.mp4",
+              },
+            },
+          ],
+        },
+      ],
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+  },
+
   responsesFunctionCallOutputWithoutThoughtSignatureParam: {
     "chat-completions": null,
     responses: {

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -14349,6 +14349,106 @@ Please paste or provide the text you would like me to summarize, and I will glad
 }
 `;
 
+exports[`chat-completions → google > chatCompletionsUrlBackedAudioFileParam > request 1`] = `
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "Transcribe this audio clip.",
+        },
+        {
+          "fileData": {
+            "fileUri": "https://samplelib.com/mp3/sample-3s.mp3",
+            "mimeType": "audio/mp3",
+          },
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "model": "gemini-3.5-flash",
+}
+`;
+
+exports[`chat-completions → google > chatCompletionsUrlBackedAudioFileParam > response 1`] = `
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "(music)",
+        "role": "assistant",
+      },
+    },
+  ],
+  "created": 0,
+  "id": "chatcmpl-transformed",
+  "model": "gemini-3.5-flash",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 205,
+    "completion_tokens_details": {
+      "reasoning_tokens": 202,
+    },
+    "prompt_tokens": 87,
+    "total_tokens": 292,
+  },
+}
+`;
+
+exports[`chat-completions → google > chatCompletionsUrlBackedVideoFileParam > request 1`] = `
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "Describe this video clip.",
+        },
+        {
+          "fileData": {
+            "fileUri": "https://samplelib.com/lib/preview/mp4/sample-5s.mp4",
+            "mimeType": "video/mp4",
+          },
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "model": "gemini-3.5-flash",
+}
+`;
+
+exports[`chat-completions → google > chatCompletionsUrlBackedVideoFileParam > response 1`] = `
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "annotations": [],
+        "content": "The video shows a sunny day in a park, with green trees, a paved path, a bench, and a road with cars and a bus driving by.",
+        "role": "assistant",
+      },
+    },
+  ],
+  "created": 0,
+  "id": "chatcmpl-transformed",
+  "model": "gemini-3.5-flash",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 315,
+    "completion_tokens_details": {
+      "reasoning_tokens": 283,
+    },
+    "prompt_tokens": 550,
+    "total_tokens": 865,
+  },
+}
+`;
+
 exports[`chat-completions → google > complexReasoningRequest > request 1`] = `
 {
   "contents": [

--- a/payloads/snapshots/chatCompletionsUrlBackedAudioFileParam/chat-completions/error.json
+++ b/payloads/snapshots/chatCompletionsUrlBackedAudioFileParam/chat-completions/error.json
@@ -1,0 +1,3 @@
+{
+  "error": "Error: 400 Invalid file data: 'messages[0].content[1].file.file_data'. Expected a base64-encoded data URL with an application/pdf MIME type (e.g. 'data:application/pdf;base64,SGVsbG8sIFdvcmxkIQ=='), but got a value without the 'data:' prefix."
+}

--- a/payloads/snapshots/chatCompletionsUrlBackedAudioFileParam/chat-completions/request.json
+++ b/payloads/snapshots/chatCompletionsUrlBackedAudioFileParam/chat-completions/request.json
@@ -1,0 +1,21 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "Transcribe this audio clip."
+        },
+        {
+          "type": "file",
+          "file": {
+            "filename": "sample-3s.mp3",
+            "file_data": "https://samplelib.com/mp3/sample-3s.mp3"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/payloads/snapshots/chatCompletionsUrlBackedVideoFileParam/chat-completions/error.json
+++ b/payloads/snapshots/chatCompletionsUrlBackedVideoFileParam/chat-completions/error.json
@@ -1,0 +1,3 @@
+{
+  "error": "Error: 400 Invalid file data: 'messages[0].content[1].file.file_data'. Expected a base64-encoded data URL with an application/pdf MIME type (e.g. 'data:application/pdf;base64,SGVsbG8sIFdvcmxkIQ=='), but got a value without the 'data:' prefix."
+}

--- a/payloads/snapshots/chatCompletionsUrlBackedVideoFileParam/chat-completions/request.json
+++ b/payloads/snapshots/chatCompletionsUrlBackedVideoFileParam/chat-completions/request.json
@@ -1,0 +1,21 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "Describe this video clip."
+        },
+        {
+          "type": "file",
+          "file": {
+            "filename": "sample-5s.mp4",
+            "file_data": "https://samplelib.com/lib/preview/mp4/sample-5s.mp4"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/payloads/transforms/chat-completions_to_anthropic/chatCompletionsUrlBackedAudioFileParam.json
+++ b/payloads/transforms/chat-completions_to_anthropic/chatCompletionsUrlBackedAudioFileParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert URL-backed file with MIME type audio/mp3 to Anthropic document input"
+}

--- a/payloads/transforms/chat-completions_to_anthropic/chatCompletionsUrlBackedVideoFileParam.json
+++ b/payloads/transforms/chat-completions_to_anthropic/chatCompletionsUrlBackedVideoFileParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert URL-backed file with MIME type video/mp4 to Anthropic document input"
+}

--- a/payloads/transforms/chat-completions_to_bedrock/chatCompletionsUrlBackedAudioFileParam-streaming.json
+++ b/payloads/transforms/chat-completions_to_bedrock/chatCompletionsUrlBackedAudioFileParam-streaming.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert Lingua file content to Bedrock Converse file input"
+}

--- a/payloads/transforms/chat-completions_to_bedrock/chatCompletionsUrlBackedAudioFileParam.json
+++ b/payloads/transforms/chat-completions_to_bedrock/chatCompletionsUrlBackedAudioFileParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert Lingua file content to Bedrock Converse file input"
+}

--- a/payloads/transforms/chat-completions_to_bedrock/chatCompletionsUrlBackedVideoFileParam-streaming.json
+++ b/payloads/transforms/chat-completions_to_bedrock/chatCompletionsUrlBackedVideoFileParam-streaming.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert Lingua file content to Bedrock Converse file input"
+}

--- a/payloads/transforms/chat-completions_to_bedrock/chatCompletionsUrlBackedVideoFileParam.json
+++ b/payloads/transforms/chat-completions_to_bedrock/chatCompletionsUrlBackedVideoFileParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert Lingua file content to Bedrock Converse file input"
+}

--- a/payloads/transforms/chat-completions_to_google/chatCompletionsUrlBackedAudioFileParam.json
+++ b/payloads/transforms/chat-completions_to_google/chatCompletionsUrlBackedAudioFileParam.json
@@ -1,0 +1,36 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "(music)",
+            "thoughtSignature": "Er0GCroGARFNMg+nBDFGwNzaB6sN8F2GCcv02Nx5fqWxOI+gq/1CaWQJuW2CMBpg1J50GAScy0DzvwlctfFDZB7egDQCK/1ASpn5RTKIBpsi9MNTasLTNC0Cy9VMsePkrvhhJgv3dVooKJ45PquZ/xDm8O4qBVStB7yvgDgI8Amxw889uyqn//eKDL1B9vc3KrMUmZtkN+aNwITlZ5RzBT9HTiQ2z9xlRt4SNK8sYcdUGXBxr9SerlNPqEZWxw3g15qGv4qF/48XV3XtQGjKf/hI2IdBWDmP223CqNlh3daOVQ9OdsVFDqBJZzWAoMzJsCaBsDByvR9NztcV1pWova3qc7sIBL21pQP/jKI/yZBYYphIwuldRoqJocMGQur58nN9ENkp20g9PjAS8dEoUJ6HTU4IG5Ls2u3SGFrjrkaLfhWlwd/jxEZsmcZfL6Xfgw4CuL/OyVl5sBMu/jDyV/6BDVqipZjfLZDx2cWtDaFE3xlqERiAGM62+kE0zWpDu5P3xxrT9WwHxrQpHJU70jgG1eJ8qVXoQ1YY1GaifAkrPZo83JzfOEViPpX7FpWoZ2Jm264m2N9HAFUB7sFWoPewRw++ms0Yq2VINAlv+mh/PjNKZvFt27WumFnImwpbHPuTqh+YXPie19GD/+81dfIVLrFKd8mZ5+bAvSWFhmlV+Na2cq09miCRnL2xcfuiNG+L4+e/yOdK/mygl/etPa6OSBWfGEeT/AlNSthZJ1f3uRGeiukf/YzG1E6mSvnN5XOqUxV5HAWWqTV3a+lki+A81GCwAhAt0ymsLjEqz+6S3BoFVPbnt6JW6kKeU7XbaNtn9VpqwSqauR33z5FyUMSKk4kgZnnQRKjyjeA3aI+r0AHC+eAJa4E3WeMYGOxap6JDyCdjmeFo/+b7a2Q0JQ5tNkBB9J1UuZlrn3kIgdUTrHEZJ9JPz+YjfZAeh8IDB9XbdIEzSPDXmbFrPUrftVkJz1JUkGjeC8y8Ei84nhH79xa2DJxXI2heifuqCXTDEg7uO44RModv7swYxdsUkgSvX484fzKHBGxLkkyJ7v8M47wFejygreEQkHWHmhEnOeELXEua41inDkwIsXEC9Q=="
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 87,
+    "candidatesTokenCount": 3,
+    "totalTokenCount": 292,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 7
+      },
+      {
+        "modality": "AUDIO",
+        "tokenCount": 80
+      }
+    ],
+    "thoughtsTokenCount": 202,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "kD5yaoHiJaaU_uMPhrPb-AE"
+}

--- a/payloads/transforms/chat-completions_to_google/chatCompletionsUrlBackedVideoFileParam.json
+++ b/payloads/transforms/chat-completions_to_google/chatCompletionsUrlBackedVideoFileParam.json
@@ -1,0 +1,36 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The video shows a sunny day in a park, with green trees, a paved path, a bench, and a road with cars and a bus driving by.",
+            "thoughtSignature": "ErEJCq4JARFNMg/1v3QXbOUa9j+rySyurg0hLmPRYc8P8P30WTGab6M/XG0f+oVFzuqO9qVYHGpLkuK9+6ndhLRa03Rp6fbtkO9KZBYU7OFKjdLnElVM/8QXhCu6otQjBk2TZBXAeTVENc7uVwbAnD91EAGVFaslUqKX9Hhk9d3CyUC/C7G6GHaK+ubOCNLXIsDWIYeIK0gbdge152zu4cqeRY8sWVfyz/gn/b3MDzsBK8VE/3BUGOnSJL5FxymnmrjCq6XKfXIsDTNGpWqkVM/JMoWq2jAEGDl4IJCpxD1vs+HFhE3ZNsAWxZRG0gMuHVS1MPiqxiOQ2d5Ut4dbhK1K2XxobBp3WrQi8o79X4cG38kuLa7JIf7gtS4QGUsDL0uJPgM23uHr8ilcOi9odQ/XIcqSQzeoMxeOIe+WgKhMjJyoYQIynf5GKoteRIeg1+x59YQmvlLiny3eZtadNpcvPtP4zbBtzrkYYq20Ktc/nn4nKYh+pBW9DZiqTplQIyxWMX1p4RFBY3yUreJTRxpKiI3t8NTJJzi/plfbjF/HPBzhw99N797TI6mRT+5SPE8ckcDnNMyuW2T199HrGD/yLANivBb6tgTmHtAgP3h0JiROtG88cILOxfcT//EcxTjd70zvwAMXrFvUxB9MmDeRrqAOc7S/YSV02x6e9my4VnQOQKcVxNRXIUNs4otsijYdKxm8lUGn35O9qZFD0ATxhN5UWjNj50apV+4xLlEgML/XowoPb8tYpUzAH3h4LZL7pEps++54bFC6df8DIR3/Rl11CwoW2k9doiWlJjSTAVsJMPPOlAHaXGSRhgtIILG3DTOx5+7G02lnhOzUwMBlKTD90Yp9YmmdcolRMastAbAGTJNdAkIdMd/tpmV4awOC9B7DZAFDjimo35f+mcoxZyTt2meMCUaR5k10bzU1U0SQ8Yq4AQmF/zsZfabDT+G3bY5NDpvx2JFuw+ivkYgQmNZVFyXV1QY+M0bESNnz3PxARxU9HZ8nHTzOAbd0jiiDKoK15eeiavxZvRq62bmjLEBbZw4UETJDwrG61p/tsGY8jA4tGmQ8TWpdLzuRA22XmsAXzFDWaHUE81YieTitDwzpaMMsINUh3+o9WC3ygsdQ/wDSjkAMTQBNUJ6sCWMgMQDp/Hd8oDN91f7dj20NITMMGYN8g1Gp6T6f/grLS/8XPujExEO+gBnY3zmb1bI7Wy/dfP4z3Acee0fD6ULrcOtfO78F+bgWDae+zE0B73vLA/G5aX7Okzv90ChllMzu35/JIpqEk0DOSf+Y1o3eJl9S9EgwmbRuPM7ZNX0aIvI+3N18B8B8WWm6nShgvAKBt2pebOIxfFmZoWlEF+rf6yTluprvUbKueokD1xuOKT5Nk2mA/pwEcZNQijZ/a61FqHZseNo9dWBDnfXp4MT9cBPnXnaOjLk3MRm1NUWKzmus7ni3PXH1J9+jApcYCkJBM6Ab1fl8uWGBC8MtRh6zFakQShmgTNH07imV20v+N6KllqM9iFx+WXYtDgcRBAcppSH3nWMszdsZ5Re8lQdc/+kaYqs3v9ehvDwL4e9DLhPTJG2d55phPz8Knv2inRYb1w=="
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 550,
+    "candidatesTokenCount": 32,
+    "totalTokenCount": 865,
+    "promptTokensDetails": [
+      {
+        "modality": "VIDEO",
+        "tokenCount": 539
+      },
+      {
+        "modality": "TEXT",
+        "tokenCount": 11
+      }
+    ],
+    "thoughtsTokenCount": 283,
+    "serviceTier": "standard"
+  },
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "kD5yatX5Ku2g_uMP1_aqkAk"
+}

--- a/payloads/transforms/chat-completions_to_responses/chatCompletionsUrlBackedAudioFileParam.json
+++ b/payloads/transforms/chat-completions_to_responses/chatCompletionsUrlBackedAudioFileParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert Lingua file content with MIME type audio/mp3 to OpenAI Responses input_file"
+}

--- a/payloads/transforms/chat-completions_to_responses/chatCompletionsUrlBackedVideoFileParam.json
+++ b/payloads/transforms/chat-completions_to_responses/chatCompletionsUrlBackedVideoFileParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert Lingua file content with MIME type video/mp4 to OpenAI Responses input_file"
+}

--- a/payloads/transforms/transform_errors.json
+++ b/payloads/transforms/transform_errors.json
@@ -17,6 +17,10 @@
     "chatCompletionsUrlBackedAudioFileParam": "Bedrock Converse does not support file input",
     "chatCompletionsUrlBackedVideoFileParam": "Bedrock Converse does not support file input"
   },
+  "chat-completions_to_bedrock_streaming": {
+    "chatCompletionsUrlBackedAudioFileParam": "Bedrock Converse does not support file input",
+    "chatCompletionsUrlBackedVideoFileParam": "Bedrock Converse does not support file input"
+  },
   "responses_to_anthropic": {
     "reasoningRequestTruncated": "Anthropic requires max_tokens > budget_tokens; min budget (1024) exceeds max_tokens (100)",
     "webSearchToolParam": "Tool 'web_search_preview' of type 'web_search_preview' is not supported by anthropic",

--- a/payloads/transforms/transform_errors.json
+++ b/payloads/transforms/transform_errors.json
@@ -3,11 +3,19 @@
     "temperatureParam": "OpenAI rejected: 'temperature' is not supported with this model",
     "logprobsParam": "OpenAI rejected: logprobs are not supported with reasoning models",
     "chatCompletionsSystemCacheControlParam": "OpenAI Responses only supports request-level 30m cache TTLs and cannot preserve the per-block 1h TTL",
-    "chatCompletionsAssistantCacheControlParam": "Responses output_text cannot preserve assistant text cache control"
+    "chatCompletionsAssistantCacheControlParam": "Responses output_text cannot preserve assistant text cache control",
+    "chatCompletionsUrlBackedAudioFileParam": "OpenAI Responses input_file does not support audio files",
+    "chatCompletionsUrlBackedVideoFileParam": "OpenAI Responses input_file does not support video files"
+  },
+  "chat-completions_to_anthropic": {
+    "chatCompletionsUrlBackedAudioFileParam": "Anthropic document input does not support URL-backed audio files",
+    "chatCompletionsUrlBackedVideoFileParam": "Anthropic document input does not support URL-backed video files"
   },
   "chat-completions_to_bedrock": {
     "multimodalRequest": "Bedrock rejected transformed OpenAI image URL content because Converse expects image bytes",
-    "imageUrlMimeTypeFallbackParam": "Bedrock rejected transformed OpenAI image URL content because Converse expects image bytes"
+    "imageUrlMimeTypeFallbackParam": "Bedrock rejected transformed OpenAI image URL content because Converse expects image bytes",
+    "chatCompletionsUrlBackedAudioFileParam": "Bedrock Converse does not support file input",
+    "chatCompletionsUrlBackedVideoFileParam": "Bedrock Converse does not support file input"
   },
   "responses_to_anthropic": {
     "reasoningRequestTruncated": "Anthropic requires max_tokens > budget_tokens; min budget (1024) exceeds max_tokens (100)",


### PR DESCRIPTION
https://linear.app/braintrustdata/issue/BT-6537/gateway-assigns-applicationoctet-stream-to-url-backed-audiovideo-files

Fix URL-backed audio and video file inputs for Gemini and Vertex prompt invocation.

  OpenAI-style file parts with HTTPS URLs previously inferred only .txt and .pdf; audio/video became application/octet-
  stream, which Google rejects. Lingua now infers supported MIME types from the supplied filename, URL path, or signed-URL
  response-content-type, so .mp3 emits audio/mp3 and .mp4 emits video/mp4.

  Also tighten cross-provider behavior:

  - OpenAI Responses rejects audio/video input_file locally and avoids file_url + filename conflicts.
  - Anthropic rejects unsupported audio/video files locally, including base64 inputs, rather than sending malformed
    document blocks.

  - Bedrock Converse rejects unsupported file content explicitly rather than silently dropping it.
  - Add MP3/MP4 payload cases, captures, transform expectations, and cross-provider expected-difference entries.

  ## Customer impact

  Unblocks Gemini and Vertex customers using large public or signed URL audio/video files through stored prompts and the playground, without base64-embedding media.

  ## Validation

  - Gemini captures succeeded for URL-backed MP3 and MP4.
  - Focused Lingua converter tests pass.
  - Cross-provider transformation guard passes.
  - cargo fmt --check and git diff --check pass.