### PR TITLE
preserve LangChain Gemini thinking blocks

### DIFF
--- a/crates/lingua/src/processing/import/langchain.rs
+++ b/crates/lingua/src/processing/import/langchain.rs
@@ -376,8 +376,10 @@ fn parse_assistant_content(
                         serde_json::from_value::<LangChainContentPartCompat>(value).ok()
                     })
                     .collect();
-                let fallback_signature = find_text_signature(&parsed_parts);
-                for parsed in parsed_parts {
+                let fallback_signatures: Vec<_> = (0..parsed_parts.len())
+                    .map(|index| adjacent_text_signature(&parsed_parts, index))
+                    .collect();
+                for (index, parsed) in parsed_parts.into_iter().enumerate() {
                     match parsed {
                         LangChainContentPartCompat::Text { text, .. } => {
                             parts.push(AssistantContentPart::Text(TextContentPart {
@@ -408,7 +410,7 @@ fn parse_assistant_content(
                                 thinking,
                                 signature,
                                 extras,
-                                &fallback_signature,
+                                fallback_signatures[index].clone(),
                             ));
                         }
                         _ => {}
@@ -444,8 +446,10 @@ fn parse_assistant_content(
                     serde_json::from_value::<LangChainContentPartCompat>(value).ok()
                 })
                 .collect();
-            let fallback_signature = find_text_signature(&parsed_parts);
-            for parsed in parsed_parts {
+            let fallback_signatures: Vec<_> = (0..parsed_parts.len())
+                .map(|index| adjacent_text_signature(&parsed_parts, index))
+                .collect();
+            for (index, parsed) in parsed_parts.into_iter().enumerate() {
                 match parsed {
                     LangChainContentPartCompat::Text { text, .. } => {
                         parts.push(AssistantContentPart::Text(TextContentPart {
@@ -464,7 +468,7 @@ fn parse_assistant_content(
                             thinking,
                             signature,
                             extras,
-                            &fallback_signature,
+                            fallback_signatures[index].clone(),
                         ));
                     }
                     // When tool_calls is non-empty, ToolUse blocks in content[] are the
@@ -500,26 +504,32 @@ fn parse_assistant_content(
     }
 }
 
-fn find_text_signature(parts: &[LangChainContentPartCompat]) -> Option<String> {
-    parts.iter().find_map(|part| match part {
-        LangChainContentPartCompat::Text { extras, .. } => {
-            extras.as_ref().and_then(|extras| extras.signature.clone())
-        }
-        _ => None,
-    })
+fn adjacent_text_signature(
+    parts: &[LangChainContentPartCompat],
+    thinking_index: usize,
+) -> Option<String> {
+    [thinking_index.checked_add(1), thinking_index.checked_sub(1)]
+        .into_iter()
+        .flatten()
+        .find_map(|index| match parts.get(index) {
+            Some(LangChainContentPartCompat::Text { extras, .. }) => {
+                extras.as_ref().and_then(|extras| extras.signature.clone())
+            }
+            _ => None,
+        })
 }
 
 fn reasoning_part(
     text: String,
     signature: Option<String>,
     extras: Option<LangChainContentPartExtrasCompat>,
-    fallback_signature: &Option<String>,
+    fallback_signature: Option<String>,
 ) -> AssistantContentPart {
     AssistantContentPart::Reasoning {
         text,
         encrypted_content: signature
             .or_else(|| extras.and_then(|extras| extras.signature))
-            .or_else(|| fallback_signature.clone()),
+            .or(fallback_signature),
     }
 }
 
@@ -732,6 +742,12 @@ mod tests {
                             "extras": {"signature": "signature-value"},
                             "text": "visible answer",
                             "type": "text"
+                        },
+                        {"thinking": "more reasoning", "type": "thinking"},
+                        {
+                            "extras": {"signature": "second-signature"},
+                            "text": "more visible answer",
+                            "type": "text"
                         }
                     ],
                     "id": "message-id",
@@ -765,6 +781,18 @@ mod tests {
             &parts[1],
             AssistantContentPart::Text(TextContentPart { text, .. })
                 if text == "visible answer"
+        ));
+        assert!(matches!(
+            &parts[2],
+            AssistantContentPart::Reasoning {
+                text,
+                encrypted_content: Some(signature),
+            } if text == "more reasoning" && signature == "second-signature"
+        ));
+        assert!(matches!(
+            &parts[3],
+            AssistantContentPart::Text(TextContentPart { text, .. })
+                if text == "more visible answer"
         ));
     }
 

--- a/crates/lingua/src/processing/import/langchain.rs
+++ b/crates/lingua/src/processing/import/langchain.rs
@@ -120,7 +120,17 @@ struct OpenAiFunctionCompat {
 #[serde(tag = "type")]
 enum LangChainContentPartCompat {
     #[serde(rename = "text", alias = "input_text", alias = "output_text")]
-    Text { text: String },
+    Text {
+        text: String,
+        #[serde(default)]
+        extras: Option<LangChainContentPartExtrasCompat>,
+    },
+    #[serde(rename = "thinking")]
+    Thinking {
+        thinking: String,
+        #[serde(default)]
+        extras: Option<LangChainContentPartExtrasCompat>,
+    },
     #[serde(rename = "image_url")]
     ImageUrl { image_url: LangChainImageUrlCompat },
     #[serde(rename = "image")]
@@ -133,6 +143,12 @@ enum LangChainContentPartCompat {
         name: String,
         input: Value,
     },
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct LangChainContentPartExtrasCompat {
+    #[serde(default)]
+    signature: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -250,7 +266,7 @@ fn parse_user_content(value: Value) -> Option<UserContent> {
                     continue;
                 };
                 match parsed {
-                    LangChainContentPartCompat::Text { text } => {
+                    LangChainContentPartCompat::Text { text, .. } => {
                         converted_parts.push(UserContentPart::Text(TextContentPart {
                             text,
                             encrypted_content: None,
@@ -293,6 +309,7 @@ fn parse_user_content(value: Value) -> Option<UserContent> {
                         });
                     }
                     LangChainContentPartCompat::ToolUse { .. } => {}
+                    LangChainContentPartCompat::Thinking { .. } => {}
                 }
             }
             if converted_parts.is_empty() {
@@ -351,13 +368,16 @@ fn parse_assistant_content(
             Value::String(text) => Some(AssistantContent::String(text)),
             Value::Array(values) => {
                 let mut parts = Vec::new();
-                for value in values {
-                    let parsed = serde_json::from_value::<LangChainContentPartCompat>(value);
-                    let Ok(parsed) = parsed else {
-                        continue;
-                    };
+                let parsed_parts: Vec<_> = values
+                    .into_iter()
+                    .filter_map(|value| {
+                        serde_json::from_value::<LangChainContentPartCompat>(value).ok()
+                    })
+                    .collect();
+                let fallback_signature = find_text_signature(&parsed_parts);
+                for parsed in parsed_parts {
                     match parsed {
-                        LangChainContentPartCompat::Text { text } => {
+                        LangChainContentPartCompat::Text { text, .. } => {
                             parts.push(AssistantContentPart::Text(TextContentPart {
                                 text,
                                 encrypted_content: None,
@@ -376,6 +396,9 @@ fn parse_assistant_content(
                                 status: None,
                                 provider_executed: None,
                             });
+                        }
+                        LangChainContentPartCompat::Thinking { thinking, extras } => {
+                            parts.push(reasoning_part(thinking, extras, &fallback_signature));
                         }
                         _ => {}
                     }
@@ -404,19 +427,25 @@ fn parse_assistant_content(
             }
         }
         Value::Array(values) => {
-            for value in values {
-                let parsed = serde_json::from_value::<LangChainContentPartCompat>(value);
-                let Ok(parsed) = parsed else {
-                    continue;
-                };
+            let parsed_parts: Vec<_> = values
+                .into_iter()
+                .filter_map(|value| {
+                    serde_json::from_value::<LangChainContentPartCompat>(value).ok()
+                })
+                .collect();
+            let fallback_signature = find_text_signature(&parsed_parts);
+            for parsed in parsed_parts {
                 match parsed {
-                    LangChainContentPartCompat::Text { text } => {
+                    LangChainContentPartCompat::Text { text, .. } => {
                         parts.push(AssistantContentPart::Text(TextContentPart {
                             text,
                             encrypted_content: None,
                             cache_control: None,
                             provider_options: None,
                         }));
+                    }
+                    LangChainContentPartCompat::Thinking { thinking, extras } => {
+                        parts.push(reasoning_part(thinking, extras, &fallback_signature));
                     }
                     // When tool_calls is non-empty, ToolUse blocks in content[] are the
                     // same tool calls in provider format (Anthropic/Bedrock). Skip them
@@ -448,6 +477,28 @@ fn parse_assistant_content(
         None
     } else {
         Some(AssistantContent::Array(parts))
+    }
+}
+
+fn find_text_signature(parts: &[LangChainContentPartCompat]) -> Option<String> {
+    parts.iter().find_map(|part| match part {
+        LangChainContentPartCompat::Text { extras, .. } => {
+            extras.as_ref().and_then(|extras| extras.signature.clone())
+        }
+        _ => None,
+    })
+}
+
+fn reasoning_part(
+    text: String,
+    extras: Option<LangChainContentPartExtrasCompat>,
+    fallback_signature: &Option<String>,
+) -> AssistantContentPart {
+    AssistantContentPart::Reasoning {
+        text,
+        encrypted_content: extras
+            .and_then(|extras| extras.signature)
+            .or_else(|| fallback_signature.clone()),
     }
 }
 
@@ -642,5 +693,57 @@ mod tests {
 
         assert_eq!(text_parts.len(), 1, "expected one text part");
         assert_eq!(tool_call_parts.len(), 1, "expected one tool call part");
+    }
+
+    #[test]
+    fn imports_langchain_llm_result_thinking_with_text_signature() {
+        let input = crate::serde_json::json!({
+            "generations": [[{
+                "generation_info": {
+                    "finish_reason": "STOP",
+                    "model_name": "gemini-3-flash-preview"
+                },
+                "message": {
+                    "additional_kwargs": {},
+                    "content": [
+                        {"thinking": "blah blah blah", "type": "thinking"},
+                        {
+                            "extras": {"signature": "signature-value"},
+                            "text": "visible answer",
+                            "type": "text"
+                        }
+                    ],
+                    "id": "message-id",
+                    "response_metadata": {},
+                    "type": "ai"
+                },
+                "text": "visible answer",
+                "type": "ChatGeneration"
+            }]],
+            "llm_output": {},
+            "type": "LLMResult"
+        });
+
+        let messages =
+            try_parse_langchain_for_import(&input).expect("expected LangChain result to parse");
+        let Message::Assistant { content, .. } = &messages[0] else {
+            panic!("expected assistant message");
+        };
+        let AssistantContent::Array(parts) = content else {
+            panic!("expected assistant content parts");
+        };
+
+        assert!(matches!(
+            &parts[0],
+            AssistantContentPart::Reasoning {
+                text,
+                encrypted_content: Some(signature),
+            } if text == "blah blah blah" && signature == "signature-value"
+        ));
+        assert!(matches!(
+            &parts[1],
+            AssistantContentPart::Text(TextContentPart { text, .. })
+                if text == "visible answer"
+        ));
     }
 }

--- a/crates/lingua/src/processing/import/langchain.rs
+++ b/crates/lingua/src/processing/import/langchain.rs
@@ -129,6 +129,8 @@ enum LangChainContentPartCompat {
     Thinking {
         thinking: String,
         #[serde(default)]
+        signature: Option<String>,
+        #[serde(default)]
         extras: Option<LangChainContentPartExtrasCompat>,
     },
     #[serde(rename = "image_url")]
@@ -397,8 +399,17 @@ fn parse_assistant_content(
                                 provider_executed: None,
                             });
                         }
-                        LangChainContentPartCompat::Thinking { thinking, extras } => {
-                            parts.push(reasoning_part(thinking, extras, &fallback_signature));
+                        LangChainContentPartCompat::Thinking {
+                            thinking,
+                            signature,
+                            extras,
+                        } => {
+                            parts.push(reasoning_part(
+                                thinking,
+                                signature,
+                                extras,
+                                &fallback_signature,
+                            ));
                         }
                         _ => {}
                     }
@@ -444,8 +455,17 @@ fn parse_assistant_content(
                             provider_options: None,
                         }));
                     }
-                    LangChainContentPartCompat::Thinking { thinking, extras } => {
-                        parts.push(reasoning_part(thinking, extras, &fallback_signature));
+                    LangChainContentPartCompat::Thinking {
+                        thinking,
+                        signature,
+                        extras,
+                    } => {
+                        parts.push(reasoning_part(
+                            thinking,
+                            signature,
+                            extras,
+                            &fallback_signature,
+                        ));
                     }
                     // When tool_calls is non-empty, ToolUse blocks in content[] are the
                     // same tool calls in provider format (Anthropic/Bedrock). Skip them
@@ -491,13 +511,14 @@ fn find_text_signature(parts: &[LangChainContentPartCompat]) -> Option<String> {
 
 fn reasoning_part(
     text: String,
+    signature: Option<String>,
     extras: Option<LangChainContentPartExtrasCompat>,
     fallback_signature: &Option<String>,
 ) -> AssistantContentPart {
     AssistantContentPart::Reasoning {
         text,
-        encrypted_content: extras
-            .and_then(|extras| extras.signature)
+        encrypted_content: signature
+            .or_else(|| extras.and_then(|extras| extras.signature))
             .or_else(|| fallback_signature.clone()),
     }
 }
@@ -744,6 +765,38 @@ mod tests {
             &parts[1],
             AssistantContentPart::Text(TextContentPart { text, .. })
                 if text == "visible answer"
+        ));
+    }
+
+    #[test]
+    fn imports_langchain_thinking_with_top_level_signature() {
+        let input = crate::serde_json::json!([{
+            "type": "AIMessage",
+            "content": [
+                {
+                    "thinking": "internal reasoning",
+                    "signature": "reasoning-signature",
+                    "type": "thinking"
+                },
+                {"text": "visible answer", "type": "text"}
+            ]
+        }]);
+
+        let messages =
+            try_parse_langchain_for_import(&input).expect("expected LangChain message to parse");
+        let Message::Assistant { content, .. } = &messages[0] else {
+            panic!("expected assistant message");
+        };
+        let AssistantContent::Array(parts) = content else {
+            panic!("expected assistant content parts");
+        };
+
+        assert!(matches!(
+            &parts[0],
+            AssistantContentPart::Reasoning {
+                text,
+                encrypted_content: Some(signature),
+            } if text == "internal reasoning" && signature == "reasoning-signature"
         ));
     }
 }

--- a/payloads/import-cases/langchain-thinking-blocks.assertions.json
+++ b/payloads/import-cases/langchain-thinking-blocks.assertions.json
@@ -1,0 +1,23 @@
+{
+  "expectedMessageCount": 2,
+  "expectedRolesInOrder": [
+    "user",
+    "assistant"
+  ],
+  "expectedAssistantContentPartTypes": [
+    ["reasoning", "text", "reasoning", "text", "reasoning", "text"]
+  ],
+  "expectedReasoningEncryptedContent": [
+    "top-level-signature",
+    "text-fallback-signature",
+    "thinking-extras-signature"
+  ],
+  "mustContainText": [
+    "First internal reasoning.",
+    "First visible answer.",
+    "Second internal reasoning.",
+    "Second visible answer.",
+    "Third internal reasoning.",
+    "Third visible answer."
+  ]
+}

--- a/payloads/import-cases/langchain-thinking-blocks.spans.json
+++ b/payloads/import-cases/langchain-thinking-blocks.spans.json
@@ -1,0 +1,65 @@
+[
+  {
+    "input": [
+      [
+        {
+          "content": "Explain the result.",
+          "type": "human"
+        }
+      ]
+    ],
+    "output": {
+      "generations": [
+        [
+          {
+            "message": {
+              "content": [
+                {
+                  "thinking": "First internal reasoning.",
+                  "signature": "top-level-signature",
+                  "type": "thinking"
+                },
+                {
+                  "extras": {
+                    "signature": "adjacent-to-top-level-signature"
+                  },
+                  "text": "First visible answer.",
+                  "type": "text"
+                },
+                {
+                  "thinking": "Second internal reasoning.",
+                  "type": "thinking"
+                },
+                {
+                  "extras": {
+                    "signature": "text-fallback-signature"
+                  },
+                  "text": "Second visible answer.",
+                  "type": "text"
+                },
+                {
+                  "extras": {
+                    "signature": "thinking-extras-signature"
+                  },
+                  "thinking": "Third internal reasoning.",
+                  "type": "thinking"
+                },
+                {
+                  "extras": {
+                    "signature": "adjacent-to-extras-signature"
+                  },
+                  "text": "Third visible answer.",
+                  "type": "text"
+                }
+              ],
+              "type": "ai"
+            },
+            "generation_info": {
+              "finish_reason": "stop"
+            }
+          }
+        ]
+      ]
+    }
+  }
+]

--- a/payloads/import-cases/langchain-thinking-blocks.spans.json
+++ b/payloads/import-cases/langchain-thinking-blocks.spans.json
@@ -20,9 +20,6 @@
                   "type": "thinking"
                 },
                 {
-                  "extras": {
-                    "signature": "adjacent-to-top-level-signature"
-                  },
                   "text": "First visible answer.",
                   "type": "text"
                 },
@@ -45,9 +42,6 @@
                   "type": "thinking"
                 },
                 {
-                  "extras": {
-                    "signature": "adjacent-to-extras-signature"
-                  },
                   "text": "Third visible answer.",
                   "type": "text"
                 }


### PR DESCRIPTION
## Context

LangChain Gemini responses can include thinking content blocks with reasoning text and a signature. The importer previously ignored these blocks, losing model reasoning content.

  ## Description

The importer now converts LangChain thinking blocks into AssistantContentPart::Reasoning, preserves signatures from thinking.extras.signature, falls back to signatures from adjacent text.extras.signature blocks, and includes a regression test for LangChain LLMResult imports.
  
## Testing

### Added

- Regression test for LangChain LLMResult imports containing Gemini thinking and text signature blocks.

### Ran

- cargo test -p lingua imports_langchain_llm_result_thinking_with_text_signature
- cargo test -p lingua processing::import::langchain
- cargo test -p lingua --test import_fixtures
  
### Manually confirmed 
  
<img width="1502" height="1170" alt="Screenshot 2026-08-12 at 3 30 01 PM" src="https://github.com/user-attachments/assets/b0073b8b-0ab8-44d0-adf5-8109f95ec783" />

<img width="1482" height="951" alt="Screenshot 2026-08-12 at 3 29 40 PM" src="https://github.com/user-attachments/assets/6777691f-d9b3-4e19-94e7-7b56394f93c7" />
