### PR TITLE
Disable Gemini 2.5 thinking via thinkingBudget: 0 on explicit opt-out (BT-4707)

### DIFF
--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -12,7 +12,8 @@ use crate::capabilities::ProviderFormat;
 use crate::processing::adapters::ProviderAdapter;
 use crate::processing::transform::TransformError;
 use crate::providers::google::capabilities::{
-    effort_to_thinking_level, thinking_level_to_effort, GoogleCapabilities, GoogleThinkingStyle,
+    effort_to_thinking_level, supports_disabling_thinking, thinking_level_to_effort,
+    GoogleCapabilities, GoogleThinkingStyle,
 };
 use crate::providers::google::convert::SYNTHETIC_CALL_ID_PREFIX;
 use crate::providers::google::detect::try_parse_google;
@@ -361,12 +362,8 @@ impl ProviderAdapter for GoogleAdapter {
         }
 
         // Build generationConfig if any params are set
-        let has_reasoning = req
-            .params
-            .reasoning
-            .as_ref()
-            .map(|r| !r.is_effectively_disabled())
-            .unwrap_or(false);
+        // Present even when disabled so an opt-out still builds generationConfig.
+        let has_reasoning = req.params.reasoning.is_some();
         let has_response_format = req
             .params
             .response_format
@@ -385,11 +382,23 @@ impl ProviderAdapter for GoogleAdapter {
             // Convert ReasoningConfig to Google's thinkingConfig
             // Use capabilities to determine whether to use thinkingLevel (Gemini 3) or thinkingBudget (Gemini 2.5)
             let thinking_config = req.params.reasoning.as_ref().and_then(|r| {
+                let caps = GoogleCapabilities::detect(req.model.as_deref());
+
                 if r.is_effectively_disabled() {
+                    // An explicit opt-out must send thinkingBudget: 0, otherwise
+                    // Google defaults thinking on. Gated to models that accept 0.
+                    if r.enabled == Some(false)
+                        && caps.thinking_style == GoogleThinkingStyle::ThinkingBudget
+                        && supports_disabling_thinking(req.model.as_deref())
+                    {
+                        return Some(ThinkingConfig {
+                            include_thoughts: Some(false),
+                            thinking_budget: Some(0),
+                            thinking_level: None,
+                        });
+                    }
                     return None;
                 }
-
-                let caps = GoogleCapabilities::detect(req.model.as_deref());
 
                 match caps.thinking_style {
                     GoogleThinkingStyle::ThinkingLevelBased => {
@@ -1077,6 +1086,7 @@ fn add_dummy_thought_signatures_for_transferred_function_call_history(messages: 
 mod tests {
     use super::*;
     use crate::providers::google::GenerateContentRequest;
+    use crate::providers::openai::OpenAIAdapter;
     use crate::serde_json::json;
     use crate::universal::request::ToolChoiceMode;
     use crate::universal::ReasoningEffort;
@@ -1215,6 +1225,61 @@ mod tests {
         assert_eq!(thinking_config.include_thoughts, Some(true));
         assert_eq!(thinking_config.thinking_budget, None);
         assert_eq!(thinking_config.thinking_level, None);
+    }
+
+    // BT-4707: explicit reasoning opt-out on 2.5 Flash must send thinkingBudget: 0.
+    #[test]
+    fn test_google_flash_reasoning_off_emits_thinking_budget_zero() {
+        let openai = OpenAIAdapter;
+        let google = GoogleAdapter;
+        let universal = openai
+            .request_to_universal(json!({
+                "model": "gemini-2.5-flash",
+                "messages": [{"role": "user", "content": "hi"}],
+                "reasoning_enabled": false
+            }))
+            .unwrap();
+        assert_eq!(
+            universal.params.reasoning.as_ref().unwrap().enabled,
+            Some(false)
+        );
+
+        let reconstructed = google.request_from_universal(&universal).unwrap();
+        let reconstructed: GenerateContentRequest =
+            serde_json::from_value(reconstructed).expect("request should deserialize");
+        let thinking_config = reconstructed
+            .generation_config
+            .and_then(|config| config.thinking_config)
+            .expect("thinkingConfig should be present for an explicit opt-out on Flash");
+
+        assert_eq!(thinking_config.thinking_budget, Some(0));
+        assert_eq!(thinking_config.include_thoughts, Some(false));
+    }
+
+    // 2.5 Pro can't disable thinking (rejects 0), so no thinkingConfig is emitted.
+    #[test]
+    fn test_google_pro_reasoning_off_does_not_emit_budget_zero() {
+        let openai = OpenAIAdapter;
+        let google = GoogleAdapter;
+        let universal = openai
+            .request_to_universal(json!({
+                "model": "gemini-2.5-pro",
+                "messages": [{"role": "user", "content": "hi"}],
+                "reasoning_enabled": false
+            }))
+            .unwrap();
+
+        let reconstructed = google.request_from_universal(&universal).unwrap();
+        let reconstructed: GenerateContentRequest =
+            serde_json::from_value(reconstructed).expect("request should deserialize");
+
+        assert!(
+            reconstructed
+                .generation_config
+                .and_then(|config| config.thinking_config)
+                .is_none(),
+            "Pro must not receive a thinkingBudget: 0"
+        );
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/adapter.rs
+++ b/crates/lingua/src/providers/google/adapter.rs
@@ -1086,7 +1086,6 @@ fn add_dummy_thought_signatures_for_transferred_function_call_history(messages: 
 mod tests {
     use super::*;
     use crate::providers::google::GenerateContentRequest;
-    use crate::providers::openai::OpenAIAdapter;
     use crate::serde_json::json;
     use crate::universal::request::ToolChoiceMode;
     use crate::universal::ReasoningEffort;
@@ -1227,24 +1226,27 @@ mod tests {
         assert_eq!(thinking_config.thinking_level, None);
     }
 
+    // A universal request with reasoning explicitly off (enabled: false), as the
+    // prompt UI opt-out and the reasoning_budget: 0 workaround both produce.
+    fn gemini_reasoning_off(model: &str) -> UniversalRequest {
+        let mut universal = GoogleAdapter
+            .request_to_universal(json!({
+                "model": model,
+                "contents": [{"role": "user", "parts": [{"text": "hi"}]}]
+            }))
+            .unwrap();
+        universal.params.reasoning = Some(ReasoningConfig {
+            enabled: Some(false),
+            ..Default::default()
+        });
+        universal
+    }
+
     // BT-4707: explicit reasoning opt-out on 2.5 Flash must send thinkingBudget: 0.
     #[test]
     fn test_google_flash_reasoning_off_emits_thinking_budget_zero() {
-        let openai = OpenAIAdapter;
-        let google = GoogleAdapter;
-        let universal = openai
-            .request_to_universal(json!({
-                "model": "gemini-2.5-flash",
-                "messages": [{"role": "user", "content": "hi"}],
-                "reasoning_enabled": false
-            }))
-            .unwrap();
-        assert_eq!(
-            universal.params.reasoning.as_ref().unwrap().enabled,
-            Some(false)
-        );
-
-        let reconstructed = google.request_from_universal(&universal).unwrap();
+        let universal = gemini_reasoning_off("gemini-2.5-flash");
+        let reconstructed = GoogleAdapter.request_from_universal(&universal).unwrap();
         let reconstructed: GenerateContentRequest =
             serde_json::from_value(reconstructed).expect("request should deserialize");
         let thinking_config = reconstructed
@@ -1259,17 +1261,8 @@ mod tests {
     // 2.5 Pro can't disable thinking (rejects 0), so no thinkingConfig is emitted.
     #[test]
     fn test_google_pro_reasoning_off_does_not_emit_budget_zero() {
-        let openai = OpenAIAdapter;
-        let google = GoogleAdapter;
-        let universal = openai
-            .request_to_universal(json!({
-                "model": "gemini-2.5-pro",
-                "messages": [{"role": "user", "content": "hi"}],
-                "reasoning_enabled": false
-            }))
-            .unwrap();
-
-        let reconstructed = google.request_from_universal(&universal).unwrap();
+        let universal = gemini_reasoning_off("gemini-2.5-pro");
+        let reconstructed = GoogleAdapter.request_from_universal(&universal).unwrap();
         let reconstructed: GenerateContentRequest =
             serde_json::from_value(reconstructed).expect("request should deserialize");
 

--- a/crates/lingua/src/providers/google/capabilities.rs
+++ b/crates/lingua/src/providers/google/capabilities.rs
@@ -73,15 +73,20 @@ impl GoogleCapabilities {
 /// Whether the model accepts `thinkingBudget: 0` to turn thinking off.
 ///
 /// Only Gemini 2.5 Flash / Flash-Lite accept 0. Gemini 2.5 Pro requires a
-/// minimum budget of 128 and rejects 0, so it cannot be disabled.
+/// minimum budget of 128 and rejects 0, so it cannot be disabled. Flash
+/// multimodal variants (image / TTS / audio) have no thinkingConfig and error
+/// if one is sent, so they are excluded.
 pub fn supports_disabling_thinking(model: Option<&str>) -> bool {
-    model
-        .map(|m| {
-            normalize_google_model_id(m)
-                .to_ascii_lowercase()
-                .starts_with("gemini-2.5-flash")
-        })
-        .unwrap_or(false)
+    let Some(model) = model else {
+        return false;
+    };
+    let model = normalize_google_model_id(model).to_ascii_lowercase();
+    if !model.starts_with("gemini-2.5-flash") {
+        return false;
+    }
+    !["image", "tts", "audio"]
+        .iter()
+        .any(|kw| model.contains(kw))
 }
 
 fn normalize_google_model_id(model: &str) -> &str {
@@ -184,6 +189,17 @@ mod tests {
         assert!(!supports_disabling_thinking(Some("gemini-2.0-flash")));
         assert!(!supports_disabling_thinking(Some("gemini-3-flash-preview")));
         assert!(!supports_disabling_thinking(None));
+        // Flash multimodal variants have no thinking config.
+        assert!(!supports_disabling_thinking(Some("gemini-2.5-flash-image")));
+        assert!(!supports_disabling_thinking(Some(
+            "gemini-2.5-flash-image-preview"
+        )));
+        assert!(!supports_disabling_thinking(Some(
+            "gemini-2.5-flash-preview-tts"
+        )));
+        assert!(!supports_disabling_thinking(Some(
+            "gemini-2.5-flash-preview-native-audio-dialog"
+        )));
     }
 
     #[test]

--- a/crates/lingua/src/providers/google/capabilities.rs
+++ b/crates/lingua/src/providers/google/capabilities.rs
@@ -70,6 +70,20 @@ impl GoogleCapabilities {
     }
 }
 
+/// Whether the model accepts `thinkingBudget: 0` to turn thinking off.
+///
+/// Only Gemini 2.5 Flash / Flash-Lite accept 0. Gemini 2.5 Pro requires a
+/// minimum budget of 128 and rejects 0, so it cannot be disabled.
+pub fn supports_disabling_thinking(model: Option<&str>) -> bool {
+    model
+        .map(|m| {
+            normalize_google_model_id(m)
+                .to_ascii_lowercase()
+                .starts_with("gemini-2.5-flash")
+        })
+        .unwrap_or(false)
+}
+
 fn normalize_google_model_id(model: &str) -> &str {
     model
         .strip_prefix("publishers/google/models/")
@@ -148,6 +162,28 @@ mod tests {
             GoogleCapabilities::detect(Some("gemini-2.0-flash")).thinking_style,
             GoogleThinkingStyle::ThinkingBudget
         );
+    }
+
+    #[test]
+    fn test_supports_disabling_thinking() {
+        // 2.5 Flash / Flash-Lite accept thinkingBudget: 0.
+        assert!(supports_disabling_thinking(Some("gemini-2.5-flash")));
+        assert!(supports_disabling_thinking(Some("gemini-2.5-flash-lite")));
+        assert!(supports_disabling_thinking(Some(
+            "gemini-2.5-flash-preview-05-20"
+        )));
+        assert!(supports_disabling_thinking(Some("Gemini-2.5-Flash")));
+        assert!(supports_disabling_thinking(Some(
+            "publishers/google/models/gemini-2.5-flash"
+        )));
+        assert!(supports_disabling_thinking(Some("models/gemini-2.5-flash")));
+
+        // 2.5 Pro requires a minimum budget of 128 and cannot be disabled.
+        assert!(!supports_disabling_thinking(Some("gemini-2.5-pro")));
+        // 2.0 has no thinking config; Gemini 3 uses thinkingLevel.
+        assert!(!supports_disabling_thinking(Some("gemini-2.0-flash")));
+        assert!(!supports_disabling_thinking(Some("gemini-3-flash-preview")));
+        assert!(!supports_disabling_thinking(None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When reasoning is explicitly turned **off** (`enabled: false`) for a budget-based Gemini model, the Google adapter dropped `thinkingConfig` entirely (`is_effectively_disabled()` → `return None`). Gemini 2.5 falls back to Google's **thinking-on default**, so the model reasons anyway — the UI/opt-out has no effect on the wire.

This affects both ways a user turns reasoning off:
- Unchecking "Reasoning enabled" in the prompt UI → `reasoning_enabled: false`
- The `reasoning_budget: 0` workaround

Both collapse to `ReasoningConfig { enabled: Some(false) }` and were silently dropped.

## Fix

Emit `thinkingConfig.thinkingBudget: 0` (with `includeThoughts: false`) for an explicit opt-out on models that can actually be disabled — **Gemini 2.5 Flash / Flash-Lite**. Gemini 2.5 **Pro** requires a minimum budget of 128 and *rejects* 0, so it's left at the provider default; 2.0 / Gemini 3 don't use `thinkingBudget`. This is gated by a new `supports_disabling_thinking` capability.

Unspecified/empty reasoning configs (`enabled: None`) are unchanged — they mean "provider default", not "force off".

## Scope

- **Fixes:** explicit opt-out now takes effect on Flash; the customer's `budget: 0` workaround survives the lingua rollout instead of regressing.
- **Does not change:** a fresh 2.5 **Pro** prompt with no reasoning params (BT-4707's literal repro) — Pro can't be disabled at any layer, and the untouched-default state is a separate UI/product decision.

## Tests

- `test_google_flash_reasoning_off_emits_thinking_budget_zero` — Flash opt-out → `thinkingBudget: 0`
- `test_google_pro_reasoning_off_does_not_emit_budget_zero` — Pro opt-out → no `thinkingConfig` (guard)
- `test_supports_disabling_thinking` — capability matrix (flash/flash-lite/pro/2.0/3, Vertex/`models/` prefixed forms)

Full lingua lib suite: 1268 passed. `cargo fmt` + `clippy` clean.

> ⚠️ Not yet run locally (needs the gateway toolchain / provider access): the `AGENTS.md` capture/payload workflow (`payloads/cases/params.ts` case, `make capture`, `make test-payloads`, cross-provider + typed-boundary gates). Flagging for a maintainer to run before merge.

BT-4707 / Pylon 20058.
