### PR TITLE
thinking fields for openai completions

### DIFF
--- a/crates/lingua/src/providers/openai/convert.rs
+++ b/crates/lingua/src/providers/openai/convert.rs
@@ -183,11 +183,14 @@ fn merge_reasoning_signature(
 ///
 /// These extension type uses `#[serde(flatten)]` to wrap the generated type while adding
 /// the `reasoning` field, keeping generated types faithful to the official spec.
+///
+/// The `reasoning_content` alias covers the DeepSeek/vLLM OpenAI-compatible convention,
+/// which carries chain-of-thought tokens in a `reasoning_content` sibling of `content`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatCompletionResponseMessageExt {
     #[serde(flatten)]
     pub base: openai::ChatCompletionResponseMessage,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "reasoning_content", skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<String>,
     /// Encrypted reasoning signature for cross-provider roundtrips (e.g., Anthropic's signature)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -213,7 +216,7 @@ pub struct ChatCompletionRequestMessageExt {
     pub tool_call_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "reasoning_content", skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ChatCompletionRequestReasoning>,
     /// Encrypted reasoning signature for cross-provider roundtrips (e.g., Anthropic's signature)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/payloads/import-cases/openai-completions-reasoning-content.assertions.json
+++ b/payloads/import-cases/openai-completions-reasoning-content.assertions.json
@@ -1,0 +1,10 @@
+{
+  "expectedMessageCount": 2,
+  "expectedRolesInOrder": ["user", "assistant"],
+  "expectedAssistantContentPartTypes": [["reasoning", "text"]],
+  "mustContainText": [
+    "How many r's are in strawberry?",
+    "The r's are at positions 3, 8, and 9.",
+    "There are 3 r's in strawberry."
+  ]
+}

--- a/payloads/import-cases/openai-completions-reasoning-content.spans.json
+++ b/payloads/import-cases/openai-completions-reasoning-content.spans.json
@@ -1,0 +1,18 @@
+[
+  {
+    "input": [
+      { "role": "user", "content": "How many r's are in strawberry?" }
+    ],
+    "output": [
+      {
+        "index": 0,
+        "finish_reason": "stop",
+        "message": {
+          "role": "assistant",
+          "reasoning_content": "Let me count the letters in strawberry: s-t-r-a-w-b-e-r-r-y. The r's are at positions 3, 8, and 9.",
+          "content": "There are 3 r's in strawberry."
+        }
+      }
+    ]
+  }
+]

--- a/payloads/import-cases/openai-completions-reasoning-field.assertions.json
+++ b/payloads/import-cases/openai-completions-reasoning-field.assertions.json
@@ -1,0 +1,10 @@
+{
+  "expectedMessageCount": 2,
+  "expectedRolesInOrder": ["user", "assistant"],
+  "expectedAssistantContentPartTypes": [["reasoning", "text"]],
+  "mustContainText": [
+    "How many r's are in strawberry?",
+    "The r's are at positions 3, 8, and 9.",
+    "There are 3 r's in strawberry."
+  ]
+}

--- a/payloads/import-cases/openai-completions-reasoning-field.spans.json
+++ b/payloads/import-cases/openai-completions-reasoning-field.spans.json
@@ -1,0 +1,18 @@
+[
+  {
+    "input": [
+      { "role": "user", "content": "How many r's are in strawberry?" }
+    ],
+    "output": [
+      {
+        "index": 0,
+        "finish_reason": "stop",
+        "message": {
+          "role": "assistant",
+          "reasoning": "Let me count the letters in strawberry: s-t-r-a-w-b-e-r-r-y. The r's are at positions 3, 8, and 9.",
+          "content": "There are 3 r's in strawberry."
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
some openai compatible vendors (e.g. deepseek) return reasoning tokens in the openai chat completions response (openai itself does not though)

this change teaches lingua to recognize that field as reasoning tokens

the overall goal is to render this text in thinking blocks in the braintrust ui

<img width="318" height="187" alt="image" src="https://github.com/user-attachments/assets/39faaa9d-4702-4304-b641-928498e44d39" />
