### PR TITLE
Add custom CA support for remote media

### DIFF
--- a/crates/braintrust-llm-router/src/providers/remote_media.rs
+++ b/crates/braintrust-llm-router/src/providers/remote_media.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use lingua::processing::{adapter_for_format, adapters, normalize_universal_request_for_target};
@@ -191,22 +192,37 @@ pub(crate) async fn prepare_request_with_remote_media(
     format: ProviderFormat,
     policy: RemoteMediaPolicy,
     rewrite_body_model: bool,
+    additional_ca_bundle: Option<&str>,
 ) -> Result<PreparedRemoteMediaRequest> {
+    let additional_ca_bundle = additional_ca_bundle.map(Arc::<str>::from);
     prepare_request_with_remote_media_and_fetch_with_model_rewrite(
         body,
         spec,
         format,
         policy,
         rewrite_body_model,
-        |url| Box::pin(fetch_remote_media_as_base64(url)),
+        move |url| {
+            let additional_ca_bundle = additional_ca_bundle.clone();
+            Box::pin(async move {
+                fetch_remote_media_as_base64(url, additional_ca_bundle.as_deref()).await
+            })
+        },
     )
     .await
 }
 
-async fn fetch_remote_media_as_base64(url: &str) -> Result<MediaBlock> {
-    lingua::util::media::convert_media_to_base64(url, None, Some(MAX_REMOTE_MEDIA_BYTES))
-        .await
-        .map_err(|e| Error::InvalidRequest(format!("failed to fetch media URL {url}: {e}")))
+async fn fetch_remote_media_as_base64(
+    url: &str,
+    additional_ca_bundle: Option<&str>,
+) -> Result<MediaBlock> {
+    lingua::util::media::convert_media_to_base64_with_additional_ca_bundle(
+        url,
+        None,
+        Some(MAX_REMOTE_MEDIA_BYTES),
+        additional_ca_bundle,
+    )
+    .await
+    .map_err(|e| Error::InvalidRequest(format!("failed to fetch media URL {url}: {e}")))
 }
 
 #[cfg(test)]
@@ -943,6 +959,39 @@ mod tests {
                 .and_then(|file_data| file_data.file_uri.as_deref()),
             Some("gs://bucket/stored.pdf")
         );
+    }
+
+    #[tokio::test]
+    async fn remote_media_fetch_uses_additional_ca_bundle() {
+        let body = Bytes::from(
+            lingua::serde_json::to_vec(&json!({
+                "model": "gemini-3.1-pro-preview",
+                "input": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "input_file",
+                        "filename": "sample.pdf",
+                        "file_url": "https://93.184.216.34/sample.pdf"
+                    }]
+                }]
+            }))
+            .expect("json"),
+        );
+
+        let error = prepare_request_with_remote_media(
+            body,
+            &google_spec("gemini-3.1-pro-preview"),
+            ProviderFormat::Google,
+            RemoteMediaPolicy::GOOGLE,
+            true,
+            Some("not a certificate"),
+        )
+        .await
+        .expect_err("certificate-free bundle should fail before sending the request");
+
+        assert!(error
+            .to_string()
+            .contains("additional CA bundle contains no certificates"));
     }
 
     #[tokio::test]

--- a/crates/braintrust-llm-router/src/router.rs
+++ b/crates/braintrust-llm-router/src/router.rs
@@ -263,12 +263,25 @@ fn native_responses_requires_json_response(body: &[u8]) -> bool {
     }
 }
 
