### PR TITLE
support GCS-backed media for Vertex prompts

### DIFF
--- a/crates/coverage-report/src/requests_expected_differences.json
+++ b/crates/coverage-report/src/requests_expected_differences.json
@@ -1491,6 +1491,54 @@
       "errors": [
         { "pattern": "Lingua file content to Bedrock Converse file input", "reason": "Bedrock Converse does not support Lingua file input" }
       ]
+    },
+    {
+      "testCase": "chatCompletionsGcsBackedVideoFileParam",
+      "source": "ChatCompletions",
+      "target": "Google",
+      "fields": [
+        { "pattern": "messages[*].content[*].filename", "reason": "Google fileData has no filename field; it preserves the GCS URI and inferred video MIME type for Vertex" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsGcsBackedVideoFileParam",
+      "source": "ChatCompletions",
+      "target": "Responses",
+      "errors": [
+        { "pattern": "Lingua file content with MIME type video/mp4 to OpenAI Responses input_file", "reason": "OpenAI Responses input_file does not support video files" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsGcsBackedVideoFileParam",
+      "source": "ChatCompletions",
+      "target": "Anthropic",
+      "errors": [
+        { "pattern": "Lingua file content with MIME type video/mp4 to Anthropic document input", "reason": "Anthropic document input does not support GCS-backed video files" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsGcsBackedVideoFileParam",
+      "source": "ChatCompletions",
+      "target": "Bedrock",
+      "errors": [
+        { "pattern": "Lingua file content to Bedrock Converse file input", "reason": "Bedrock Converse does not support Lingua file input" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsGcsBackedVideoFileParam",
+      "source": "ChatCompletions",
+      "target": "Bedrock Anthropic",
+      "errors": [
+        { "pattern": "Lingua file content with MIME type video/mp4 to Anthropic document input", "reason": "Bedrock Anthropic does not support URL-backed video files" }
+      ]
+    },
+    {
+      "testCase": "chatCompletionsGcsBackedVideoFileParam",
+      "source": "ChatCompletions",
+      "target": "Vertex Anthropic",
+      "errors": [
+        { "pattern": "Lingua file content with MIME type video/mp4 to Anthropic document input", "reason": "Vertex Anthropic does not support URL-backed video files" }
+      ]
     }
   ]
 }

--- a/crates/lingua/src/providers/google/convert.rs
+++ b/crates/lingua/src/providers/google/convert.rs
@@ -34,7 +34,9 @@ use crate::universal::response::{
     TokenModality, UniversalUsage,
 };
 use crate::universal::tools::{BuiltinToolProvider, UniversalTool, UniversalToolType};
-use crate::util::media::{infer_mime_type_from_reference, parse_base64_data_url};
+use crate::util::media::{
+    infer_mime_type_from_reference, is_remote_media_uri, parse_base64_data_url,
+};
 
 /// Prefix for synthetic tool call IDs generated when Google omits them.
 pub(super) const SYNTHETIC_CALL_ID_PREFIX: &str = "call_";
@@ -432,9 +434,7 @@ impl TryFromLLM<Message> for GoogleContent {
                                             }),
                                             ..Default::default()
                                         });
-                                    } else if data.starts_with("http://")
-                                        || data.starts_with("https://")
-                                    {
+                                    } else if is_remote_media_uri(&data) {
                                         let mime_type =
                                             media_type.unwrap_or_else(|| mime_type_from_url(&data));
                                         converted.push(GooglePart {
@@ -470,9 +470,7 @@ impl TryFromLLM<Message> for GoogleContent {
                                             }),
                                             ..Default::default()
                                         });
-                                    } else if data.starts_with("http://")
-                                        || data.starts_with("https://")
-                                    {
+                                    } else if is_remote_media_uri(&data) {
                                         let mime_type = if media_type == "application/octet-stream" {
                                             infer_mime_type_from_reference(
                                                 filename.as_deref(),
@@ -1783,6 +1781,28 @@ mod tests {
                 .and_then(|file_data| file_data.mime_type.as_deref()),
             Some("video/mp4")
         );
+    }
+
+    #[test]
+    fn test_gcs_backed_video_file_emits_google_file_data() {
+        let message = Message::User {
+            content: UserContent::Array(vec![UserContentPart::File {
+                data: Value::String("gs://lingua-test-bucket/sample-200mb.mp4".to_string()),
+                filename: None,
+                media_type: "application/octet-stream".to_string(),
+                provider_options: None,
+            }]),
+        };
+
+        let content = <GoogleContent as TryFromLLM<Message>>::try_from(message).unwrap();
+        let part = &content.parts.unwrap()[0];
+        let file_data = part.file_data.as_ref().expect("file_data should exist");
+        assert_eq!(
+            file_data.file_uri.as_deref(),
+            Some("gs://lingua-test-bucket/sample-200mb.mp4")
+        );
+        assert_eq!(file_data.mime_type.as_deref(), Some("video/mp4"));
+        assert!(part.inline_data.is_none());
     }
 
     #[test]

--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -14,7 +14,9 @@ use crate::universal::{
     ToolDiscoveryResultContentPart, ToolDiscoveryResultItem, ToolResultContentPart, UserContent,
     UserContentPart,
 };
-use crate::util::media::{infer_mime_type_from_reference, parse_base64_data_url};
+use crate::util::media::{
+    infer_mime_type_from_reference, is_remote_media_uri, parse_base64_data_url,
+};
 use base64::Engine;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
@@ -984,7 +986,7 @@ fn universal_file_payload_from_openai(
     let reference_url = file_url.as_deref().or_else(|| {
         file_data
             .as_deref()
-            .filter(|data| data.starts_with("http://") || data.starts_with("https://"))
+            .filter(|data| is_remote_media_uri(data))
     });
     let media_type = openai_media_type_from_reference(filename.as_deref(), reference_url);
 
@@ -7024,6 +7026,43 @@ mod tests {
         match converted {
             UserContentPart::File { media_type, .. } => {
                 assert_eq!(media_type, "audio/mp3");
+            }
+            other => panic!("expected file content, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn chat_completions_gcs_backed_file_preserves_uri_and_infers_video_mime_type() {
+        let input = openai::ChatCompletionRequestMessageContentPart {
+            text: None,
+            content_part_type: openai::PurpleType::File,
+            prompt_cache_breakpoint: None,
+            image_url: None,
+            input_audio: None,
+            file: Some(openai::File {
+                file_data: Some("gs://lingua-test-bucket/sample-200mb.mp4".to_string()),
+                file_id: None,
+                filename: None,
+            }),
+            refusal: None,
+        };
+
+        let converted = <UserContentPart as TryFromLLM<
+            openai::ChatCompletionRequestMessageContentPart,
+        >>::try_from(input)
+        .expect("GCS-backed file should import");
+
+        match converted {
+            UserContentPart::File {
+                data, media_type, ..
+            } => {
+                assert_eq!(
+                    data,
+                    serde_json::Value::String(
+                        "gs://lingua-test-bucket/sample-200mb.mp4".to_string()
+                    )
+                );
+                assert_eq!(media_type, "video/mp4");
             }
             other => panic!("expected file content, got {:?}", other),
         }

--- a/crates/lingua/src/util/media.rs
+++ b/crates/lingua/src/util/media.rs
@@ -106,7 +106,14 @@ pub struct FileMetadata {
     pub content_type: Option<String>,
 }
 
-/// Infer a MIME type from a filename or HTTP(S) URL reference.
+/// Return whether a media reference can be sent to a provider as a remote URI.
+pub fn is_remote_media_uri(reference: &str) -> bool {
+    url::Url::parse(reference)
+        .map(|parsed| matches!(parsed.scheme(), "http" | "https" | "gs"))
+        .unwrap_or(false)
+}
+
+/// Infer a MIME type from a filename or supported remote URI reference.
 ///
 /// A content type encoded in a signed URL takes precedence over filename and
 /// path-extension inference.
@@ -188,7 +195,7 @@ fn mime_type_from_filename(name: &str) -> Option<&'static str> {
 /// Parse file metadata from a URL.
 ///
 /// This handles:
-/// - Regular HTTP(S) URLs: extracts filename from path
+/// - Regular HTTP(S) URLs and GCS URIs: extracts filename from path
 /// - S3 presigned URLs: extracts filename from response-content-disposition
 ///
 /// Returns `None` if the URL cannot be parsed or doesn't contain a filename.
@@ -201,8 +208,7 @@ pub fn parse_file_metadata_from_url(url: &str) -> Option<FileMetadata> {
     // Try to parse as URL
     let parsed = url::Url::parse(url).ok()?;
 
-    // If the URL is not http(s), file cannot be accessed
-    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+    if !matches!(parsed.scheme(), "http" | "https" | "gs") {
         return None;
     }
 
@@ -881,6 +887,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_file_metadata_from_gcs_uri() {
+        let metadata =
+            parse_file_metadata_from_url("gs://lingua-test-bucket/media/sample-200mb.mp4").unwrap();
+        assert_eq!(metadata.filename, "sample-200mb.mp4");
+        assert!(metadata.content_type.is_none());
+        assert!(is_remote_media_uri(
+            "gs://lingua-test-bucket/media/sample-200mb.mp4"
+        ));
+    }
+
+    #[test]
     fn test_parse_file_metadata_from_url_invalid() {
         assert!(parse_file_metadata_from_url("").is_none());
         assert!(parse_file_metadata_from_url("not a url").is_none());
@@ -907,6 +924,13 @@ mod tests {
                 Some("https://example.com/audio/sample-3s.mp3")
             ),
             Some("audio/mp3".to_string())
+        );
+        assert_eq!(
+            infer_mime_type_from_reference(
+                None,
+                Some("gs://lingua-test-bucket/video/sample-200mb.mp4")
+            ),
+            Some("video/mp4".to_string())
         );
     }
 

--- a/payloads/cases/models.ts
+++ b/payloads/cases/models.ts
@@ -22,6 +22,7 @@ export const BEDROCK_ANTHROPIC_MODEL =
   "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 export const VERTEX_ANTHROPIC_MODEL =
   "publishers/anthropic/models/claude-haiku-4-5";
+export const VERTEX_GOOGLE_MODEL = "publishers/google/models/gemini-2.5-flash";
 
 // Baseten serves OSS models behind an OpenAI-compatible (chat-completions) API.
 // Used to capture real OSS-provider wire behavior (e.g. GLM streaming framing)

--- a/payloads/cases/params.ts
+++ b/payloads/cases/params.ts
@@ -30,6 +30,7 @@ import {
   GOOGLE_TTS_MODEL,
   BEDROCK_MODEL,
   BEDROCK_ANTHROPIC_MODEL,
+  VERTEX_GOOGLE_MODEL,
 } from "./models";
 
 type ChatCompletionAssistantMessageWithReasoningSignature =
@@ -639,6 +640,51 @@ export const paramsCases: TestCaseCollection = {
     anthropic: null,
     google: null,
     bedrock: null,
+  },
+
+  chatCompletionsGcsBackedVideoFileParam: {
+    "chat-completions": {
+      model: OPENAI_CHAT_COMPLETIONS_MODEL,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Describe this video clip.",
+            },
+            {
+              type: "file",
+              file: {
+                filename: "sample-200mb.mp4",
+                file_data: "gs://lingua-test-bucket/sample-200mb.mp4",
+              },
+            },
+          ],
+        },
+      ],
+    },
+    responses: null,
+    anthropic: null,
+    google: null,
+    bedrock: null,
+    "vertex-google": {
+      model: VERTEX_GOOGLE_MODEL,
+      contents: [
+        {
+          role: "user",
+          parts: [
+            { text: "Describe this video clip." },
+            {
+              fileData: {
+                fileUri: "gs://lingua-test-bucket/sample-200mb.mp4",
+                mimeType: "video/mp4",
+              },
+            },
+          ],
+        },
+      ],
+    },
   },
 
   responsesFunctionCallOutputWithoutThoughtSignatureParam: {

--- a/payloads/cases/types.ts
+++ b/payloads/cases/types.ts
@@ -112,6 +112,7 @@ export interface TestCase {
   bedrock: BedrockConverseRequest | null;
   "bedrock-anthropic"?: AnthropicMessageCreateParams | null;
   "vertex-anthropic"?: AnthropicMessageCreateParams | null;
+  "vertex-google"?: GoogleGenerateContentRequest | null;
   // Baseten serves OSS models via an OpenAI-compatible chat-completions API.
   baseten?: ChatCompletionCreateParams | null;
   // Optional expectations for proxy compatibility tests
@@ -134,4 +135,5 @@ export const PROVIDER_TYPES = [
   "bedrock",
   "bedrock-anthropic",
   "vertex-anthropic",
+  "vertex-google",
 ] as const;

--- a/payloads/scripts/capture.ts
+++ b/payloads/scripts/capture.ts
@@ -14,6 +14,7 @@ import { googleExecutor } from "./providers/google";
 import { bedrockExecutor } from "./providers/bedrock";
 import { bedrockAnthropicExecutor } from "./providers/bedrock-anthropic";
 import { vertexAnthropicExecutor } from "./providers/vertex-anthropic";
+import { vertexGoogleExecutor } from "./providers/vertex-google";
 import { basetenExecutor } from "./providers/baseten";
 import { type ProviderExecutor } from "./types";
 
@@ -26,6 +27,7 @@ const allProviders = [
   bedrockExecutor,
   bedrockAnthropicExecutor,
   vertexAnthropicExecutor,
+  vertexGoogleExecutor,
   basetenExecutor,
 ] as const;
 

--- a/payloads/scripts/providers/vertex-anthropic.ts
+++ b/payloads/scripts/providers/vertex-anthropic.ts
@@ -186,7 +186,7 @@ function createSignedJwt(key: ServiceAccountKey): string {
 
 let cachedToken: { token: string; expiresAt: number } | null = null;
 
-async function getAccessToken(): Promise<string> {
+export async function getVertexAccessToken(): Promise<string> {
   if (cachedToken && Date.now() < cachedToken.expiresAt - 60_000) {
     return cachedToken.token;
   }
@@ -305,7 +305,7 @@ export async function executeVertexAnthropic(
     );
   }
   const { stream } = options ?? {};
-  const token = await getAccessToken();
+  const token = await getVertexAccessToken();
   const { model, body, bodyObj } = buildVertexBody(payload);
   const result: CaptureResult<
     AnthropicMessageCreateParams | VertexAnthropicBody,

--- a/payloads/scripts/providers/vertex-google.ts
+++ b/payloads/scripts/providers/vertex-google.ts
@@ -1,0 +1,125 @@
+import { CaptureResult, ExecuteOptions, ProviderExecutor } from "../types";
+import {
+  allTestCases,
+  getCaseNames,
+  getCaseForProvider,
+  hasExpectation,
+  type GoogleGenerateContentRequest,
+} from "../../cases";
+import { parseGoogleSseStream } from "../transforms/helpers";
+import { getVertexAccessToken } from "./vertex-anthropic";
+
+type VertexGoogleResponse = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseVertexGoogleResponse(value: unknown): VertexGoogleResponse {
+  if (!isRecord(value)) {
+    throw new Error("Invalid Vertex Google response: expected object");
+  }
+  return value;
+}
+
+export const vertexGoogleCases: Record<string, GoogleGenerateContentRequest> =
+  {};
+
+getCaseNames(allTestCases).forEach((caseName) => {
+  if (hasExpectation(allTestCases, caseName)) {
+    return;
+  }
+  const caseData = getCaseForProvider(allTestCases, caseName, "vertex-google");
+  if (caseData) {
+    vertexGoogleCases[caseName] = caseData;
+  }
+});
+
+function vertexGoogleUrl(model: string, stream: boolean): string {
+  const project = process.env.VERTEX_PROJECT;
+  if (!project) {
+    throw new Error("VERTEX_PROJECT environment variable is required");
+  }
+  const location = process.env.VERTEX_LOCATION ?? "us-east5";
+  const method = stream ? "streamGenerateContent?alt=sse" : "generateContent";
+  return `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/${model}:${method}`;
+}
+
+async function requestVertexGoogle(
+  model: string,
+  payload: GoogleGenerateContentRequest,
+  token: string,
+  stream: boolean
+): Promise<Response> {
+  const { model: _model, ...body } = payload;
+  return fetch(vertexGoogleUrl(model, stream), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function executeVertexGoogle(
+  _caseName: string,
+  payload: GoogleGenerateContentRequest,
+  options?: ExecuteOptions
+): Promise<
+  CaptureResult<
+    GoogleGenerateContentRequest,
+    VertexGoogleResponse,
+    VertexGoogleResponse
+  >
+> {
+  const { stream } = options ?? {};
+  const model = payload.model;
+  if (!model) {
+    throw new Error("Vertex Google requests require a model");
+  }
+
+  const result: CaptureResult<
+    GoogleGenerateContentRequest,
+    VertexGoogleResponse,
+    VertexGoogleResponse
+  > = { request: payload };
+
+  try {
+    const token = await getVertexAccessToken();
+    if (stream !== true) {
+      const response = await requestVertexGoogle(model, payload, token, false);
+      if (!response.ok) {
+        throw new Error(
+          `Vertex generateContent failed: ${response.status} ${await response.text()}`
+        );
+      }
+      const json: unknown = await response.json();
+      result.response = parseVertexGoogleResponse(json);
+    }
+    if (stream !== false) {
+      const response = await requestVertexGoogle(model, payload, token, true);
+      if (!response.ok) {
+        throw new Error(
+          `Vertex streamGenerateContent failed: ${response.status} ${await response.text()}`
+        );
+      }
+      result.streamingResponse =
+        await parseGoogleSseStream<VertexGoogleResponse>(response);
+    }
+  } catch (error) {
+    result.error = String(error);
+  }
+
+  return result;
+}
+
+export const vertexGoogleExecutor: ProviderExecutor<
+  GoogleGenerateContentRequest,
+  VertexGoogleResponse,
+  VertexGoogleResponse
+> = {
+  name: "vertex-google",
+  cases: vertexGoogleCases,
+  execute: executeVertexGoogle,
+};

--- a/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
+++ b/payloads/scripts/transforms/__snapshots__/transforms.test.ts.snap
@@ -14858,6 +14858,28 @@ exports[`chat-completions → google > chatCompletionsAssistantCacheControlParam
 }
 `;
 
+exports[`chat-completions → google > chatCompletionsGcsBackedVideoFileParam > request 1`] = `
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "Describe this video clip.",
+        },
+        {
+          "fileData": {
+            "fileUri": "gs://lingua-test-bucket/sample-200mb.mp4",
+            "mimeType": "video/mp4",
+          },
+        },
+      ],
+      "role": "user",
+    },
+  ],
+  "model": "gemini-3.5-flash",
+}
+`;
+
 exports[`chat-completions → google > chatCompletionsSystemCacheControlParam > request 1`] = `
 {
   "contents": [

--- a/payloads/snapshots/chatCompletionsGcsBackedVideoFileParam/chat-completions/error.json
+++ b/payloads/snapshots/chatCompletionsGcsBackedVideoFileParam/chat-completions/error.json
@@ -1,0 +1,3 @@
+{
+  "error": "Error: 400 Invalid file data: 'messages[0].content[1].file.file_data'. Expected a base64-encoded data URL with an application/pdf MIME type (e.g. 'data:application/pdf;base64,SGVsbG8sIFdvcmxkIQ=='), but got a value without the 'data:' prefix."
+}

--- a/payloads/snapshots/chatCompletionsGcsBackedVideoFileParam/chat-completions/request.json
+++ b/payloads/snapshots/chatCompletionsGcsBackedVideoFileParam/chat-completions/request.json
@@ -1,0 +1,21 @@
+{
+  "model": "gpt-5-nano",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "Describe this video clip."
+        },
+        {
+          "type": "file",
+          "file": {
+            "filename": "sample-200mb.mp4",
+            "file_data": "gs://lingua-test-bucket/sample-200mb.mp4"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/payloads/snapshots/chatCompletionsGcsBackedVideoFileParam/vertex-google/request.json
+++ b/payloads/snapshots/chatCompletionsGcsBackedVideoFileParam/vertex-google/request.json
@@ -1,0 +1,19 @@
+{
+  "model": "publishers/google/models/gemini-2.5-flash",
+  "contents": [
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "Describe this video clip."
+        },
+        {
+          "fileData": {
+            "fileUri": "gs://lingua-test-bucket/sample-200mb.mp4",
+            "mimeType": "video/mp4"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/payloads/snapshots/chatCompletionsGcsBackedVideoFileParam/vertex-google/response.json
+++ b/payloads/snapshots/chatCompletionsGcsBackedVideoFileParam/vertex-google/response.json
@@ -1,0 +1,46 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": "The video clip displays a classic broadcast television test pattern, characterized by its vibrant, vertical color bars. From left to right, these bars typically include black, cyan, magenta, blue, yellow, green, red, and white. A large, partially black and white circular element is prominent on the left side of the screen, and a horizontal bar showcasing a color gradient (like a rainbow) runs along the bottom.\n\nOn the right side of the screen, a black rectangular box contains white, pixelated digital numbers that function as a continuous upward-counting timer. The timer starts at \"00\" and progresses to \"1:49\" by the end of the clip.\n\nThe entire video is accompanied by a continuous, high-pitched, and steady sine wave tone, commonly associated with a television signal loss or test broadcast. The visual elements remain static while the counter increases and the tone persists."
+          }
+        ]
+      },
+      "finishReason": "STOP",
+      "avgLogprobs": -2.569578065976992
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 42455,
+    "candidatesTokenCount": 182,
+    "totalTokenCount": 43736,
+    "trafficType": "ON_DEMAND",
+    "promptTokensDetails": [
+      {
+        "modality": "AUDIO",
+        "tokenCount": 3750
+      },
+      {
+        "modality": "TEXT",
+        "tokenCount": 5
+      },
+      {
+        "modality": "VIDEO",
+        "tokenCount": 38700
+      }
+    ],
+    "candidatesTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 182
+      }
+    ],
+    "thoughtsTokenCount": 1099
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "createTime": "2026-08-11T15:32:56.290994Z",
+  "responseId": "qEB7arLhEf_Mw-UP19WGkQM"
+}

--- a/payloads/transforms/chat-completions_to_anthropic/chatCompletionsGcsBackedVideoFileParam.json
+++ b/payloads/transforms/chat-completions_to_anthropic/chatCompletionsGcsBackedVideoFileParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert Lingua file content with MIME type video/mp4 to Anthropic document input"
+}

--- a/payloads/transforms/chat-completions_to_bedrock/chatCompletionsGcsBackedVideoFileParam-streaming.json
+++ b/payloads/transforms/chat-completions_to_bedrock/chatCompletionsGcsBackedVideoFileParam-streaming.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert Lingua file content to Bedrock Converse file input"
+}

--- a/payloads/transforms/chat-completions_to_bedrock/chatCompletionsGcsBackedVideoFileParam.json
+++ b/payloads/transforms/chat-completions_to_bedrock/chatCompletionsGcsBackedVideoFileParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert Lingua file content to Bedrock Converse file input"
+}

--- a/payloads/transforms/chat-completions_to_google/chatCompletionsGcsBackedVideoFileParam.json
+++ b/payloads/transforms/chat-completions_to_google/chatCompletionsGcsBackedVideoFileParam.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "contents": [
+      {
+        "parts": [
+          {
+            "text": "Describe this video clip."
+          },
+          {
+            "fileData": {
+              "fileUri": "gs://lingua-test-bucket/sample-200mb.mp4",
+              "mimeType": "video/mp4"
+            }
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "model": "gemini-3.5-flash"
+  },
+  "error": "Google API error (400): {\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Referencing Google Cloud Storage files directly is not supported. Register them using FileService.RegisterFile first. \",\n    \"status\": \"INVALID_ARGUMENT\"\n  }\n}\n",
+  "name": "Error"
+}

--- a/payloads/transforms/chat-completions_to_responses/chatCompletionsGcsBackedVideoFileParam.json
+++ b/payloads/transforms/chat-completions_to_responses/chatCompletionsGcsBackedVideoFileParam.json
@@ -1,0 +1,3 @@
+{
+  "error": "Conversion from universal format failed: Unsupported mapping: cannot convert Lingua file content with MIME type video/mp4 to OpenAI Responses input_file"
+}

--- a/payloads/transforms/transform_errors.json
+++ b/payloads/transforms/transform_errors.json
@@ -5,21 +5,28 @@
     "chatCompletionsSystemCacheControlParam": "OpenAI Responses only supports request-level 30m cache TTLs and cannot preserve the per-block 1h TTL",
     "chatCompletionsAssistantCacheControlParam": "Responses output_text cannot preserve assistant text cache control",
     "chatCompletionsUrlBackedAudioFileParam": "OpenAI Responses input_file does not support audio files",
-    "chatCompletionsUrlBackedVideoFileParam": "OpenAI Responses input_file does not support video files"
+    "chatCompletionsUrlBackedVideoFileParam": "OpenAI Responses input_file does not support video files",
+    "chatCompletionsGcsBackedVideoFileParam": "OpenAI Responses input_file does not support video files"
   },
   "chat-completions_to_anthropic": {
     "chatCompletionsUrlBackedAudioFileParam": "Anthropic document input does not support URL-backed audio files",
-    "chatCompletionsUrlBackedVideoFileParam": "Anthropic document input does not support URL-backed video files"
+    "chatCompletionsUrlBackedVideoFileParam": "Anthropic document input does not support URL-backed video files",
+    "chatCompletionsGcsBackedVideoFileParam": "Anthropic document input does not support URL-backed video files"
+  },
+  "chat-completions_to_google": {
+    "chatCompletionsGcsBackedVideoFileParam": "Gemini API requires FileService registration for GCS URIs; direct gs:// fileData is supported by Vertex only"
   },
   "chat-completions_to_bedrock": {
     "multimodalRequest": "Bedrock rejected transformed OpenAI image URL content because Converse expects image bytes",
     "imageUrlMimeTypeFallbackParam": "Bedrock rejected transformed OpenAI image URL content because Converse expects image bytes",
     "chatCompletionsUrlBackedAudioFileParam": "Bedrock Converse does not support file input",
-    "chatCompletionsUrlBackedVideoFileParam": "Bedrock Converse does not support file input"
+    "chatCompletionsUrlBackedVideoFileParam": "Bedrock Converse does not support file input",
+    "chatCompletionsGcsBackedVideoFileParam": "Bedrock Converse does not support file input"
   },
   "chat-completions_to_bedrock_streaming": {
     "chatCompletionsUrlBackedAudioFileParam": "Bedrock Converse does not support file input",
-    "chatCompletionsUrlBackedVideoFileParam": "Bedrock Converse does not support file input"
+    "chatCompletionsUrlBackedVideoFileParam": "Bedrock Converse does not support file input",
+    "chatCompletionsGcsBackedVideoFileParam": "Bedrock Converse does not support file input"
   },
   "responses_to_anthropic": {
     "reasoningRequestTruncated": "Anthropic requires max_tokens > budget_tokens; min budget (1024) exceeds max_tokens (100)",


### PR DESCRIPTION
## Support GCS-backed media for Vertex prompts

  Enable Braintrust stored prompts, invoke(), and Playground requests to send gs:// audio/video URIs to Vertex as
  fileData.fileUri.

  Previously, Lingua recognized only HTTP(S) media URLs. GCS URIs fell through to inlineData, where Vertex tried to
  base64-decode the literal gs://… string.

  Changes:

  - Recognize gs:// as a remote media URI.
  - Infer MIME type from GCS object paths, such as .mp4.
  - Preserve OpenAI-compatible file.file_data: "gs://…" through universal conversion.
  - Emit Google/Vertex fileData with fileUri and mimeType.
  - Add a GCS-backed 200 MB MP4 regression fixture.
  - Add a Vertex-Google payload capture executor using typed response parsing and the existing Vertex OAuth flow.

  Validation:

  - Rust GCS conversion tests pass.
  - Payload transforms, coverage checks, typed-boundary checks, TypeScript lint, and typecheck pass.
  - Live Vertex generateContent successfully read gs://lingua-test-bucket/sample-200mb.mp4 and returned a video
    description.