+#[cfg(test)]
 async fn prepare_provider_request(
     body: Bytes,
     spec: &ModelSpec,
     format: ProviderFormat,
     stream: bool,
     options: RequestPreparationOptions,
+) -> Result<(Bytes, Option<ProviderFormat>, ProviderFormat, bool, bool)> {
+    prepare_provider_request_with_additional_ca_bundle(body, spec, format, stream, options, None)
+        .await
+}
+
+async fn prepare_provider_request_with_additional_ca_bundle(
+    body: Bytes,
+    spec: &ModelSpec,
+    format: ProviderFormat,
+    stream: bool,
+    options: RequestPreparationOptions,
+    additional_ca_bundle: Option<&str>,
 ) -> Result<(Bytes, Option<ProviderFormat>, ProviderFormat, bool, bool)> {
     let (
         body,
@@ -283,6 +296,7 @@ async fn prepare_provider_request(
                 format,
                 policy,
                 options.rewrite_body_model,
+                additional_ca_bundle,
             )
             .await?;
             (
@@ -374,6 +388,7 @@ pub struct Router {
     auth_configs: HashMap<String, AuthConfig>,     // alias -> auth
     formats: HashMap<ProviderFormat, String>,      // format -> default alias
     retry_policy: RetryPolicy,
+    remote_media_additional_ca_bundle: Option<String>,
 }
 
 impl Router {
@@ -421,8 +436,15 @@ impl Router {
                 };
                 (body, None, route.format, requires_json_response, true)
             } else {
-                prepare_provider_request(body, route.spec.as_ref(), route.format, stream, options)
-                    .await?
+                prepare_provider_request_with_additional_ca_bundle(
+                    body,
+                    route.spec.as_ref(),
+                    route.format,
+                    stream,
+                    options,
+                    self.remote_media_additional_ca_bundle.as_deref(),
+                )
+                .await?
             };
         Ok((
             PreparedRequestInner {
@@ -1171,6 +1193,7 @@ pub struct RouterBuilder {
     custom_catalog: Option<ModelCatalog>,
     provider_entries: Vec<ProviderEntry>,
     retry_policy: RetryPolicy,
+    remote_media_additional_ca_bundle: Option<String>,
 }
 
 impl Default for RouterBuilder {
@@ -1186,6 +1209,7 @@ impl RouterBuilder {
             custom_catalog: None,
             provider_entries: Vec::new(),
             retry_policy: RetryPolicy::default(),
+            remote_media_additional_ca_bundle: None,
         }
     }
 
@@ -1214,6 +1238,12 @@ impl RouterBuilder {
 
     pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
         self.retry_policy = policy;
+        self
+    }
+
+    /// Add trusted roots for remote media downloaded while preparing provider requests.
+    pub fn with_remote_media_additional_ca_bundle(mut self, bundle: Option<String>) -> Self {
+        self.remote_media_additional_ca_bundle = bundle;
         self
     }
 
@@ -1312,6 +1342,7 @@ impl RouterBuilder {
             formats,
             auth_configs,
             retry_policy: self.retry_policy,
+            remote_media_additional_ca_bundle: self.remote_media_additional_ca_bundle,
         })
     }
 }
@@ -2324,6 +2355,39 @@ mod tests {
             .expect("stream item")
             .expect("stream item succeeds");
         assert!(!first.data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn router_passes_additional_ca_bundle_to_remote_media_fetches() {
+        let model = "gemini-3.1-pro-preview";
+        let mut catalog = ModelCatalog::empty();
+        catalog.insert(model.into(), google_spec(model));
+        let router = Router::builder()
+            .with_catalog(Arc::new(catalog))
+            .with_remote_media_additional_ca_bundle(Some("not a certificate".to_string()))
+            .add_provider(
+                "google",
+                FakeProvider {
+                    name: "google",
+                    formats: vec![ProviderFormat::Google],
+                },
+                dummy_auth(),
+                vec![ProviderFormat::Google],
+            )
+            .build()
+            .expect("router builds");
+        let body = Bytes::from_static(
+            br#"{"model":"gemini-3.1-pro-preview","input":[{"role":"user","content":[{"type":"input_file","filename":"sample.pdf","file_url":"https://93.184.216.34/sample.pdf"}]}]}"#,
+        );
+
+        let error = match create_test_request(&router, body, model, ProviderFormat::Google).await {
+            Ok(_) => panic!("certificate-free bundle should fail before sending the request"),
+            Err(error) => error,
+        };
+
+        assert!(error
+            .to_string()
+            .contains("additional CA bundle contains no certificates"));
     }
 
     fn google_chat_router(model: &str) -> Router {

--- a/crates/lingua/src/util/media.rs
+++ b/crates/lingua/src/util/media.rs
@@ -389,6 +389,21 @@ mod wasm_fetch {
             data,
         })
     }
+
+    /// Fetch a URL using the platform trust store plus an optional PEM CA bundle.
+    pub async fn fetch_url_to_base64_with_additional_ca_bundle(
+        url: &str,
+        allowed_types: Option<&[&str]>,
+        max_bytes: Option<usize>,
+        additional_ca_bundle: Option<&str>,
+    ) -> Result<MediaBlock, MediaError> {
+        if additional_ca_bundle.is_some() {
+            return Err(MediaError::FetchError(
+                "additional CA bundles are not supported on wasm32".to_string(),
+            ));
+        }
+        fetch_url_to_base64(url, allowed_types, max_bytes).await
+    }
 }
 
 // ============================================================================
@@ -593,7 +608,31 @@ mod native_fetch {
         })
     }
 
-    async fn fetch_validated_url(url: &str) -> Result<reqwest::Response, MediaError> {
+    fn add_additional_ca_bundle(
+        mut builder: reqwest::ClientBuilder,
+        additional_ca_bundle: Option<&str>,
+    ) -> Result<reqwest::ClientBuilder, MediaError> {
+        let Some(additional_ca_bundle) = additional_ca_bundle else {
+            return Ok(builder);
+        };
+
+        let certificates = reqwest::Certificate::from_pem_bundle(additional_ca_bundle.as_bytes())
+            .map_err(|error| MediaError::FetchError(error.to_string()))?;
+        if certificates.is_empty() {
+            return Err(MediaError::FetchError(
+                "additional CA bundle contains no certificates".to_string(),
+            ));
+        }
+        for certificate in certificates {
+            builder = builder.add_root_certificate(certificate);
+        }
+        Ok(builder)
+    }
+
+    async fn fetch_validated_url(
+        url: &str,
+        additional_ca_bundle: Option<&str>,
+    ) -> Result<reqwest::Response, MediaError> {
         let mut current_url = Url::parse(url)
             .map_err(|e| MediaError::FetchError(format!("invalid media URL: {e}")))?;
 
@@ -606,6 +645,7 @@ mod native_fetch {
                 client_builder =
                     client_builder.resolve_to_addrs(&hostname, &validated_url.addresses);
             }
+            client_builder = add_additional_ca_bundle(client_builder, additional_ca_bundle)?;
             let client = client_builder
                 .build()
                 .map_err(|e| MediaError::FetchError(e.to_string()))?;
@@ -676,7 +716,17 @@ mod native_fetch {
         allowed_types: Option<&[&str]>,
         max_bytes: Option<usize>,
     ) -> Result<MediaBlock, MediaError> {
-        let mut response = fetch_validated_url(url).await?;
+        fetch_url_to_base64_with_additional_ca_bundle(url, allowed_types, max_bytes, None).await
+    }
+
+    /// Fetch a URL using the default trust store plus an optional PEM CA bundle.
+    pub async fn fetch_url_to_base64_with_additional_ca_bundle(
+        url: &str,
+        allowed_types: Option<&[&str]>,
+        max_bytes: Option<usize>,
+        additional_ca_bundle: Option<&str>,
+    ) -> Result<MediaBlock, MediaError> {
+        let mut response = fetch_validated_url(url, additional_ca_bundle).await?;
 
         if !response.status().is_success() {
             return Err(MediaError::FetchError(format!(
@@ -864,15 +914,28 @@ mod native_fetch {
                 assert!(!is_blocked_ip(address), "{address} should be allowed");
             }
         }
+
+        #[test]
+        fn additional_ca_bundle_rejects_content_without_certificates() {
+            let error =
+                add_additional_ca_bundle(reqwest::Client::builder(), Some("not a certificate"))
+                    .expect_err("certificate-free bundle should fail");
+
+            assert!(matches!(
+                error,
+                MediaError::FetchError(message)
+                    if message.contains("contains no certificates")
+            ));
+        }
     }
 }
 
 // Re-export the appropriate implementation
 #[cfg(target_arch = "wasm32")]
-pub use wasm_fetch::fetch_url_to_base64;
+pub use wasm_fetch::{fetch_url_to_base64, fetch_url_to_base64_with_additional_ca_bundle};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use native_fetch::fetch_url_to_base64;
+pub use native_fetch::{fetch_url_to_base64, fetch_url_to_base64_with_additional_ca_bundle};
 
 /// Convert media (URL or data URL) to a MediaBlock.
 ///
@@ -889,13 +952,29 @@ pub async fn convert_media_to_base64(
     allowed_types: Option<&[&str]>,
     max_bytes: Option<usize>,
 ) -> Result<MediaBlock, MediaError> {
+    convert_media_to_base64_with_additional_ca_bundle(media, allowed_types, max_bytes, None).await
+}
+
+/// Convert media to base64, trusting an optional additional PEM CA bundle for URL fetches.
+pub async fn convert_media_to_base64_with_additional_ca_bundle(
+    media: &str,
+    allowed_types: Option<&[&str]>,
+    max_bytes: Option<usize>,
+    additional_ca_bundle: Option<&str>,
+) -> Result<MediaBlock, MediaError> {
     // Try to parse as data URL first
     if let Some(block) = parse_base64_data_url(media) {
         return Ok(block);
     }
 
     // Otherwise fetch the URL
-    fetch_url_to_base64(media, allowed_types, max_bytes).await
+    fetch_url_to_base64_with_additional_ca_bundle(
+        media,
+        allowed_types,
+        max_bytes,
+        additional_ca_bundle,
+    )
+    .await
 }
 
 /// Check if a URL is a localhost URL (for special handling).


### PR DESCRIPTION
## Context

This builds on #443, which added custom CA bundle support to Lingua’s provider HTTP clients.

Remote media downloads use a separate HTTP client, so they were not covered by that change.

## Changes

- Apply the optional CA bundle when downloading remote media
- Pass the bundle through `RouterBuilder`
- Preserve existing behavior when no bundle is configured
- Add tests covering the configuration path

## Validation

- `cargo test -p braintrust-llm-router remote_media_fetch_uses_additional_ca_bundle`
- `cargo test -p braintrust-llm-router router_passes_additional_ca_bundle_to_remote_media_fetches`
- `cargo test --verbose`
- `cargo fmt --all`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --all-targets --all-features -- -D warnings`